### PR TITLE
[Fix] StoredFile, Skill 식별자 기반 동일성 보완

### DIFF
--- a/src/main/java/com/generic4/itda/domain/file/StoredFile.java
+++ b/src/main/java/com/generic4/itda/domain/file/StoredFile.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -78,5 +79,21 @@ public class StoredFile extends BaseEntity {
 
     public boolean hasSameStoredName(String storedName) {
         return this.storedName.equals(storedName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StoredFile that)) {
+            return false;
+        }
+        return id != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/generic4/itda/domain/skill/Skill.java
+++ b/src/main/java/com/generic4/itda/domain/skill/Skill.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,5 +46,21 @@ public class Skill extends BaseTimeEntity {
 
         this.name = name.trim();
         this.description = StringUtils.hasText(description) ? description.trim() : null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Skill that)) {
+            return false;
+        }
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/test/java/com/generic4/itda/domain/file/StoredFileTest.java
+++ b/src/test/java/com/generic4/itda/domain/file/StoredFileTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -167,6 +168,85 @@ class StoredFileTest {
             StoredFile storedFile = createStoredFile("avatar.png", "stored-uuid.png", "/files/stored-uuid.png", "image/png", 0L);
 
             assertThat(storedFile.hasSameStoredName("other-uuid.png")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("equals and hashCode")
+    class EqualsAndHashCode {
+
+        @Test
+        @DisplayName("같은 참조이면 동등하다")
+        void sameReference_isEqual() {
+            StoredFile file = createStoredFile("a.png", "s.png", "/files/s.png", "image/png", 0L);
+
+            assertThat(file).isEqualTo(file);
+        }
+
+        @Test
+        @DisplayName("id가 null인 두 인스턴스는 동등하지 않다")
+        void nullIdInstances_areNotEqualToEachOther() {
+            StoredFile file1 = createStoredFile("a.png", "s1.png", "/files/s1.png", "image/png", 0L);
+            StoredFile file2 = createStoredFile("a.png", "s2.png", "/files/s2.png", "image/png", 0L);
+
+            assertThat(file1).isNotEqualTo(file2);
+        }
+
+        @Test
+        @DisplayName("같은 id를 가지면 동등하다")
+        void sameId_areEqual() {
+            StoredFile file1 = createStoredFile("a.png", "s1.png", "/files/s1.png", "image/png", 0L);
+            StoredFile file2 = createStoredFile("b.pdf", "s2.pdf", "/files/s2.pdf", "application/pdf", 100L);
+            ReflectionTestUtils.setField(file1, "id", 1L);
+            ReflectionTestUtils.setField(file2, "id", 1L);
+
+            assertThat(file1).isEqualTo(file2);
+        }
+
+        @Test
+        @DisplayName("다른 id를 가지면 동등하지 않다")
+        void differentId_areNotEqual() {
+            StoredFile file1 = createStoredFile("a.png", "s1.png", "/files/s1.png", "image/png", 0L);
+            StoredFile file2 = createStoredFile("a.png", "s2.png", "/files/s2.png", "image/png", 0L);
+            ReflectionTestUtils.setField(file1, "id", 1L);
+            ReflectionTestUtils.setField(file2, "id", 2L);
+
+            assertThat(file1).isNotEqualTo(file2);
+        }
+
+        @Test
+        @DisplayName("null과 비교하면 동등하지 않다")
+        void notEqualToNull() {
+            StoredFile file = createStoredFile("a.png", "s.png", "/files/s.png", "image/png", 0L);
+
+            assertThat(file).isNotEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("다른 타입과 비교하면 동등하지 않다")
+        void notEqualToDifferentType() {
+            StoredFile file = createStoredFile("a.png", "s.png", "/files/s.png", "image/png", 0L);
+
+            assertThat(file).isNotEqualTo("a.png");
+        }
+
+        @Test
+        @DisplayName("id가 null이면 hashCode는 0이다")
+        void nullIdHashCode_isZero() {
+            StoredFile file = createStoredFile("a.png", "s.png", "/files/s.png", "image/png", 0L);
+
+            assertThat(file.hashCode()).isZero();
+        }
+
+        @Test
+        @DisplayName("같은 id를 가지면 hashCode가 동일하다")
+        void sameId_haveSameHashCode() {
+            StoredFile file1 = createStoredFile("a.png", "s1.png", "/files/s1.png", "image/png", 0L);
+            StoredFile file2 = createStoredFile("b.pdf", "s2.pdf", "/files/s2.pdf", "application/pdf", 100L);
+            ReflectionTestUtils.setField(file1, "id", 42L);
+            ReflectionTestUtils.setField(file2, "id", 42L);
+
+            assertThat(file1.hashCode()).isEqualTo(file2.hashCode());
         }
     }
 

--- a/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
+++ b/src/test/java/com/generic4/itda/domain/resume/ResumeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class ResumeTest {
 
@@ -735,6 +736,70 @@ class ResumeTest {
         assertThatThrownBy(() -> resume.updateSkill(skill, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("숙련도는 필수 입력값입니다.");
+    }
+
+    @DisplayName("같은 id를 가진 다른 StoredFile 인스턴스로 파일을 삭제할 수 있다")
+    @Test
+    void removeFileByDifferentInstanceWithSameId() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        StoredFile original = createStoredFile("resume.pdf");
+        ReflectionTestUtils.setField(original, "id", 1L);
+        resume.addFile(original);
+
+        StoredFile sameIdButDifferentInstance = createStoredFile("different-name.pdf");
+        ReflectionTestUtils.setField(sameIdButDifferentInstance, "id", 1L);
+
+        resume.removeFile(sameIdButDifferentInstance);
+
+        assertThat(resume.getAttachments()).isEmpty();
+    }
+
+    @DisplayName("같은 id를 가진 다른 Skill 인스턴스로 스킬을 삭제할 수 있다")
+    @Test
+    void removeSkillByDifferentInstanceWithSameId() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill original = Skill.create("Java", "백엔드 언어");
+        ReflectionTestUtils.setField(original, "id", 1L);
+        resume.addSkill(original, Proficiency.ADVANCED);
+
+        Skill sameIdButDifferentInstance = Skill.create("Java", "다른 설명");
+        ReflectionTestUtils.setField(sameIdButDifferentInstance, "id", 1L);
+
+        resume.removeSkill(sameIdButDifferentInstance);
+
+        assertThat(resume.getSkills()).isEmpty();
+    }
+
+    @DisplayName("같은 id를 가진 다른 Skill 인스턴스로 스킬 숙련도를 수정할 수 있다")
+    @Test
+    void updateSkillByDifferentInstanceWithSameId() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill original = Skill.create("Java", "백엔드 언어");
+        ReflectionTestUtils.setField(original, "id", 1L);
+        resume.addSkill(original, Proficiency.BEGINNER);
+
+        Skill sameIdButDifferentInstance = Skill.create("Java", "다른 설명");
+        ReflectionTestUtils.setField(sameIdButDifferentInstance, "id", 1L);
+
+        resume.updateSkill(sameIdButDifferentInstance, Proficiency.ADVANCED);
+
+        assertThat(resume.getSkills().iterator().next().getProficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+
+    @DisplayName("같은 id를 가진 다른 Skill 인스턴스를 추가하면 중복으로 거부된다")
+    @Test
+    void addSkillWithSameIdButDifferentInstanceIsRejectedAsDuplicate() {
+        Resume resume = createResume(createMember(), "백엔드 개발자입니다.", (byte) 3, createCareerPayload());
+        Skill original = Skill.create("Java", "백엔드 언어");
+        ReflectionTestUtils.setField(original, "id", 1L);
+        resume.addSkill(original, Proficiency.BEGINNER);
+
+        Skill sameIdButDifferentInstance = Skill.create("다른이름", "다른설명");
+        ReflectionTestUtils.setField(sameIdButDifferentInstance, "id", 1L);
+
+        assertThatThrownBy(() -> resume.addSkill(sameIdButDifferentInstance, Proficiency.ADVANCED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 등록된 스킬입니다.");
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/domain/skill/SkillTest.java
+++ b/src/test/java/com/generic4/itda/domain/skill/SkillTest.java
@@ -6,7 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
@@ -70,6 +73,85 @@ class SkillTest {
         skill.update("Spring", description);
 
         assertThat(skill.getDescription()).isNull();
+    }
+
+    @Nested
+    @DisplayName("equals and hashCode")
+    class EqualsAndHashCode {
+
+        @Test
+        @DisplayName("같은 참조이면 동등하다")
+        void sameReference_isEqual() {
+            Skill skill = createSkill("Java", null);
+
+            assertThat(skill).isEqualTo(skill);
+        }
+
+        @Test
+        @DisplayName("id가 null인 두 인스턴스는 동등하지 않다")
+        void nullIdInstances_areNotEqualToEachOther() {
+            Skill skill1 = createSkill("Java", null);
+            Skill skill2 = createSkill("Java", null);
+
+            assertThat(skill1).isNotEqualTo(skill2);
+        }
+
+        @Test
+        @DisplayName("같은 id를 가지면 동등하다")
+        void sameId_areEqual() {
+            Skill skill1 = createSkill("Java", null);
+            Skill skill2 = createSkill("Spring", "웹 프레임워크");
+            ReflectionTestUtils.setField(skill1, "id", 1L);
+            ReflectionTestUtils.setField(skill2, "id", 1L);
+
+            assertThat(skill1).isEqualTo(skill2);
+        }
+
+        @Test
+        @DisplayName("다른 id를 가지면 동등하지 않다")
+        void differentId_areNotEqual() {
+            Skill skill1 = createSkill("Java", null);
+            Skill skill2 = createSkill("Java", null);
+            ReflectionTestUtils.setField(skill1, "id", 1L);
+            ReflectionTestUtils.setField(skill2, "id", 2L);
+
+            assertThat(skill1).isNotEqualTo(skill2);
+        }
+
+        @Test
+        @DisplayName("null과 비교하면 동등하지 않다")
+        void notEqualToNull() {
+            Skill skill = createSkill("Java", null);
+
+            assertThat(skill).isNotEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("다른 타입과 비교하면 동등하지 않다")
+        void notEqualToDifferentType() {
+            Skill skill = createSkill("Java", null);
+
+            assertThat(skill).isNotEqualTo("Java");
+        }
+
+        @Test
+        @DisplayName("id가 null이면 hashCode는 0이다")
+        void nullIdHashCode_isZero() {
+            Skill skill = createSkill("Java", null);
+
+            assertThat(skill.hashCode()).isZero();
+        }
+
+        @Test
+        @DisplayName("같은 id를 가지면 hashCode가 동일하다")
+        void sameId_haveSameHashCode() {
+            Skill skill1 = createSkill("Java", null);
+            Skill skill2 = createSkill("Spring", "웹 프레임워크");
+            ReflectionTestUtils.setField(skill1, "id", 42L);
+            ReflectionTestUtils.setField(skill2, "id", 42L);
+
+            assertThat(skill1.hashCode()).isEqualTo(skill2.hashCode());
+        }
     }
 
     private static Skill createSkill(String name, String description) {


### PR DESCRIPTION
## 🔎 What

- StoredFile/Skill 엔티티의 equals/hashcode를 id기반으로 변경
- Resume에서 파일, 스킬 삭제, 수정 등을 통해 실제 동작 확인

## 🔗 Issue

- Closes: #5 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?