### PR TITLE
[Feat] 이력서 aggregate 마무리

### DIFF
--- a/src/main/java/com/generic4/itda/domain/resume/Proficiency.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Proficiency.java
@@ -4,11 +4,13 @@ import lombok.Getter;
 
 @Getter
 public enum Proficiency {
-    BEGINNER("초급"), INTERMEDIATE("중급"), ADVANCED("고급");
+    BEGINNER("초급", 1), INTERMEDIATE("중급", 2), ADVANCED("고급", 3);
 
     private final String description;
+    private final int priority;
 
-    Proficiency(String description) {
+    Proficiency(String description, int priority) {
         this.description = description;
+        this.priority = priority;
     }
 }

--- a/src/main/java/com/generic4/itda/domain/resume/Proficiency.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Proficiency.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.domain.resume;
+
+import lombok.Getter;
+
+@Getter
+public enum Proficiency {
+    BEGINNER("초급"), INTERMEDIATE("중급"), ADVANCED("고급");
+
+    private final String description;
+
+    Proficiency(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -164,7 +164,7 @@ public class Resume extends BaseEntity {
 
     public void addFile(StoredFile file) {
         Assert.notNull(file, "첨부 파일은 필수값입니다.");
-        Assert.state(this.attachments.size() <= 10, "첨부파일은 최대 10개까지 등록할 수 있습니다.");
+        Assert.state(this.attachments.size() < 10, "첨부파일은 최대 10개까지 등록할 수 있습니다.");
 
         ResumeAttachment attachment = ResumeAttachment.create(this, file);
         this.attachments.add(attachment);

--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -3,6 +3,7 @@ package com.generic4.itda.domain.resume;
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.shared.BaseEntity;
+import com.generic4.itda.domain.skill.Skill;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -25,14 +26,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(callSuper = false)
 public class Resume extends BaseEntity {
 
     @Id
@@ -72,6 +71,10 @@ public class Resume extends BaseEntity {
     @OneToMany(mappedBy = "resume", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("displayOrder ASC")
     private final List<ResumeAttachment> attachments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "resume", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("proficiency desc")
+    private final List<ResumeSkill> skills = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Resume(Member member, String introduction, Byte careerYears, CareerPayload career,
@@ -177,6 +180,31 @@ public class Resume extends BaseEntity {
                 attachments.get(i).changeDisplayOrder(i);
             }
         }
+    }
+
+    public void addSkill(Skill skill, Proficiency proficiency) {
+        Assert.notNull(skill, "스킬은 필수 입력값입니다.");
+        Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
+
+        ResumeSkill resumeSkill = ResumeSkill.create(this, skill, proficiency);
+        this.skills.add(resumeSkill);
+    }
+
+    public void removeSkill(Skill skill) {
+        Assert.notNull(skill, "스킬은 필수 입력값입니다.");
+        this.skills.removeIf(resumeSkill -> resumeSkill.getSkill().equals(skill));
+    }
+
+    public void updateSkill(Skill skill, Proficiency proficiency) {
+        Assert.notNull(skill, "스킬은 필수 입력값입니다.");
+        Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
+
+        ResumeSkill storedSkill = this.skills.stream()
+                .filter(resumeSkill -> resumeSkill.getSkill().equals(skill))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("기존에 없는 스킬은 업데이트 할 수 없습니다."));
+
+        storedSkill.update(skill, proficiency);
     }
 
     private String normalizePortfolioUrl(String portfolioUrl) {

--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -21,6 +21,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.OrderBy;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -69,11 +70,10 @@ public class Resume extends BaseEntity {
     private String portfolioUrl;
 
     @OneToMany(mappedBy = "resume", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("displayOrder ASC")
+    @OrderBy("createdAt asc")
     private final List<ResumeAttachment> attachments = new ArrayList<>();
 
     @OneToMany(mappedBy = "resume", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("proficiency desc")
     private final List<ResumeSkill> skills = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
@@ -166,20 +166,13 @@ public class Resume extends BaseEntity {
         Assert.notNull(file, "첨부 파일은 필수값입니다.");
         Assert.state(this.attachments.size() <= 10, "첨부파일은 최대 10개까지 등록할 수 있습니다.");
 
-        int order = this.attachments.size();
-        ResumeAttachment attachment = ResumeAttachment.create(this, file, order);
+        ResumeAttachment attachment = ResumeAttachment.create(this, file);
         this.attachments.add(attachment);
     }
 
     public void removeFile(StoredFile file) {
         Assert.notNull(file, "삭제할 첨부 파일은 필수값입니다.");
-
-        boolean isRemoved = this.attachments.removeIf(attachment -> attachment.getFile().equals(file));
-        if (isRemoved) {
-            for (int i = 0; i < attachments.size(); i++) {
-                attachments.get(i).changeDisplayOrder(i);
-            }
-        }
+        this.attachments.removeIf(attachment -> attachment.getFile().equals(file));
     }
 
     public void addSkill(Skill skill, Proficiency proficiency) {
@@ -205,6 +198,12 @@ public class Resume extends BaseEntity {
                 .orElseThrow(() -> new IllegalStateException("기존에 없는 스킬은 업데이트 할 수 없습니다."));
 
         storedSkill.update(skill, proficiency);
+    }
+
+    public List<ResumeSkill> getSortedSkills() {
+        return this.skills.stream()
+                .sorted(Comparator.comparingInt((ResumeSkill s) -> s.getProficiency().getPriority()).reversed())
+                .toList();
     }
 
     private String normalizePortfolioUrl(String portfolioUrl) {

--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -21,12 +21,14 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.OrderBy;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SortComparator;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -74,7 +76,8 @@ public class Resume extends BaseEntity {
     private final List<ResumeAttachment> attachments = new ArrayList<>();
 
     @OneToMany(mappedBy = "resume", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<ResumeSkill> skills = new ArrayList<>();
+    @SortComparator(ResumeSkillComparator.class)
+    private final SortedSet<ResumeSkill> skills = new TreeSet<>(new ResumeSkillComparator());
 
     @Builder(access = AccessLevel.PRIVATE)
     private Resume(Member member, String introduction, Byte careerYears, CareerPayload career,
@@ -180,6 +183,8 @@ public class Resume extends BaseEntity {
         Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
 
         ResumeSkill resumeSkill = ResumeSkill.create(this, skill, proficiency);
+        Assert.state(!this.skills.contains(resumeSkill), "이미 등록된 스킬입니다.");
+
         this.skills.add(resumeSkill);
     }
 
@@ -198,12 +203,6 @@ public class Resume extends BaseEntity {
                 .orElseThrow(() -> new IllegalStateException("기존에 없는 스킬은 업데이트 할 수 없습니다."));
 
         storedSkill.update(skill, proficiency);
-    }
-
-    public List<ResumeSkill> getSortedSkills() {
-        return this.skills.stream()
-                .sorted(Comparator.comparingInt((ResumeSkill s) -> s.getProficiency().getPriority()).reversed())
-                .toList();
     }
 
     private String normalizePortfolioUrl(String portfolioUrl) {

--- a/src/main/java/com/generic4/itda/domain/resume/ResumeAttachment.java
+++ b/src/main/java/com/generic4/itda/domain/resume/ResumeAttachment.java
@@ -2,7 +2,6 @@ package com.generic4.itda.domain.resume;
 
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.shared.BaseTimeEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,21 +9,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
-@Table(
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_resume_attachments_resume_id_and_display_order",
-                        columnNames = {"resume_id", "display_order"}
-                )
-        }
-)
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,25 +31,15 @@ public class ResumeAttachment extends BaseTimeEntity {
     @JoinColumn(name = "file_id", nullable = false)
     private StoredFile file;
 
-    @Column(unique = true)
-    private int displayOrder;
-
-    private ResumeAttachment(Resume resume, StoredFile file, int displayOrder) {
+    private ResumeAttachment(Resume resume, StoredFile file) {
         Assert.notNull(resume, "이력서는 필수값입니다.");
         Assert.notNull(file, "첨부 파일은 필수값입니다.");
-        Assert.isTrue(displayOrder >= 0, "표시 순서는 음수일 수 없습니다.");
 
         this.resume = resume;
         this.file = file;
-        this.displayOrder = displayOrder;
     }
 
-    public static ResumeAttachment create(Resume resume, StoredFile file, int displayOrder) {
-        return new ResumeAttachment(resume, file, displayOrder);
-    }
-
-    public void changeDisplayOrder(int displayOrder) {
-        Assert.isTrue(displayOrder >= 0, "표시 순서는 음수일 수 없습니다.");
-        this.displayOrder = displayOrder;
+    public static ResumeAttachment create(Resume resume, StoredFile file) {
+        return new ResumeAttachment(resume, file);
     }
 }

--- a/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
+++ b/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -57,5 +58,17 @@ public class ResumeSkill extends BaseTimeEntity {
 
         this.skill = skill;
         this.proficiency = proficiency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ResumeSkill that)) return false;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
+++ b/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
@@ -1,0 +1,61 @@
+package com.generic4.itda.domain.resume;
+
+import com.generic4.itda.domain.shared.BaseTimeEntity;
+import com.generic4.itda.domain.skill.Skill;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResumeSkill extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "skill_id")
+    private Skill skill;
+
+    @Enumerated(EnumType.STRING)
+    private Proficiency proficiency;
+
+    private ResumeSkill(Resume resume, Skill skill, Proficiency proficiency) {
+        Assert.notNull(resume, "이력서는 필수 입력값입니다.");
+        Assert.notNull(skill, "스킬은 필수 입력값입니다.");
+        Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
+
+        this.resume = resume;
+        this.skill = skill;
+        this.proficiency = proficiency;
+    }
+
+    public static ResumeSkill create(Resume resume, Skill skill, Proficiency proficiency) {
+        return new ResumeSkill(resume, skill, proficiency);
+    }
+
+    public void update(Skill skill, Proficiency proficiency) {
+        Assert.notNull(skill, "스킬은 필수 입력값입니다.");
+        Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
+
+        this.skill = skill;
+        this.proficiency = proficiency;
+    }
+}

--- a/src/main/java/com/generic4/itda/domain/resume/ResumeSkillComparator.java
+++ b/src/main/java/com/generic4/itda/domain/resume/ResumeSkillComparator.java
@@ -1,0 +1,20 @@
+package com.generic4.itda.domain.resume;
+
+import java.util.Comparator;
+
+public class ResumeSkillComparator implements Comparator<ResumeSkill> {
+
+    @Override
+    public int compare(ResumeSkill o1, ResumeSkill o2) {
+        // priority 내림차순 (ADVANCED=3 > INTERMEDIATE=2 > BEGINNER=1)
+        int priorityCompare = Integer.compare(
+                o2.getProficiency().getPriority(),
+                o1.getProficiency().getPriority()
+        );
+        if (priorityCompare != 0) {
+            return priorityCompare;
+        }
+        // 동일 priority면 스킬 이름 오름차순
+        return o1.getSkill().getName().compareTo(o2.getSkill().getName());
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.domain.resume.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+    
+}

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeAttachmentTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeAttachmentTest.java
@@ -7,8 +7,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.generic4.itda.domain.file.StoredFile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class ResumeAttachmentTest {
 
@@ -18,17 +16,16 @@ class ResumeAttachmentTest {
         Resume resume = createResume();
         StoredFile file = createStoredFile("resume.pdf");
 
-        ResumeAttachment attachment = ResumeAttachment.create(resume, file, 0);
+        ResumeAttachment attachment = ResumeAttachment.create(resume, file);
 
         assertThat(attachment.getResume()).isEqualTo(resume);
         assertThat(attachment.getFile()).isEqualTo(file);
-        assertThat(attachment.getDisplayOrder()).isEqualTo(0);
     }
 
     @DisplayName("이력서가 누락되면 이력서 첨부파일 생성에 실패한다")
     @Test
     void failWhenResumeIsNull() {
-        assertThatThrownBy(() -> ResumeAttachment.create(null, createStoredFile("resume.pdf"), 0))
+        assertThatThrownBy(() -> ResumeAttachment.create(null, createStoredFile("resume.pdf")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이력서는 필수값입니다.");
     }
@@ -36,39 +33,9 @@ class ResumeAttachmentTest {
     @DisplayName("첨부 파일이 누락되면 이력서 첨부파일 생성에 실패한다")
     @Test
     void failWhenFileIsNull() {
-        assertThatThrownBy(() -> ResumeAttachment.create(createResume(), null, 0))
+        assertThatThrownBy(() -> ResumeAttachment.create(createResume(), null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("첨부 파일은 필수값입니다.");
-    }
-
-    @DisplayName("표시 순서가 음수이면 이력서 첨부파일 생성에 실패한다")
-    @ParameterizedTest
-    @ValueSource(ints = {-1, -10})
-    void failWhenDisplayOrderIsNegative(int displayOrder) {
-        assertThatThrownBy(() -> ResumeAttachment.create(createResume(), createStoredFile("resume.pdf"), displayOrder))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("표시 순서는 음수일 수 없습니다.");
-    }
-
-    @DisplayName("유효한 표시 순서로 변경하면 순서가 업데이트된다")
-    @Test
-    void changeDisplayOrderWithValidValue() {
-        ResumeAttachment attachment = ResumeAttachment.create(createResume(), createStoredFile("resume.pdf"), 0);
-
-        attachment.changeDisplayOrder(2);
-
-        assertThat(attachment.getDisplayOrder()).isEqualTo(2);
-    }
-
-    @DisplayName("표시 순서를 음수로 변경하면 실패한다")
-    @ParameterizedTest
-    @ValueSource(ints = {-1, -5})
-    void failWhenChangeDisplayOrderIsNegative(int displayOrder) {
-        ResumeAttachment attachment = ResumeAttachment.create(createResume(), createStoredFile("resume.pdf"), 0);
-
-        assertThatThrownBy(() -> attachment.changeDisplayOrder(displayOrder))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("표시 순서는 음수일 수 없습니다.");
     }
 
     private static Resume createResume() {
@@ -96,6 +63,7 @@ class ResumeAttachmentTest {
     }
 
     private static StoredFile createStoredFile(String originalName) {
-        return StoredFile.create(originalName, "stored-" + originalName, "/files/" + originalName, "application/pdf", 1024L);
+        return StoredFile.create(originalName, "stored-" + originalName, "/files/" + originalName, "application/pdf",
+                1024L);
     }
 }

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeSkillTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeSkillTest.java
@@ -1,0 +1,119 @@
+package com.generic4.itda.domain.resume;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.domain.skill.Skill;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ResumeSkillTest {
+
+    @DisplayName("유효한 입력이 주어지면 이력서 스킬을 생성한다")
+    @Test
+    void createWithValidInputs() {
+        Resume resume = createResume();
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, skill, Proficiency.ADVANCED);
+
+        assertThat(resumeSkill.getResume()).isEqualTo(resume);
+        assertThat(resumeSkill.getSkill()).isEqualTo(skill);
+        assertThat(resumeSkill.getProficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+
+    @DisplayName("이력서가 누락되면 이력서 스킬 생성에 실패한다")
+    @Test
+    void failWhenResumeIsNull() {
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        assertThatThrownBy(() -> ResumeSkill.create(null, skill, Proficiency.BEGINNER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이력서는 필수 입력값입니다.");
+    }
+
+    @DisplayName("스킬이 누락되면 이력서 스킬 생성에 실패한다")
+    @Test
+    void failWhenSkillIsNull() {
+        Resume resume = createResume();
+
+        assertThatThrownBy(() -> ResumeSkill.create(resume, null, Proficiency.BEGINNER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스킬은 필수 입력값입니다.");
+    }
+
+    @DisplayName("숙련도가 누락되면 이력서 스킬 생성에 실패한다")
+    @Test
+    void failWhenProficiencyIsNull() {
+        Resume resume = createResume();
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        assertThatThrownBy(() -> ResumeSkill.create(resume, skill, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("숙련도는 필수 입력값입니다.");
+    }
+
+    @DisplayName("유효한 입력이 주어지면 이력서 스킬을 수정한다")
+    @Test
+    void updateWithValidInputs() {
+        Resume resume = createResume();
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, skill, Proficiency.BEGINNER);
+
+        Skill updatedSkill = Skill.create("Spring Boot", "웹 프레임워크");
+        resumeSkill.update(updatedSkill, Proficiency.ADVANCED);
+
+        assertThat(resumeSkill.getSkill()).isEqualTo(updatedSkill);
+        assertThat(resumeSkill.getProficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+
+    @DisplayName("수정 시 스킬이 누락되면 실패한다")
+    @Test
+    void failWhenUpdateSkillIsNull() {
+        Resume resume = createResume();
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, skill, Proficiency.BEGINNER);
+
+        assertThatThrownBy(() -> resumeSkill.update(null, Proficiency.ADVANCED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스킬은 필수 입력값입니다.");
+    }
+
+    @DisplayName("수정 시 숙련도가 누락되면 실패한다")
+    @Test
+    void failWhenUpdateProficiencyIsNull() {
+        Resume resume = createResume();
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, skill, Proficiency.BEGINNER);
+
+        assertThatThrownBy(() -> resumeSkill.update(skill, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("숙련도는 필수 입력값입니다.");
+    }
+
+    private static Resume createResume() {
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName("Generic4");
+        item.setPosition("Backend Engineer");
+        item.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        item.setStartYearMonth("2024-01");
+        item.setCurrentlyWorking(true);
+        item.setSummary("Spring Boot 기반 API를 개발했습니다.");
+        item.setTechStack(List.of("Java", "Spring Boot"));
+
+        CareerPayload career = new CareerPayload();
+        career.setItems(List.of(item));
+
+        return Resume.create(
+                createMember(),
+                "백엔드 개발자입니다.",
+                (byte) 3,
+                career,
+                WorkType.HYBRID,
+                ResumeWritingStatus.WRITING,
+                null
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -563,37 +563,6 @@ class ResumeTest {
         assertThat(resume.getPortfolioUrl()).isEqualTo("https://github.com/user");
     }
 
-    @DisplayName("파일을 추가하면 첫 번째 첨부파일의 표시 순서는 0이다")
-    @Test
-    void addFirstFileHasDisplayOrderZero() {
-        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
-        StoredFile file = createStoredFile("resume.pdf");
-
-        resume.addFile(file);
-
-        assertThat(resume.getAttachments()).hasSize(1);
-        assertThat(resume.getAttachments().get(0).getFile()).isEqualTo(file);
-        assertThat(resume.getAttachments().get(0).getDisplayOrder()).isEqualTo(0);
-    }
-
-    @DisplayName("파일을 순서대로 추가하면 표시 순서가 순차적으로 할당된다")
-    @Test
-    void addMultipleFilesAssignsSequentialDisplayOrder() {
-        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
-        StoredFile file1 = createStoredFile("resume1.pdf");
-        StoredFile file2 = createStoredFile("resume2.pdf");
-        StoredFile file3 = createStoredFile("resume3.pdf");
-
-        resume.addFile(file1);
-        resume.addFile(file2);
-        resume.addFile(file3);
-
-        assertThat(resume.getAttachments()).hasSize(3);
-        assertThat(resume.getAttachments().get(0).getDisplayOrder()).isEqualTo(0);
-        assertThat(resume.getAttachments().get(1).getDisplayOrder()).isEqualTo(1);
-        assertThat(resume.getAttachments().get(2).getDisplayOrder()).isEqualTo(2);
-    }
-
     @DisplayName("파일을 삭제하면 첨부파일 목록에서 제거된다")
     @Test
     void removeFileDeletesAttachment() {
@@ -604,26 +573,6 @@ class ResumeTest {
         resume.removeFile(file);
 
         assertThat(resume.getAttachments()).isEmpty();
-    }
-
-    @DisplayName("중간 파일을 삭제하면 나머지 첨부파일의 표시 순서가 재정렬된다")
-    @Test
-    void removeMiddleFileReordersRemainingAttachments() {
-        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
-        StoredFile file1 = createStoredFile("resume1.pdf");
-        StoredFile file2 = createStoredFile("resume2.pdf");
-        StoredFile file3 = createStoredFile("resume3.pdf");
-        resume.addFile(file1);
-        resume.addFile(file2);
-        resume.addFile(file3);
-
-        resume.removeFile(file2);
-
-        assertThat(resume.getAttachments()).hasSize(2);
-        assertThat(resume.getAttachments().get(0).getFile()).isEqualTo(file1);
-        assertThat(resume.getAttachments().get(0).getDisplayOrder()).isEqualTo(0);
-        assertThat(resume.getAttachments().get(1).getFile()).isEqualTo(file3);
-        assertThat(resume.getAttachments().get(1).getDisplayOrder()).isEqualTo(1);
     }
 
     @DisplayName("존재하지 않는 파일을 삭제해도 첨부파일 목록이 변하지 않는다")

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.skill.Skill;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -670,6 +671,120 @@ class ResumeTest {
         assertThatThrownBy(() -> resume.removeFile(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("삭제할 첨부 파일은 필수값입니다.");
+    }
+
+    @DisplayName("스킬을 추가하면 스킬 목록에 등록된다")
+    @Test
+    void addSkillAppendsToSkillList() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        resume.addSkill(skill, Proficiency.ADVANCED);
+
+        assertThat(resume.getSkills()).hasSize(1);
+        assertThat(resume.getSkills().get(0).getSkill()).isEqualTo(skill);
+        assertThat(resume.getSkills().get(0).getProficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+
+    @DisplayName("스킬을 삭제하면 스킬 목록에서 제거된다")
+    @Test
+    void removeSkillDeletesFromSkillList() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        resume.addSkill(skill, Proficiency.ADVANCED);
+
+        resume.removeSkill(skill);
+
+        assertThat(resume.getSkills()).isEmpty();
+    }
+
+    @DisplayName("존재하지 않는 스킬을 삭제해도 스킬 목록이 변하지 않는다")
+    @Test
+    void removeNonExistentSkillDoesNotChangeSkillList() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        Skill otherSkill = Skill.create("Python", "스크립트 언어");
+        resume.addSkill(skill, Proficiency.ADVANCED);
+
+        resume.removeSkill(otherSkill);
+
+        assertThat(resume.getSkills()).hasSize(1);
+    }
+
+    @DisplayName("스킬을 수정하면 숙련도가 변경된다")
+    @Test
+    void updateSkillChangesProficiency() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        resume.addSkill(skill, Proficiency.BEGINNER);
+
+        resume.updateSkill(skill, Proficiency.ADVANCED);
+
+        assertThat(resume.getSkills().get(0).getProficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+
+    @DisplayName("null 스킬을 추가하면 실패한다")
+    @Test
+    void failWhenAddSkillIsNull() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+
+        assertThatThrownBy(() -> resume.addSkill(null, Proficiency.BEGINNER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스킬은 필수 입력값입니다.");
+    }
+
+    @DisplayName("null 숙련도로 스킬을 추가하면 실패한다")
+    @Test
+    void failWhenAddProficiencyIsNull() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        assertThatThrownBy(() -> resume.addSkill(skill, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("숙련도는 필수 입력값입니다.");
+    }
+
+    @DisplayName("null 스킬을 삭제하면 실패한다")
+    @Test
+    void failWhenRemoveSkillIsNull() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+
+        assertThatThrownBy(() -> resume.removeSkill(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스킬은 필수 입력값입니다.");
+    }
+
+    @DisplayName("존재하지 않는 스킬을 수정하면 실패한다")
+    @Test
+    void failWhenUpdateNonExistentSkill() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+
+        assertThatThrownBy(() -> resume.updateSkill(skill, Proficiency.ADVANCED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("기존에 없는 스킬은 업데이트 할 수 없습니다.");
+    }
+
+    @DisplayName("null 스킬로 수정하면 실패한다")
+    @Test
+    void failWhenUpdateSkillIsNull() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+
+        assertThatThrownBy(() -> resume.updateSkill(null, Proficiency.ADVANCED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스킬은 필수 입력값입니다.");
+    }
+
+    @DisplayName("null 숙련도로 스킬을 수정하면 실패한다")
+    @Test
+    void failWhenUpdateProficiencyIsNull() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        resume.addSkill(skill, Proficiency.BEGINNER);
+
+        assertThatThrownBy(() -> resume.updateSkill(skill, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("숙련도는 필수 입력값입니다.");
     }
 
     private static StoredFile createStoredFile(String originalName) {

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -603,7 +603,7 @@ class ResumeTest {
     @Test
     void failWhenAttachmentsExceedMaxLimit() {
         Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
-        for (int i = 0; i <= 10; i++) {
+        for (int i = 0; i < 10; i++) {
             resume.addFile(createStoredFile("file" + i + ".pdf"));
         }
 

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.ResumeSkill;
 import com.generic4.itda.domain.skill.Skill;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -631,8 +632,9 @@ class ResumeTest {
         resume.addSkill(skill, Proficiency.ADVANCED);
 
         assertThat(resume.getSkills()).hasSize(1);
-        assertThat(resume.getSkills().get(0).getSkill()).isEqualTo(skill);
-        assertThat(resume.getSkills().get(0).getProficiency()).isEqualTo(Proficiency.ADVANCED);
+        ResumeSkill addedSkill = resume.getSkills().iterator().next();
+        assertThat(addedSkill.getSkill()).isEqualTo(skill);
+        assertThat(addedSkill.getProficiency()).isEqualTo(Proficiency.ADVANCED);
     }
 
     @DisplayName("스킬을 삭제하면 스킬 목록에서 제거된다")
@@ -669,7 +671,7 @@ class ResumeTest {
 
         resume.updateSkill(skill, Proficiency.ADVANCED);
 
-        assertThat(resume.getSkills().get(0).getProficiency()).isEqualTo(Proficiency.ADVANCED);
+        assertThat(resume.getSkills().iterator().next().getProficiency()).isEqualTo(Proficiency.ADVANCED);
     }
 
     @DisplayName("null 스킬을 추가하면 실패한다")

--- a/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
@@ -1,0 +1,387 @@
+package com.generic4.itda.repository;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.H2RepositoryTest;
+import com.generic4.itda.domain.file.StoredFile;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@H2RepositoryTest
+class ResumeAssociationTest {
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StoredFileRepository storedFileRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Resume savedResume;
+
+    @BeforeEach
+    void setUp() {
+        Member member = memberRepository.save(createMember());
+        Resume resume = Resume.create(member, "자기소개", (byte) 3, new CareerPayload(),
+                WorkType.REMOTE, ResumeWritingStatus.WRITING, null);
+        savedResume = resumeRepository.saveAndFlush(resume);
+        em.clear();
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 스킬 정렬 — getSortedSkills()
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("스킬 정렬 — getSortedSkills()")
+    class SkillSortingTest {
+
+        /**
+         * skills 컬렉션에 @OrderBy가 없으므로 DB 조회 순서에 의존하지 않습니다.
+         * getSortedSkills()는 Proficiency.priority 기준 내림차순으로 정렬합니다:
+         * ADVANCED(3) > INTERMEDIATE(2) > BEGINNER(1)
+         */
+        @DisplayName("BEGINNER·INTERMEDIATE·ADVANCED 순으로 삽입해도 getSortedSkills()는 priority 내림차순으로 반환한다")
+        @Test
+        void getSortedSkills_orderedByPriorityDesc() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            Skill java = Skill.create("Java", null);
+            Skill python = Skill.create("Python", null);
+            Skill go = Skill.create("Go", null);
+            em.persist(java);
+            em.persist(python);
+            em.persist(go);
+
+            // 의도적으로 낮은 숙련도부터 삽입
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resume.addSkill(python, Proficiency.INTERMEDIATE);
+            resume.addSkill(go, Proficiency.ADVANCED);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+            List<ResumeSkill> sorted = found.getSortedSkills();
+
+            assertThat(sorted)
+                    .extracting(ResumeSkill::getProficiency)
+                    .containsExactly(Proficiency.ADVANCED, Proficiency.INTERMEDIATE, Proficiency.BEGINNER);
+        }
+
+        @DisplayName("동일 숙련도 스킬이 포함되어도 getSortedSkills()는 올바른 priority 내림차순을 유지한다")
+        @Test
+        void getSortedSkills_withDuplicatePriority() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            Skill java = Skill.create("Java", null);
+            Skill kotlin = Skill.create("Kotlin", null);
+            Skill python = Skill.create("Python", null);
+            em.persist(java);
+            em.persist(kotlin);
+            em.persist(python);
+
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resume.addSkill(kotlin, Proficiency.ADVANCED);
+            resume.addSkill(python, Proficiency.ADVANCED);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+            List<ResumeSkill> sorted = found.getSortedSkills();
+
+            assertThat(sorted).hasSize(3);
+            assertThat(sorted.subList(0, 2))
+                    .extracting(ResumeSkill::getProficiency)
+                    .containsOnly(Proficiency.ADVANCED);
+            assertThat(sorted.get(2).getProficiency()).isEqualTo(Proficiency.BEGINNER);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 첨부파일 정렬 — @OrderBy("createdAt asc")
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("첨부파일 정렬 — @OrderBy(\"createdAt asc\")")
+    class AttachmentSortingTest {
+
+        /**
+         * attachments는 @OrderBy("createdAt asc")로 정렬됩니다.
+         * 파일별로 saveAndFlush 후 Thread.sleep을 사용해 createdAt 차이를 보장합니다.
+         */
+        @DisplayName("가장 먼저 생성된 파일이 attachments 리스트의 첫 번째로 조회된다")
+        @Test
+        void orderedByCreatedAtAsc() throws InterruptedException {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            StoredFile file0 = storedFileRepository.save(toStoredFile("report.pdf", "s-0.pdf"));
+            resume.addFile(file0);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file1 = storedFileRepository.save(toStoredFile("portfolio.pdf", "s-1.pdf"));
+            resume.addFile(file1);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file2 = storedFileRepository.save(toStoredFile("cover.pdf", "s-2.pdf"));
+            resume.addFile(file2);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+
+            assertThat(found.getAttachments()).hasSize(3);
+            // 생성 시간 오름차순: file0(earliest) → file1 → file2(latest)
+            assertThat(found.getAttachments())
+                    .extracting(a -> a.getFile().getId())
+                    .containsExactly(file0.getId(), file1.getId(), file2.getId());
+        }
+
+        @DisplayName("나중에 생성된 파일은 attachments 리스트의 뒤에 위치한다")
+        @Test
+        void lateAddedFile_appearsLast() throws InterruptedException {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            StoredFile first = storedFileRepository.save(toStoredFile("first.pdf", "sf.pdf"));
+            resume.addFile(first);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile last = storedFileRepository.save(toStoredFile("last.pdf", "sl.pdf"));
+            resume.addFile(last);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+
+            assertThat(found.getAttachments()).hasSize(2);
+            assertThat(found.getAttachments().get(0).getFile().getId()).isEqualTo(first.getId());
+            assertThat(found.getAttachments().get(1).getFile().getId()).isEqualTo(last.getId());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // orphanRemoval — 스킬
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("orphanRemoval - 스킬")
+    class SkillOrphanRemovalTest {
+
+        @DisplayName("removeSkill 후 flush하면 DB에서 해당 ResumeSkill 레코드가 삭제된다")
+        @Test
+        void removeSkill_deletesOrphanRow() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            Skill java = Skill.create("Java", null);
+            Skill python = Skill.create("Python", null);
+            em.persist(java);
+            em.persist(python);
+
+            resume.addSkill(java, Proficiency.ADVANCED);
+            resume.addSkill(python, Proficiency.INTERMEDIATE);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+            Skill managedJava = em.find(Skill.class, java.getId());
+            persisted.removeSkill(managedJava);
+            resumeRepository.saveAndFlush(persisted);
+            em.clear();
+
+            Resume afterRemoval = resumeRepository.findById(resume.getId()).orElseThrow();
+            assertThat(afterRemoval.getSkills()).hasSize(1);
+            assertThat(afterRemoval.getSkills().get(0).getSkill().getName()).isEqualTo("Python");
+
+            Long count = em.createQuery(
+                            "SELECT COUNT(rs) FROM ResumeSkill rs WHERE rs.resume.id = :id", Long.class)
+                    .setParameter("id", resume.getId())
+                    .getSingleResult();
+            assertThat(count).isEqualTo(1L);
+        }
+
+        @DisplayName("모든 스킬 제거 후 DB에 ResumeSkill 레코드가 하나도 없다")
+        @Test
+        void removeAllSkills_noOrphanRowRemains() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            Skill java = Skill.create("Java", null);
+            em.persist(java);
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+            Skill managedJava = em.find(Skill.class, java.getId());
+            persisted.removeSkill(managedJava);
+            resumeRepository.saveAndFlush(persisted);
+            em.clear();
+
+            Long count = em.createQuery(
+                            "SELECT COUNT(rs) FROM ResumeSkill rs WHERE rs.resume.id = :id", Long.class)
+                    .setParameter("id", resume.getId())
+                    .getSingleResult();
+            assertThat(count).isZero();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // orphanRemoval — 첨부파일
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("orphanRemoval - 첨부파일")
+    class AttachmentOrphanRemovalTest {
+
+        @DisplayName("중간 파일 제거 후 flush하면 DB에서 해당 ResumeAttachment 레코드가 삭제된다")
+        @Test
+        void removeMiddleFile_deletesOrphanRow() throws InterruptedException {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            StoredFile file0 = storedFileRepository.save(toStoredFile("a.pdf", "sa.pdf"));
+            resume.addFile(file0);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file1 = storedFileRepository.save(toStoredFile("b.pdf", "sb.pdf"));
+            resume.addFile(file1);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file2 = storedFileRepository.save(toStoredFile("c.pdf", "sc.pdf"));
+            resume.addFile(file2);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            // 중간 파일(file1) 제거
+            Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+            StoredFile managedFile1 = em.find(StoredFile.class, file1.getId());
+            persisted.removeFile(managedFile1);
+            resumeRepository.saveAndFlush(persisted);
+            em.clear();
+
+            Resume afterRemoval = resumeRepository.findById(resume.getId()).orElseThrow();
+            assertThat(afterRemoval.getAttachments()).hasSize(2);
+
+            Long count = em.createQuery(
+                            "SELECT COUNT(ra) FROM ResumeAttachment ra WHERE ra.resume.id = :id", Long.class)
+                    .setParameter("id", resume.getId())
+                    .getSingleResult();
+            assertThat(count).isEqualTo(2L);
+
+            // @OrderBy("createdAt asc"): file0(earliest) → file2
+            assertThat(afterRemoval.getAttachments())
+                    .extracting(a -> a.getFile().getId())
+                    .containsExactly(file0.getId(), file2.getId());
+        }
+
+        @DisplayName("첫 번째 파일 제거 후 flush하면 DB에서 해당 ResumeAttachment 레코드가 삭제된다")
+        @Test
+        void removeFirstFile_deletesOrphanRow() throws InterruptedException {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            StoredFile file0 = storedFileRepository.save(toStoredFile("x.pdf", "sx.pdf"));
+            resume.addFile(file0);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file1 = storedFileRepository.save(toStoredFile("y.pdf", "sy.pdf"));
+            resume.addFile(file1);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file2 = storedFileRepository.save(toStoredFile("z.pdf", "sz.pdf"));
+            resume.addFile(file2);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            // 첫 번째 파일(file0) 제거
+            Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+            StoredFile managedFile0 = em.find(StoredFile.class, file0.getId());
+            persisted.removeFile(managedFile0);
+            resumeRepository.saveAndFlush(persisted);
+            em.clear();
+
+            Resume afterRemoval = resumeRepository.findById(resume.getId()).orElseThrow();
+            assertThat(afterRemoval.getAttachments()).hasSize(2);
+
+            Long count = em.createQuery(
+                            "SELECT COUNT(ra) FROM ResumeAttachment ra WHERE ra.resume.id = :id", Long.class)
+                    .setParameter("id", resume.getId())
+                    .getSingleResult();
+            assertThat(count).isEqualTo(2L);
+
+            // @OrderBy("createdAt asc"): file1 → file2
+            assertThat(afterRemoval.getAttachments())
+                    .extracting(a -> a.getFile().getId())
+                    .containsExactly(file1.getId(), file2.getId());
+        }
+
+        @DisplayName("모든 파일 제거 후 DB에 ResumeAttachment 레코드가 하나도 없다")
+        @Test
+        void removeAllFiles_noOrphanRowRemains() throws InterruptedException {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+
+            StoredFile file0 = storedFileRepository.save(toStoredFile("p.pdf", "sp.pdf"));
+            resume.addFile(file0);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file1 = storedFileRepository.save(toStoredFile("q.pdf", "sq.pdf"));
+            resume.addFile(file1);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+            StoredFile mf0 = em.find(StoredFile.class, file0.getId());
+            StoredFile mf1 = em.find(StoredFile.class, file1.getId());
+            persisted.removeFile(mf0);
+            persisted.removeFile(mf1);
+            resumeRepository.saveAndFlush(persisted);
+            em.clear();
+
+            Long count = em.createQuery(
+                            "SELECT COUNT(ra) FROM ResumeAttachment ra WHERE ra.resume.id = :id", Long.class)
+                    .setParameter("id", resume.getId())
+                    .getSingleResult();
+            assertThat(count).isZero();
+        }
+    }
+
+    private StoredFile toStoredFile(String originalName, String storedName) {
+        return StoredFile.create(originalName, storedName, "/files/" + storedName, "application/pdf", 1024L);
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
@@ -3,8 +3,6 @@ package com.generic4.itda.repository;
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.generic4.itda.fixture.MemberFixture;
-
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
@@ -15,8 +13,10 @@ import com.generic4.itda.domain.resume.ResumeSkill;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.fixture.MemberFixture;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -58,8 +58,7 @@ class ResumeAssociationTest {
     class SkillSortingTest {
 
         /**
-         * skills 컬렉션에 @OrderBy가 없으므로 DB 조회 순서에 의존하지 않습니다.
-         * getSortedSkills()는 Proficiency.priority 기준 내림차순으로 정렬합니다:
+         * skills 컬렉션에 @OrderBy가 없으므로 DB 조회 순서에 의존하지 않습니다. getSortedSkills()는 Proficiency.priority 기준 내림차순으로 정렬합니다:
          * ADVANCED(3) > INTERMEDIATE(2) > BEGINNER(1)
          */
         @DisplayName("BEGINNER·INTERMEDIATE·ADVANCED 순으로 삽입해도 getSortedSkills()는 priority 내림차순으로 반환한다")
@@ -82,9 +81,8 @@ class ResumeAssociationTest {
             em.clear();
 
             Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
-            List<ResumeSkill> sorted = found.getSortedSkills();
 
-            assertThat(sorted)
+            assertThat(found.getSkills())
                     .extracting(ResumeSkill::getProficiency)
                     .containsExactly(Proficiency.ADVANCED, Proficiency.INTERMEDIATE, Proficiency.BEGINNER);
         }
@@ -108,7 +106,7 @@ class ResumeAssociationTest {
             em.clear();
 
             Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
-            List<ResumeSkill> sorted = found.getSortedSkills();
+            List<ResumeSkill> sorted = List.copyOf(found.getSkills());
 
             assertThat(sorted).hasSize(3);
             assertThat(sorted.subList(0, 2))
@@ -127,8 +125,7 @@ class ResumeAssociationTest {
     class AttachmentSortingTest {
 
         /**
-         * attachments는 @OrderBy("createdAt asc")로 정렬됩니다.
-         * 파일별로 saveAndFlush 후 Thread.sleep을 사용해 createdAt 차이를 보장합니다.
+         * attachments는 @OrderBy("createdAt asc")로 정렬됩니다. 파일별로 saveAndFlush 후 Thread.sleep을 사용해 createdAt 차이를 보장합니다.
          */
         @DisplayName("가장 먼저 생성된 파일이 attachments 리스트의 첫 번째로 조회된다")
         @Test
@@ -218,7 +215,7 @@ class ResumeAssociationTest {
 
             Resume afterRemoval = resumeRepository.findById(resume.getId()).orElseThrow();
             assertThat(afterRemoval.getSkills()).hasSize(1);
-            assertThat(afterRemoval.getSkills().get(0).getSkill().getName()).isEqualTo("Python");
+            assertThat(afterRemoval.getSkills().iterator().next().getSkill().getName()).isEqualTo("Python");
 
             Long count = em.createQuery(
                             "SELECT COUNT(rs) FROM ResumeSkill rs WHERE rs.resume.id = :id", Long.class)
@@ -392,9 +389,8 @@ class ResumeAssociationTest {
     class CascadePersistTest {
 
         /**
-         * Member, Skill, StoredFile은 Resume 에서 cascade되지 않으므로 직접 영속화합니다.
-         * ResumeSkill과 ResumeAttachment는 Resume.skills / Resume.attachments 컬렉션에
-         * CascadeType.ALL이 설정되어 있어 resumeRepository.save(resume) 한 번으로 함께 저장됩니다.
+         * Member, Skill, StoredFile은 Resume 에서 cascade되지 않으므로 직접 영속화합니다. ResumeSkill과 ResumeAttachment는 Resume.skills /
+         * Resume.attachments 컬렉션에 CascadeType.ALL이 설정되어 있어 resumeRepository.save(resume) 한 번으로 함께 저장됩니다.
          */
         @DisplayName("resumeRepository.save() 한 번으로 ResumeSkill, ResumeAttachment가 함께 저장된다")
         @Test
@@ -440,9 +436,8 @@ class ResumeAssociationTest {
             assertThat(skillCount).isEqualTo(2L);
             assertThat(attachmentCount).isEqualTo(1L);
 
-            // getSortedSkills(): priority 내림차순 — ADVANCED(3) > BEGINNER(1)
-            List<ResumeSkill> sorted = found.getSortedSkills();
-            assertThat(sorted)
+            // getSkills(): TreeSet — priority 내림차순 ADVANCED(3) > BEGINNER(1)
+            assertThat(found.getSkills())
                     .extracting(ResumeSkill::getProficiency)
                     .containsExactly(Proficiency.ADVANCED, Proficiency.BEGINNER);
 
@@ -485,6 +480,54 @@ class ResumeAssociationTest {
             assertThat(found.getAttachments())
                     .extracting(a -> a.getFile().getId())
                     .containsExactly(file0.getId(), file1.getId(), file2.getId());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 스킬 중복 방지 — DB 저장 후 재조회 시나리오
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("스킬 중복 방지 — DB 저장 후 재조회")
+    class SkillDuplicateTest {
+
+        /**
+         * DB에 스킬을 저장한 뒤 재조회하면, addSkill 중복 방지 로직이 올바르게 동작한다.
+         */
+        @DisplayName("DB에 저장된 스킬과 동일한 스킬을 같은 숙련도로 추가하면 예외가 발생한다")
+        @Test
+        void addDuplicateSkill_afterPersist_sameProficiency_throwsException() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+            Skill java = Skill.create("Java", null);
+            em.persist(java);
+            resume.addSkill(java, Proficiency.ADVANCED);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume reloaded = resumeRepository.findById(resume.getId()).orElseThrow();
+            Skill managedJava = em.find(Skill.class, java.getId());
+
+            Assertions.assertThatThrownBy(() -> reloaded.addSkill(managedJava, Proficiency.ADVANCED))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("이미 등록된 스킬입니다.");
+        }
+
+        @DisplayName("DB에 저장된 스킬과 동일한 스킬을 다른 숙련도로 추가하면 예외가 발생한다")
+        @Test
+        void addDuplicateSkill_afterPersist_differentProficiency_throwsException() {
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+            Skill java = Skill.create("Java", null);
+            em.persist(java);
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            Resume reloaded = resumeRepository.findById(resume.getId()).orElseThrow();
+            Skill managedJava = em.find(Skill.class, java.getId());
+
+            Assertions.assertThatThrownBy(() -> reloaded.addSkill(managedJava, Proficiency.BEGINNER))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("이미 등록된 스킬입니다.");
         }
     }
 

--- a/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
@@ -3,6 +3,8 @@ package com.generic4.itda.repository;
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.generic4.itda.fixture.MemberFixture;
+
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
@@ -378,6 +380,111 @@ class ResumeAssociationTest {
                     .setParameter("id", resume.getId())
                     .getSingleResult();
             assertThat(count).isZero();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 신규 Resume 저장 — CascadeType.ALL
+    // ═══════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("신규 Resume 저장 — CascadeType.ALL")
+    class CascadePersistTest {
+
+        /**
+         * Member, Skill, StoredFile은 Resume 에서 cascade되지 않으므로 직접 영속화합니다.
+         * ResumeSkill과 ResumeAttachment는 Resume.skills / Resume.attachments 컬렉션에
+         * CascadeType.ALL이 설정되어 있어 resumeRepository.save(resume) 한 번으로 함께 저장됩니다.
+         */
+        @DisplayName("resumeRepository.save() 한 번으로 ResumeSkill, ResumeAttachment가 함께 저장된다")
+        @Test
+        void singleSave_cascadesResumeSkillAndAttachment() {
+            // Resume cascade 대상이 아닌 엔티티는 직접 영속화
+            Member member = memberRepository.save(
+                    MemberFixture.createMember("new@test.com", "hashed-pw", "신규회원", "010-9999-0001"));
+
+            Skill java = Skill.create("Java", null);
+            Skill kotlin = Skill.create("Kotlin", null);
+            em.persist(java);
+            em.persist(kotlin);
+            em.flush();
+
+            StoredFile file = storedFileRepository.save(toStoredFile("portfolio.pdf", "portfolio-s.pdf"));
+
+            // 루트 엔티티 생성 후 자식 연결 — 별도 save 없음
+            Resume resume = Resume.create(member, "신규 자기소개", (byte) 5, new CareerPayload(),
+                    WorkType.HYBRID, ResumeWritingStatus.WRITING, null);
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resume.addSkill(kotlin, Proficiency.ADVANCED);
+            resume.addFile(file);
+
+            // 단일 save() 호출로 전체 애그리거트 저장
+            resumeRepository.saveAndFlush(resume);
+            Long resumeId = resume.getId();
+            em.clear();
+
+            // 재조회: 영속성 컨텍스트 간섭 없이 DB 상태 직접 검증
+            Resume found = resumeRepository.findById(resumeId).orElseThrow();
+            assertThat(found.getSkills()).hasSize(2);
+            assertThat(found.getAttachments()).hasSize(1);
+
+            // JPQL로 실제 DB 레코드 수 검증
+            Long skillCount = em.createQuery(
+                            "SELECT COUNT(rs) FROM ResumeSkill rs WHERE rs.resume.id = :id", Long.class)
+                    .setParameter("id", resumeId)
+                    .getSingleResult();
+            Long attachmentCount = em.createQuery(
+                            "SELECT COUNT(ra) FROM ResumeAttachment ra WHERE ra.resume.id = :id", Long.class)
+                    .setParameter("id", resumeId)
+                    .getSingleResult();
+            assertThat(skillCount).isEqualTo(2L);
+            assertThat(attachmentCount).isEqualTo(1L);
+
+            // getSortedSkills(): priority 내림차순 — ADVANCED(3) > BEGINNER(1)
+            List<ResumeSkill> sorted = found.getSortedSkills();
+            assertThat(sorted)
+                    .extracting(ResumeSkill::getProficiency)
+                    .containsExactly(Proficiency.ADVANCED, Proficiency.BEGINNER);
+
+            // 첨부파일 파일 ID 검증
+            assertThat(found.getAttachments().get(0).getFile().getId()).isEqualTo(file.getId());
+        }
+
+        @DisplayName("신규 Resume에 파일을 순차적으로 추가하면 createdAt asc 순으로 조회된다")
+        @Test
+        void newResume_multipleFiles_orderedByCreatedAtAsc() throws InterruptedException {
+            Member member = memberRepository.save(
+                    MemberFixture.createMember("order@test.com", "hashed-pw", "정렬회원", "010-9999-0002"));
+
+            Resume resume = Resume.create(member, "자기소개", (byte) 0, new CareerPayload(),
+                    WorkType.REMOTE, ResumeWritingStatus.WRITING, null);
+            resumeRepository.saveAndFlush(resume);
+
+            // 파일별 개별 flush + sleep으로 createdAt 차이 보장
+            StoredFile file0 = storedFileRepository.save(toStoredFile("cv1.pdf", "cv1-s.pdf"));
+            resume.addFile(file0);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file1 = storedFileRepository.save(toStoredFile("cv2.pdf", "cv2-s.pdf"));
+            resume.addFile(file1);
+            resumeRepository.saveAndFlush(resume);
+
+            Thread.sleep(20);
+
+            StoredFile file2 = storedFileRepository.save(toStoredFile("cv3.pdf", "cv3-s.pdf"));
+            resume.addFile(file2);
+            resumeRepository.saveAndFlush(resume);
+
+            em.clear();
+
+            // @OrderBy("createdAt asc"): 가장 먼저 추가된 파일이 인덱스 0
+            Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+            assertThat(found.getAttachments()).hasSize(3);
+            assertThat(found.getAttachments())
+                    .extracting(a -> a.getFile().getId())
+                    .containsExactly(file0.getId(), file1.getId(), file2.getId());
         }
     }
 

--- a/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
@@ -1,0 +1,222 @@
+package com.generic4.itda.repository;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.H2RepositoryTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@H2RepositoryTest
+class ResumeRepositoryTest {
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @DisplayName("경력이 없는 CareerPayload도 JSON으로 정상 저장/조회된다")
+    @Test
+    void saveAndLoad_emptyCareer() {
+        Member member = memberRepository.save(createMember());
+        CareerPayload career = new CareerPayload();
+
+        Resume resume = Resume.create(member, "자기소개입니다.", (byte) 0, career, WorkType.REMOTE,
+                ResumeWritingStatus.WRITING, null);
+        resumeRepository.saveAndFlush(resume);
+        entityManager.clear();
+
+        Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+        assertThat(found.getCareer()).isNotNull();
+        assertThat(found.getCareer().getVersion()).isEqualTo(1);
+        assertThat(found.getCareer().getItems()).isEmpty();
+    }
+
+    @DisplayName("재직 중인 CareerItemPayload는 endYearMonth 없이 저장/조회된다")
+    @Test
+    void saveAndLoad_currentlyWorkingCareerItem() {
+        Member member = memberRepository.save(createMember());
+
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName("카카오");
+        item.setPosition("백엔드 개발자");
+        item.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        item.setStartYearMonth("2022-03");
+        item.setCurrentlyWorking(true);
+        item.setSummary("Spring Boot 기반 서비스 개발");
+        item.setTechStack(List.of("Java", "Spring Boot", "MySQL"));
+
+        CareerPayload career = new CareerPayload();
+        career.getItems().add(item);
+
+        Resume resume = Resume.create(member, "자기소개", (byte) 3, career, WorkType.REMOTE,
+                ResumeWritingStatus.WRITING, null);
+        resumeRepository.saveAndFlush(resume);
+        entityManager.clear();
+
+        Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+        CareerPayload loadedCareer = found.getCareer();
+
+        assertThat(loadedCareer.getVersion()).isEqualTo(1);
+        assertThat(loadedCareer.getItems()).hasSize(1);
+
+        CareerItemPayload loadedItem = loadedCareer.getItems().get(0);
+        assertThat(loadedItem.getCompanyName()).isEqualTo("카카오");
+        assertThat(loadedItem.getPosition()).isEqualTo("백엔드 개발자");
+        assertThat(loadedItem.getEmploymentType()).isEqualTo(CareerEmploymentType.FULL_TIME);
+        assertThat(loadedItem.getStartYearMonth()).isEqualTo("2022-03");
+        assertThat(loadedItem.getEndYearMonth()).isNull();
+        assertThat(loadedItem.getCurrentlyWorking()).isTrue();
+        assertThat(loadedItem.getSummary()).isEqualTo("Spring Boot 기반 서비스 개발");
+        assertThat(loadedItem.getTechStack()).containsExactly("Java", "Spring Boot", "MySQL");
+    }
+
+    @DisplayName("퇴직한 CareerItemPayload는 endYearMonth와 함께 저장/조회된다")
+    @Test
+    void saveAndLoad_formerCareerItem() {
+        Member member = memberRepository.save(createMember());
+
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName("네이버");
+        item.setPosition("시스템 엔지니어");
+        item.setEmploymentType(CareerEmploymentType.CONTRACT);
+        item.setStartYearMonth("2020-01");
+        item.setEndYearMonth("2021-12");
+        item.setCurrentlyWorking(false);
+        item.setSummary(null);
+        item.setTechStack(List.of());
+
+        CareerPayload career = new CareerPayload();
+        career.getItems().add(item);
+
+        Resume resume = Resume.create(member, "자기소개", (byte) 2, career, WorkType.SITE,
+                ResumeWritingStatus.DONE, null);
+        resumeRepository.saveAndFlush(resume);
+        entityManager.clear();
+
+        Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+        CareerItemPayload loadedItem = found.getCareer().getItems().get(0);
+
+        assertThat(loadedItem.getStartYearMonth()).isEqualTo("2020-01");
+        assertThat(loadedItem.getEndYearMonth()).isEqualTo("2021-12");
+        assertThat(loadedItem.getCurrentlyWorking()).isFalse();
+        assertThat(loadedItem.getSummary()).isNull();
+        assertThat(loadedItem.getTechStack()).isEmpty();
+    }
+
+    @DisplayName("복수의 CareerItemPayload가 순서대로 저장/조회된다")
+    @Test
+    void saveAndLoad_multipleCareerItems_orderPreserved() {
+        Member member = memberRepository.save(createMember());
+
+        CareerItemPayload item1 = new CareerItemPayload();
+        item1.setCompanyName("A사");
+        item1.setPosition("주니어 개발자");
+        item1.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        item1.setStartYearMonth("2019-03");
+        item1.setEndYearMonth("2021-02");
+        item1.setCurrentlyWorking(false);
+        item1.setTechStack(List.of("Python", "Django"));
+
+        CareerItemPayload item2 = new CareerItemPayload();
+        item2.setCompanyName("B사");
+        item2.setPosition("시니어 개발자");
+        item2.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        item2.setStartYearMonth("2021-03");
+        item2.setCurrentlyWorking(true);
+        item2.setSummary("마이크로서비스 설계 및 개발");
+        item2.setTechStack(List.of("Java", "Kotlin", "Kubernetes"));
+
+        CareerItemPayload item3 = new CareerItemPayload();
+        item3.setCompanyName("C사");
+        item3.setPosition("프리랜서");
+        item3.setEmploymentType(CareerEmploymentType.FREELANCE);
+        item3.setStartYearMonth("2018-06");
+        item3.setEndYearMonth("2019-01");
+        item3.setCurrentlyWorking(false);
+        item3.setTechStack(List.of());
+
+        CareerPayload career = new CareerPayload();
+        career.getItems().addAll(List.of(item1, item2, item3));
+
+        Resume resume = Resume.create(member, "자기소개", (byte) 7, career, WorkType.HYBRID,
+                ResumeWritingStatus.WRITING, null);
+        resumeRepository.saveAndFlush(resume);
+        entityManager.clear();
+
+        Resume found = resumeRepository.findById(resume.getId()).orElseThrow();
+        List<CareerItemPayload> loadedItems = found.getCareer().getItems();
+
+        assertThat(loadedItems).hasSize(3);
+        assertThat(loadedItems.get(0).getCompanyName()).isEqualTo("A사");
+        assertThat(loadedItems.get(0).getTechStack()).containsExactly("Python", "Django");
+        assertThat(loadedItems.get(1).getCompanyName()).isEqualTo("B사");
+        assertThat(loadedItems.get(1).getTechStack()).containsExactly("Java", "Kotlin", "Kubernetes");
+        assertThat(loadedItems.get(2).getCompanyName()).isEqualTo("C사");
+        assertThat(loadedItems.get(2).getTechStack()).isEmpty();
+    }
+
+    @DisplayName("Resume 업데이트 시 변경된 CareerPayload가 올바르게 반영된다")
+    @Test
+    void update_career_reflectsChanges() {
+        Member member = memberRepository.save(createMember());
+
+        CareerItemPayload original = new CareerItemPayload();
+        original.setCompanyName("구버전 회사");
+        original.setPosition("개발자");
+        original.setEmploymentType(CareerEmploymentType.INTERN);
+        original.setStartYearMonth("2023-01");
+        original.setCurrentlyWorking(true);
+        original.setTechStack(List.of("PHP"));
+
+        CareerPayload originalCareer = new CareerPayload();
+        originalCareer.getItems().add(original);
+
+        Resume resume = Resume.create(member, "자기소개", (byte) 1, originalCareer, WorkType.REMOTE,
+                ResumeWritingStatus.WRITING, null);
+        resumeRepository.saveAndFlush(resume);
+        entityManager.clear();
+
+        Resume persisted = resumeRepository.findById(resume.getId()).orElseThrow();
+
+        CareerItemPayload updated = new CareerItemPayload();
+        updated.setCompanyName("신버전 회사");
+        updated.setPosition("시니어 개발자");
+        updated.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        updated.setStartYearMonth("2023-01");
+        updated.setEndYearMonth("2024-12");
+        updated.setCurrentlyWorking(false);
+        updated.setTechStack(List.of("Java", "Spring"));
+
+        CareerPayload updatedCareer = new CareerPayload();
+        updatedCareer.getItems().add(updated);
+
+        persisted.update("수정된 자기소개", (byte) 2, updatedCareer, WorkType.SITE,
+                ResumeWritingStatus.DONE, null);
+        resumeRepository.saveAndFlush(persisted);
+        entityManager.clear();
+
+        Resume result = resumeRepository.findById(resume.getId()).orElseThrow();
+        CareerItemPayload loadedItem = result.getCareer().getItems().get(0);
+
+        assertThat(loadedItem.getCompanyName()).isEqualTo("신버전 회사");
+        assertThat(loadedItem.getEmploymentType()).isEqualTo(CareerEmploymentType.FULL_TIME);
+        assertThat(loadedItem.getEndYearMonth()).isEqualTo("2024-12");
+        assertThat(loadedItem.getCurrentlyWorking()).isFalse();
+        assertThat(loadedItem.getTechStack()).containsExactly("Java", "Spring");
+    }
+}


### PR DESCRIPTION
## 🔎 What

- ResumeSkill 엔티티 구현 및 테스트 코드 작성
- Resume와 ResumeSkill 연관관계 매핑 및 편의 메서드 도입
- 첨부 파일 및 스킬 숙련도 정렬 정책 수정 반영
- 첨부 파일 정렬 정책 수정으로 인한 display_order의 삭제
- Resume 애그리거트 DB 슬라이스 테스트 완료
- Resume 엔티티 cascade 정책을 통한 연관관계 매핑 엔티티 삭제
- 테스트 코드 취약점 해결
- Resume에 중복 스킬 방지 로직 추가

## 🔗 Issue

- Closes: #2 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

## 🗒️ Note

- Resume의 첨부/스킬 삭제 및 수정 로직이 엔티티 동일성에 의존하는 문제는 StoredFile/Skill 엔티티 수정을 요구합니다.
- 따라서, 이 변경점은 별도의 이슈로 다루도록 하겠습니다.