### PR TITLE
[Feat] Resume 스킬 중복 추가 방어 로직 보강

### DIFF
--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -183,7 +183,11 @@ public class Resume extends BaseEntity {
         Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");
 
         ResumeSkill resumeSkill = ResumeSkill.create(this, skill, proficiency);
-        Assert.state(!this.skills.contains(resumeSkill), "이미 등록된 스킬입니다.");
+        boolean isExist = this.skills.stream()
+                .anyMatch(rs -> rs.getSkill().equals(skill));
+        if (isExist) {
+            throw new IllegalStateException("이미 등록된 스킬입니다.");
+        }
 
         this.skills.add(resumeSkill);
     }

--- a/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
+++ b/src/main/java/com/generic4/itda/domain/resume/ResumeSkill.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +20,14 @@ import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
 @Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_resume_skill_resume_id_skill_id",
+                        columnNames = {"resume_id", "skill_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResumeSkill extends BaseTimeEntity {
@@ -62,8 +72,12 @@ public class ResumeSkill extends BaseTimeEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ResumeSkill that)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ResumeSkill that)) {
+            return false;
+        }
         return id != null && id.equals(that.id);
     }
 

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.domain.file.StoredFile;
 import com.generic4.itda.domain.member.Member;
-import com.generic4.itda.domain.resume.ResumeSkill;
 import com.generic4.itda.domain.skill.Skill;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -736,6 +735,18 @@ class ResumeTest {
         assertThatThrownBy(() -> resume.updateSkill(skill, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("숙련도는 필수 입력값입니다.");
+    }
+
+    @Test
+    @DisplayName("스킬 이름만 동일한 스킬 등록은 실패한다.")
+    void failWhenAddSkillHavingDuplicateSkillName() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill skill = Skill.create("Java", "백엔드 언어");
+        resume.addSkill(skill, Proficiency.BEGINNER);
+
+        assertThatThrownBy(() -> resume.addSkill(skill, Proficiency.ADVANCED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 등록된 스킬입니다.");
     }
 
     private static StoredFile createStoredFile(String originalName) {

--- a/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeAssociationTest.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.file.StoredFile;
@@ -526,6 +527,32 @@ class ResumeAssociationTest {
             Skill managedJava = em.find(Skill.class, java.getId());
 
             Assertions.assertThatThrownBy(() -> reloaded.addSkill(managedJava, Proficiency.BEGINNER))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("이미 등록된 스킬입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("스킬 중복 방지 — 영속성 통합 검증")
+    class SkillDuplicateIntegrationTest {
+
+        @DisplayName("이미 특정 스킬이 등록된 이력서에, 동일한 스킬을 다른 숙련도로 추가 저장하려 하면 예외가 발생한다")
+        @Test
+        void addSkill_withSameSkillButDifferentProficiency_throwsException() {
+            // 1. 준비: Java 스킬을 BEGINNER로 저장
+            Resume resume = resumeRepository.findById(savedResume.getId()).orElseThrow();
+            Skill java = Skill.create("Java", null);
+            em.persist(java);
+            resume.addSkill(java, Proficiency.BEGINNER);
+            resumeRepository.saveAndFlush(resume);
+            em.clear();
+
+            // 2. 실행: 동일한 Java 스킬을 ADVANCED로 추가 시도
+            Resume reloaded = resumeRepository.findById(resume.getId()).orElseThrow();
+            Skill managedJava = em.find(Skill.class, java.getId());
+
+            // 3. 검증: 도메인 로직에 의해 IllegalStateException 발생 확인
+            assertThatThrownBy(() -> reloaded.addSkill(managedJava, Proficiency.ADVANCED))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("이미 등록된 스킬입니다.");
         }


### PR DESCRIPTION
## 🔎 What

- Resume#addSkill 도메인 코드에 방어로직 추가
- ResumeSkill에 유니크 제약조건 추가
- 중복 스킬 입력 테스트 추가

## 🔗 Issue

- Closes: #6 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?