### PR TITLE
[Feat] AI 브리프 생성 기능 구현

### DIFF
--- a/src/main/java/com/generic4/itda/config/ai/AiBriefProperties.java
+++ b/src/main/java/com/generic4/itda/config/ai/AiBriefProperties.java
@@ -1,0 +1,23 @@
+package com.generic4.itda.config.ai;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ai.brief")
+public class AiBriefProperties {
+
+    private boolean enabled = false;
+
+    private String apiUrl = "https://api.openai.com/v1/responses";
+
+    private String apiKey;
+
+    private String model = "gpt-4.1-mini";
+
+    private Integer maxOutputTokens = 2_000;
+}

--- a/src/main/java/com/generic4/itda/controller/ProposalAiBriefController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalAiBriefController.java
@@ -1,8 +1,10 @@
 package com.generic4.itda.controller;
 
 import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.ProposalAiBriefService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +18,8 @@ public class ProposalAiBriefController {
     private final ProposalAiBriefService proposalAiBriefService;
 
     @PostMapping("/{proposalId}/ai-brief")
-    public AiBriefResult generate(@PathVariable Long proposalId) {
-        return proposalAiBriefService.generate(proposalId);
+    public AiBriefResult generate(@AuthenticationPrincipal ItDaPrincipal itDaPrincipal,
+            @PathVariable Long proposalId) {
+        return proposalAiBriefService.generate(proposalId, itDaPrincipal.getEmail());
     }
 }

--- a/src/main/java/com/generic4/itda/controller/ProposalAiBriefController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalAiBriefController.java
@@ -1,0 +1,22 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.service.ProposalAiBriefService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/proposals")
+public class ProposalAiBriefController {
+
+    private final ProposalAiBriefService proposalAiBriefService;
+
+    @PostMapping("/{proposalId}/ai-brief")
+    public AiBriefResult generate(@PathVariable Long proposalId) {
+        return proposalAiBriefService.generate(proposalId);
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefGenerateRequest.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefGenerateRequest.java
@@ -1,0 +1,24 @@
+package com.generic4.itda.dto.proposal;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+@Getter
+public class AiBriefGenerateRequest {
+
+    private final String rawInputText;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiBriefGenerateRequest(String rawInputText) {
+        Assert.hasText(rawInputText, "AI 브리프 원본 입력은 필수값입니다.");
+        this.rawInputText = rawInputText;
+    }
+
+    public static AiBriefGenerateRequest from(String rawInputText) {
+        return AiBriefGenerateRequest.builder()
+                .rawInputText(rawInputText)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
@@ -1,0 +1,39 @@
+package com.generic4.itda.dto.proposal;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+@Getter
+public class AiBriefPositionResult {
+
+    private final String positionName;
+    private final Long headCount;
+    private final Long unitBudgetMin;
+    private final Long unitBudgetMax;
+    private final List<AiBriefSkillResult> skills;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiBriefPositionResult(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
+            List<AiBriefSkillResult> skills) {
+        Assert.hasText(positionName, "AI 브리프 직무명은 필수값입니다.");
+        this.positionName = positionName.trim();
+        this.headCount = headCount;
+        this.unitBudgetMin = unitBudgetMin;
+        this.unitBudgetMax = unitBudgetMax;
+        this.skills = skills == null ? List.of() : List.copyOf(skills);
+    }
+
+    public static AiBriefPositionResult of(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
+            List<AiBriefSkillResult> skills) {
+        return AiBriefPositionResult.builder()
+                .positionName(positionName)
+                .headCount(headCount)
+                .unitBudgetMin(unitBudgetMin)
+                .unitBudgetMax(unitBudgetMax)
+                .skills(skills)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
@@ -1,0 +1,49 @@
+package com.generic4.itda.dto.proposal;
+
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AiBriefResult {
+
+    private final String title;
+    private final String description;
+    private final Long totalBudgetMin;
+    private final Long totalBudgetMax;
+    private final ProposalWorkType workType;
+    private final String workPlace;
+    private final Long expectedPeriod;
+    private final List<AiBriefPositionResult> positions;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiBriefResult(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
+            ProposalWorkType workType, String workPlace, Long expectedPeriod,
+            List<AiBriefPositionResult> positions) {
+        this.title = title;
+        this.description = description;
+        this.totalBudgetMin = totalBudgetMin;
+        this.totalBudgetMax = totalBudgetMax;
+        this.workType = workType;
+        this.workPlace = workPlace;
+        this.expectedPeriod = expectedPeriod;
+        this.positions = positions == null ? List.of() : List.copyOf(positions);
+    }
+
+    public static AiBriefResult of(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
+            ProposalWorkType workType, String workPlace, Long expectedPeriod,
+            List<AiBriefPositionResult> positions) {
+        return AiBriefResult.builder()
+                .title(title)
+                .description(description)
+                .totalBudgetMin(totalBudgetMin)
+                .totalBudgetMax(totalBudgetMax)
+                .workType(workType)
+                .workPlace(workPlace)
+                .expectedPeriod(expectedPeriod)
+                .positions(positions)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefSkillResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefSkillResult.java
@@ -1,0 +1,28 @@
+package com.generic4.itda.dto.proposal;
+
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+@Getter
+public class AiBriefSkillResult {
+
+    private final String skillName;
+    private final ProposalPositionSkillImportance importance;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiBriefSkillResult(String skillName, ProposalPositionSkillImportance importance) {
+        Assert.hasText(skillName, "AI 브리프 스킬명은 필수값입니다.");
+        this.skillName = skillName.trim();
+        this.importance = importance;
+    }
+
+    public static AiBriefSkillResult of(String skillName, ProposalPositionSkillImportance importance) {
+        return AiBriefSkillResult.builder()
+                .skillName(skillName)
+                .importance(importance)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/exception/AiBriefGenerationException.java
+++ b/src/main/java/com/generic4/itda/exception/AiBriefGenerationException.java
@@ -1,0 +1,12 @@
+package com.generic4.itda.exception;
+
+public class AiBriefGenerationException extends IllegalStateException {
+
+    public AiBriefGenerationException(String message) {
+        super(message);
+    }
+
+    public AiBriefGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/generic4/itda/exception/ProposalNotFoundException.java
+++ b/src/main/java/com/generic4/itda/exception/ProposalNotFoundException.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.exception;
+
+public class ProposalNotFoundException extends IllegalArgumentException {
+
+    public ProposalNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/PositionRepository.java
+++ b/src/main/java/com/generic4/itda/repository/PositionRepository.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.domain.position.Position;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PositionRepository extends JpaRepository<Position, Long> {
+
+    Optional<Position> findByName(String name);
+}

--- a/src/main/java/com/generic4/itda/repository/SkillRepository.java
+++ b/src/main/java/com/generic4/itda/repository/SkillRepository.java
@@ -1,14 +1,10 @@
 package com.generic4.itda.repository;
 
-
 import com.generic4.itda.domain.skill.Skill;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SkillRepository extends JpaRepository<Skill, Long> {
 
-    // 나중에 스킬명 검색이 필요해지면 이름 기준 조회 메서드 추가 검토
-//    Optional<Skill> findByName(String name);
-//    boolean existsByName(String Name);
+    Optional<Skill> findByName(String name);
 }

--- a/src/main/java/com/generic4/itda/service/AiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefGenerator.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+
+public interface AiBriefGenerator {
+
+    AiBriefResult generate(AiBriefGenerateRequest request);
+}

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -1,0 +1,85 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.proposal.AiBriefPositionResult;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.SkillRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class AiBriefProposalMapper {
+
+    private final PositionRepository positionRepository;
+    private final SkillRepository skillRepository;
+
+    public void apply(Proposal proposal, AiBriefResult aiBriefResult) {
+        Assert.notNull(proposal, "제안서는 필수값입니다.");
+        Assert.notNull(aiBriefResult, "AI 브리프 결과는 필수값입니다.");
+
+        proposal.update(
+                resolveTitle(proposal, aiBriefResult),
+                proposal.getRawInputText(),
+                aiBriefResult.getDescription(),
+                aiBriefResult.getTotalBudgetMin(),
+                aiBriefResult.getTotalBudgetMax(),
+                aiBriefResult.getWorkType(),
+                aiBriefResult.getWorkPlace(),
+                aiBriefResult.getExpectedPeriod()
+        );
+
+        replacePositions(proposal, aiBriefResult.getPositions());
+    }
+
+    private void replacePositions(Proposal proposal, List<AiBriefPositionResult> positions) {
+        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
+        for (ProposalPosition existingPosition : existingPositions) {
+            proposal.removePosition(existingPosition);
+        }
+
+        for (AiBriefPositionResult positionResult : positions) {
+            Position position = findOrCreatePosition(positionResult.getPositionName());
+            ProposalPosition proposalPosition = proposal.addPosition(
+                    position,
+                    positionResult.getHeadCount(),
+                    positionResult.getUnitBudgetMin(),
+                    positionResult.getUnitBudgetMax()
+            );
+            addSkills(proposalPosition, positionResult.getSkills());
+        }
+    }
+
+    private void addSkills(ProposalPosition proposalPosition, List<AiBriefSkillResult> skills) {
+        for (AiBriefSkillResult skillResult : skills) {
+            Skill skill = findOrCreateSkill(skillResult.getSkillName());
+            proposalPosition.addSkill(skill, skillResult.getImportance());
+        }
+    }
+
+    private Position findOrCreatePosition(String positionName) {
+        return positionRepository.findByName(positionName)
+                .orElseGet(() -> positionRepository.save(Position.create(positionName)));
+    }
+
+    private Skill findOrCreateSkill(String skillName) {
+        return skillRepository.findByName(skillName)
+                .orElseGet(() -> skillRepository.save(Skill.create(skillName, null)));
+    }
+
+    private String resolveTitle(Proposal proposal, AiBriefResult aiBriefResult) {
+        if (StringUtils.hasText(aiBriefResult.getTitle())) {
+            return aiBriefResult.getTitle();
+        }
+        return proposal.getTitle();
+    }
+}

--- a/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
@@ -1,0 +1,15 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DisabledAiBriefGenerator implements AiBriefGenerator {
+
+    @Override
+    public AiBriefResult generate(AiBriefGenerateRequest request) {
+        throw new AiBriefGenerationException("AI 브리프 생성 어댑터가 등록되지 않았습니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
@@ -3,11 +3,11 @@ package com.generic4.itda.service;
 import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.exception.AiBriefGenerationException;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnMissingBean(AiBriefGenerator.class)
+@ConditionalOnProperty(prefix = "ai.brief", name = "enabled", havingValue = "false", matchIfMissing = true)
 public class DisabledAiBriefGenerator implements AiBriefGenerator {
 
     @Override

--- a/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/DisabledAiBriefGenerator.java
@@ -3,9 +3,11 @@ package com.generic4.itda.service;
 import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.exception.AiBriefGenerationException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnMissingBean(AiBriefGenerator.class)
 public class DisabledAiBriefGenerator implements AiBriefGenerator {
 
     @Override

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -38,7 +38,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - 근거가 부족한 값은 추측하지 말고 필드를 생략한다.
             - workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
             - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
-            - expectedPeriod는 개월 수 기준 정수로 반환한다.
+            - expectedPeriod는 주 단위 기준 정수로 반환한다.
             - positions는 직무명별로 나누고 같은 직무를 중복 생성하지 않는다.
             - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
             - importance를 확신할 수 없으면 PREFERENCE를 사용한다.

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -1,0 +1,320 @@
+package com.generic4.itda.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.AiBriefProperties;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefPositionResult;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@ConditionalOnProperty(prefix = "ai.brief", name = "enabled", havingValue = "true")
+public class OpenAiAiBriefGenerator implements AiBriefGenerator {
+
+    private static final String BRIEF_GENERATION_INSTRUCTIONS = """
+            당신은 IT 외주/프로젝트 제안서를 구조화하는 도우미다.
+            사용자의 자유 입력을 읽고 현재 시스템에서 바로 저장 가능한 제안서 초안 JSON으로 변환한다.
+
+            규칙:
+            - 반드시 JSON만 반환한다.
+            - title, description은 한국어로 자연스럽게 작성한다.
+            - 근거가 부족한 값은 추측하지 말고 필드를 생략한다.
+            - workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
+            - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
+            - expectedPeriod는 개월 수 기준 정수로 반환한다.
+            - positions는 직무명별로 나누고 같은 직무를 중복 생성하지 않는다.
+            - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
+            - importance를 확신할 수 없으면 PREFERENCE를 사용한다.
+            - skillName, positionName은 짧고 일반적인 명칭으로 정리한다.
+            """;
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final AiBriefProperties properties;
+
+    public OpenAiAiBriefGenerator(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+            AiBriefProperties properties) {
+        Assert.hasText(properties.getApiKey(), "AI 브리프 API 키는 필수값입니다.");
+
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    @Override
+    public AiBriefResult generate(AiBriefGenerateRequest request) {
+        Assert.notNull(request, "AI 브리프 요청은 필수값입니다.");
+
+        try {
+            JsonNode responseBody = restClient.post()
+                    .uri(properties.getApiUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .headers(headers -> headers.setBearerAuth(properties.getApiKey()))
+                    .body(buildRequestBody(request))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            String responseText = extractResponseText(responseBody);
+            return toAiBriefResult(responseText);
+        } catch (AiBriefGenerationException exception) {
+            throw exception;
+        } catch (RestClientException exception) {
+            throw new AiBriefGenerationException("OpenAI AI 브리프 호출에 실패했습니다.", exception);
+        } catch (JsonProcessingException exception) {
+            throw new AiBriefGenerationException("AI 브리프 응답 파싱에 실패했습니다.", exception);
+        } catch (RuntimeException exception) {
+            throw new AiBriefGenerationException("AI 브리프 생성에 실패했습니다.", exception);
+        }
+    }
+
+    private Map<String, Object> buildRequestBody(AiBriefGenerateRequest request) {
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("model", properties.getModel());
+        requestBody.put("instructions", BRIEF_GENERATION_INSTRUCTIONS);
+        requestBody.put("input", request.getRawInputText());
+        requestBody.put("max_output_tokens", properties.getMaxOutputTokens());
+
+        Map<String, Object> text = new LinkedHashMap<>();
+        text.put("format", buildJsonSchemaFormat());
+        requestBody.put("text", text);
+
+        return requestBody;
+    }
+
+    private Map<String, Object> buildJsonSchemaFormat() {
+        Map<String, Object> format = new LinkedHashMap<>();
+        format.put("type", "json_schema");
+        format.put("name", "proposal_ai_brief");
+        format.put("strict", true);
+        format.put("schema", buildSchema());
+        return format;
+    }
+
+    private Map<String, Object> buildSchema() {
+        Map<String, Object> schema = objectSchema();
+
+        schema.put("properties", Map.of(
+                "title", Map.of("type", "string"),
+                "description", Map.of("type", "string"),
+                "totalBudgetMin", Map.of("type", "integer"),
+                "totalBudgetMax", Map.of("type", "integer"),
+                "workType", Map.of(
+                        "type", "string",
+                        "enum", List.of("SITE", "REMOTE", "HYBRID")
+                ),
+                "workPlace", Map.of("type", "string"),
+                "expectedPeriod", Map.of("type", "integer"),
+                "positions", Map.of(
+                        "type", "array",
+                        "items", buildPositionSchema()
+                )
+        ));
+
+        return schema;
+    }
+
+    private Map<String, Object> buildPositionSchema() {
+        Map<String, Object> schema = objectSchema();
+        schema.put("required", List.of("positionName", "skills"));
+        schema.put("properties", Map.of(
+                "positionName", Map.of("type", "string"),
+                "headCount", Map.of("type", "integer"),
+                "unitBudgetMin", Map.of("type", "integer"),
+                "unitBudgetMax", Map.of("type", "integer"),
+                "skills", Map.of(
+                        "type", "array",
+                        "items", buildSkillSchema()
+                )
+        ));
+        return schema;
+    }
+
+    private Map<String, Object> buildSkillSchema() {
+        Map<String, Object> schema = objectSchema();
+        schema.put("required", List.of("skillName"));
+        schema.put("properties", Map.of(
+                "skillName", Map.of("type", "string"),
+                "importance", Map.of(
+                        "type", "string",
+                        "enum", List.of("ESSENTIAL", "PREFERENCE")
+                )
+        ));
+        return schema;
+    }
+
+    private Map<String, Object> objectSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+        return schema;
+    }
+
+    private String extractResponseText(JsonNode responseBody) {
+        if (responseBody == null || responseBody.isNull()) {
+            throw new AiBriefGenerationException("AI 브리프 응답이 비어 있습니다.");
+        }
+
+        String directOutput = readText(responseBody.get("output_text"));
+        if (StringUtils.hasText(directOutput)) {
+            return directOutput;
+        }
+
+        String refusalMessage = null;
+        JsonNode output = responseBody.get("output");
+        if (output != null && output.isArray()) {
+            for (JsonNode item : output) {
+                JsonNode content = item.get("content");
+                if (content == null || !content.isArray()) {
+                    continue;
+                }
+                for (JsonNode contentItem : content) {
+                    String text = readText(contentItem.get("text"));
+                    if (StringUtils.hasText(text)) {
+                        return text;
+                    }
+                    String refusal = readText(contentItem.get("refusal"));
+                    if (StringUtils.hasText(refusal)) {
+                        refusalMessage = refusal;
+                    }
+                }
+            }
+        }
+
+        if (StringUtils.hasText(refusalMessage)) {
+            throw new AiBriefGenerationException("AI 브리프 생성을 거부했습니다. " + refusalMessage);
+        }
+        throw new AiBriefGenerationException("AI 브리프 응답에서 본문을 찾을 수 없습니다.");
+    }
+
+    private String readText(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        JsonNode valueNode = node.get("value");
+        if (valueNode != null && valueNode.isTextual()) {
+            return valueNode.asText();
+        }
+        return null;
+    }
+
+    private AiBriefResult toAiBriefResult(String responseText) throws JsonProcessingException {
+        JsonNode root = objectMapper.readTree(responseText);
+
+        return AiBriefResult.of(
+                normalizeText(root.get("title")),
+                normalizeText(root.get("description")),
+                asLong(root.get("totalBudgetMin")),
+                asLong(root.get("totalBudgetMax")),
+                parseWorkType(root.get("workType")),
+                normalizeText(root.get("workPlace")),
+                asLong(root.get("expectedPeriod")),
+                parsePositions(root.get("positions"))
+        );
+    }
+
+    private List<AiBriefPositionResult> parsePositions(JsonNode positionsNode) {
+        if (positionsNode == null || positionsNode.isNull() || !positionsNode.isArray()) {
+            return List.of();
+        }
+
+        List<AiBriefPositionResult> positions = new ArrayList<>();
+        for (JsonNode positionNode : positionsNode) {
+            positions.add(AiBriefPositionResult.of(
+                    normalizeRequiredText(positionNode.get("positionName"), "AI 브리프 직무명은 필수값입니다."),
+                    asLong(positionNode.get("headCount")),
+                    asLong(positionNode.get("unitBudgetMin")),
+                    asLong(positionNode.get("unitBudgetMax")),
+                    parseSkills(positionNode.get("skills"))
+            ));
+        }
+        return positions;
+    }
+
+    private List<AiBriefSkillResult> parseSkills(JsonNode skillsNode) {
+        if (skillsNode == null || skillsNode.isNull() || !skillsNode.isArray()) {
+            return List.of();
+        }
+
+        List<AiBriefSkillResult> skills = new ArrayList<>();
+        for (JsonNode skillNode : skillsNode) {
+            skills.add(AiBriefSkillResult.of(
+                    normalizeRequiredText(skillNode.get("skillName"), "AI 브리프 스킬명은 필수값입니다."),
+                    parseImportance(skillNode.get("importance"))
+            ));
+        }
+        return skills;
+    }
+
+    private ProposalWorkType parseWorkType(JsonNode node) {
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return ProposalWorkType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new AiBriefGenerationException("지원하지 않는 근무 형태입니다. value=" + value, exception);
+        }
+    }
+
+    private ProposalPositionSkillImportance parseImportance(JsonNode node) {
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return ProposalPositionSkillImportance.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new AiBriefGenerationException("지원하지 않는 스킬 중요도입니다. value=" + value, exception);
+        }
+    }
+
+    private Long asLong(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isIntegralNumber()) {
+            return node.longValue();
+        }
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException exception) {
+            throw new AiBriefGenerationException("숫자 필드 파싱에 실패했습니다. value=" + value, exception);
+        }
+    }
+
+    private String normalizeRequiredText(JsonNode node, String message) {
+        String value = normalizeText(node);
+        Assert.hasText(value, message);
+        return value;
+    }
+
+    private String normalizeText(JsonNode node) {
+        String value = readText(node);
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
@@ -1,0 +1,47 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProposalAiBriefService {
+
+    private final ProposalRepository proposalRepository;
+    private final AiBriefGenerator aiBriefGenerator;
+    private final AiBriefProposalMapper aiBriefProposalMapper;
+
+    public AiBriefResult generate(Long proposalId) {
+        Assert.notNull(proposalId, "제안서 id는 필수값입니다.");
+
+        Proposal proposal = proposalRepository.findById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+
+        Assert.state(proposal.getStatus() == ProposalStatus.WRITING,
+                "작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
+
+        AiBriefResult aiBriefResult = generateAiBrief(proposal.getRawInputText());
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+        return aiBriefResult;
+    }
+
+    private AiBriefResult generateAiBrief(String rawInputText) {
+        try {
+            return aiBriefGenerator.generate(AiBriefGenerateRequest.from(rawInputText));
+        } catch (AiBriefGenerationException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw new AiBriefGenerationException("AI 브리프 생성에 실패했습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
@@ -8,6 +8,7 @@ import com.generic4.itda.exception.AiBriefGenerationException;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.ProposalRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -21,12 +22,14 @@ public class ProposalAiBriefService {
     private final AiBriefGenerator aiBriefGenerator;
     private final AiBriefProposalMapper aiBriefProposalMapper;
 
-    public AiBriefResult generate(Long proposalId) {
+    public AiBriefResult generate(Long proposalId, String memberEmail) {
         Assert.notNull(proposalId, "제안서 id는 필수값입니다.");
+        Assert.hasText(memberEmail, "회원 이메일은 필수값입니다.");
 
         Proposal proposal = proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
 
+        validateOwnership(proposal, memberEmail);
         Assert.state(proposal.getStatus() == ProposalStatus.WRITING,
                 "작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
 
@@ -42,6 +45,12 @@ public class ProposalAiBriefService {
             throw exception;
         } catch (RuntimeException exception) {
             throw new AiBriefGenerationException("AI 브리프 생성에 실패했습니다.", exception);
+        }
+    }
+
+    private void validateOwnership(Proposal proposal, String memberEmail) {
+        if (!proposal.getMember().getEmail().getValue().equals(memberEmail)) {
+            throw new AccessDeniedException("본인 제안서에 대해서만 AI 브리프를 생성할 수 있습니다.");
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,3 +32,11 @@ file:
     profile-image-dir: profile
     proposal-dir: proposal
     resume-dir: resume
+
+ai:
+  brief:
+    enabled: ${AI_BRIEF_ENABLED:false}
+    api-url: ${AI_BRIEF_API_URL:https://api.openai.com/v1/responses}
+    api-key: ${AI_BRIEF_API_KEY:}
+    model: ${AI_BRIEF_MODEL:gpt-4.1-mini}
+    max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:2000}

--- a/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
@@ -1,9 +1,10 @@
 package com.generic4.itda.controller;
 
+import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -15,6 +16,7 @@ import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.AiBriefPositionResult;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.ProposalAiBriefService;
 import java.util.List;
@@ -22,6 +24,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -40,6 +44,9 @@ class ProposalAiBriefControllerTest {
     @Test
     @DisplayName("인증된 사용자가 AI 브리프 생성을 요청하면 JSON 결과를 반환한다")
     void generateAiBrief() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678")
+        );
         AiBriefResult result = AiBriefResult.of(
                 "AI가 만든 제목",
                 "AI가 만든 설명",
@@ -62,10 +69,14 @@ class ProposalAiBriefControllerTest {
                         )
                 )
         );
-        given(proposalAiBriefService.generate(1L)).willReturn(result);
+        given(proposalAiBriefService.generate(1L, "user@example.com")).willReturn(result);
 
         mockMvc.perform(post("/proposals/{proposalId}/ai-brief", 1L)
-                        .with(user("user@example.com").roles("USER"))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -76,7 +87,7 @@ class ProposalAiBriefControllerTest {
                 .andExpect(jsonPath("$.positions[0].skills[0].skillName").value("Java"))
                 .andExpect(jsonPath("$.positions[0].skills[0].importance").value("ESSENTIAL"));
 
-        then(proposalAiBriefService).should().generate(1L);
+        then(proposalAiBriefService).should().generate(1L, "user@example.com");
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
@@ -1,0 +1,91 @@
+package com.generic4.itda.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiBriefPositionResult;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.ProposalAiBriefService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(ProposalAiBriefController.class)
+class ProposalAiBriefControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProposalAiBriefService proposalAiBriefService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("인증된 사용자가 AI 브리프 생성을 요청하면 JSON 결과를 반환한다")
+    void generateAiBrief() throws Exception {
+        AiBriefResult result = AiBriefResult.of(
+                "AI가 만든 제목",
+                "AI가 만든 설명",
+                3_000_000L,
+                5_000_000L,
+                ProposalWorkType.HYBRID,
+                "판교",
+                6L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                1L,
+                                3_000_000L,
+                                4_000_000L,
+                                List.of(
+                                        AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL),
+                                        AiBriefSkillResult.of("Spring Boot",
+                                                ProposalPositionSkillImportance.PREFERENCE)
+                                )
+                        )
+                )
+        );
+        given(proposalAiBriefService.generate(1L)).willReturn(result);
+
+        mockMvc.perform(post("/proposals/{proposalId}/ai-brief", 1L)
+                        .with(user("user@example.com").roles("USER"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("AI가 만든 제목"))
+                .andExpect(jsonPath("$.description").value("AI가 만든 설명"))
+                .andExpect(jsonPath("$.workType").value("HYBRID"))
+                .andExpect(jsonPath("$.positions[0].positionName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].skills[0].skillName").value("Java"))
+                .andExpect(jsonPath("$.positions[0].skills[0].importance").value("ESSENTIAL"));
+
+        then(proposalAiBriefService).should().generate(1L);
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 로그인 페이지로 리다이렉트된다")
+    void redirectToLoginWhenUnauthenticated() throws Exception {
+        mockMvc.perform(post("/proposals/{proposalId}/ai-brief", 1L)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
@@ -1,0 +1,102 @@
+package com.generic4.itda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.AiBriefProperties;
+import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.SkillRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.client.RestClient;
+
+class AiBriefGeneratorConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    @DisplayName("AI 브리프가 비활성화되면 fallback 생성기가 등록되고 서비스가 정상 생성된다")
+    void registerDisabledGeneratorWhenAiBriefIsDisabled() {
+        contextRunner
+                .withPropertyValues("ai.brief.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AiBriefGenerator.class);
+                    assertThat(context).hasSingleBean(DisabledAiBriefGenerator.class);
+                    assertThat(context).doesNotHaveBean(OpenAiAiBriefGenerator.class);
+                    assertThat(context).hasSingleBean(ProposalAiBriefService.class);
+                });
+    }
+
+    @Test
+    @DisplayName("AI 브리프가 활성화되고 API 키가 있으면 OpenAI 생성기가 등록된다")
+    void registerOpenAiGeneratorWhenAiBriefIsEnabled() {
+        contextRunner
+                .withPropertyValues(
+                        "ai.brief.enabled=true",
+                        "ai.brief.api-key=test-api-key",
+                        "ai.brief.model=gpt-4.1-mini"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AiBriefGenerator.class);
+                    assertThat(context).hasSingleBean(OpenAiAiBriefGenerator.class);
+                    assertThat(context).doesNotHaveBean(DisabledAiBriefGenerator.class);
+                    assertThat(context).hasSingleBean(ProposalAiBriefService.class);
+                });
+    }
+
+    @Test
+    @DisplayName("AI 브리프가 활성화되었는데 API 키가 없으면 컨텍스트 생성에 실패한다")
+    void failWhenApiKeyIsMissingInEnabledMode() {
+        contextRunner
+                .withPropertyValues("ai.brief.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseMessage("AI 브리프 API 키는 필수값입니다.");
+                });
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(AiBriefProperties.class)
+    @Import({
+            DisabledAiBriefGenerator.class,
+            OpenAiAiBriefGenerator.class,
+            AiBriefProposalMapper.class,
+            ProposalAiBriefService.class
+    })
+    static class TestConfig {
+
+        @Bean
+        RestClient.Builder restClientBuilder() {
+            return RestClient.builder();
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        ProposalRepository proposalRepository() {
+            return mock(ProposalRepository.class);
+        }
+
+        @Bean
+        PositionRepository positionRepository() {
+            return mock(PositionRepository.class);
+        }
+
+        @Bean
+        SkillRepository skillRepository() {
+            return mock(SkillRepository.class);
+        }
+    }
+}

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -1,0 +1,168 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.proposal.AiBriefPositionResult;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.SkillRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiBriefProposalMapperTest {
+
+    @Mock
+    private PositionRepository positionRepository;
+
+    @Mock
+    private SkillRepository skillRepository;
+
+    @InjectMocks
+    private AiBriefProposalMapper aiBriefProposalMapper;
+
+    @Test
+    @DisplayName("AI 브리프를 적용하면 제안서 기본 정보가 바뀌고 기존 모집 단위는 새 결과로 교체된다")
+    void apply_updatesProposalFieldsAndReplacesPositions() {
+        Proposal proposal = createProposal();
+        Position oldPosition = Position.create("디자이너");
+        Skill oldSkill = Skill.create("Figma", null);
+        ProposalPosition oldProposalPosition = proposal.addPosition(oldPosition, 1L, 1_000_000L, 2_000_000L);
+        oldProposalPosition.addSkill(oldSkill, ProposalPositionSkillImportance.ESSENTIAL);
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.empty());
+        given(positionRepository.save(any(Position.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(skillRepository.findByName("Java")).willReturn(Optional.empty());
+        given(skillRepository.save(any(Skill.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "AI가 정리한 제목",
+                "AI가 정리한 설명",
+                5_000_000L,
+                8_000_000L,
+                ProposalWorkType.HYBRID,
+                "판교",
+                12L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                2L,
+                                3_000_000L,
+                                4_000_000L,
+                                List.of(AiBriefSkillResult.of("Java", null))
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getTitle()).isEqualTo("AI가 정리한 제목");
+        assertThat(proposal.getDescription()).isEqualTo("AI가 정리한 설명");
+        assertThat(proposal.getTotalBudgetMin()).isEqualTo(5_000_000L);
+        assertThat(proposal.getTotalBudgetMax()).isEqualTo(8_000_000L);
+        assertThat(proposal.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposal.getWorkPlace()).isEqualTo("판교");
+        assertThat(proposal.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(proposal.getPositions()).hasSize(1);
+        assertThat(proposal.getPositions().get(0).getPosition().getName()).isEqualTo("백엔드 개발자");
+        assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
+        assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill().getName()).isEqualTo("Java");
+        assertThat(proposal.getPositions().get(0).getSkills().get(0).getImportance())
+                .isEqualTo(ProposalPositionSkillImportance.PREFERENCE);
+    }
+
+    @Test
+    @DisplayName("AI 브리프 제목이 비어 있으면 기존 제안서 제목을 유지한다")
+    void apply_keepsExistingTitleWhenAiTitleIsBlank() {
+        Proposal proposal = createProposal();
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                " ",
+                "설명만 갱신",
+                null,
+                null,
+                ProposalWorkType.REMOTE,
+                "강남",
+                8L,
+                List.of()
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getTitle()).isEqualTo("제안서 제목");
+        assertThat(proposal.getDescription()).isEqualTo("설명만 갱신");
+        assertThat(proposal.getWorkType()).isEqualTo(ProposalWorkType.REMOTE);
+        assertThat(proposal.getWorkPlace()).isEqualTo("강남");
+        assertThat(proposal.getExpectedPeriod()).isEqualTo(8L);
+    }
+
+    @Test
+    @DisplayName("동일 이름의 직무와 스킬이 이미 있으면 기존 마스터를 재사용한다")
+    void apply_reusesExistingPositionAndSkillWhenFoundByName() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+        Skill java = Skill.create("Java", null);
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(skillRepository.findByName("Java")).willReturn(Optional.of(java));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                1L,
+                                null,
+                                null,
+                                List.of(AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL))
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getPositions()).hasSize(1);
+        assertThat(proposal.getPositions().get(0).getPosition()).isSameAs(backend);
+        assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
+        assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill()).isSameAs(java);
+        then(positionRepository).should(never()).save(any(Position.class));
+        then(skillRepository).should(never()).save(any(Skill.class));
+    }
+
+    private Proposal createProposal() {
+        return Proposal.create(
+                createMember(),
+                "제안서 제목",
+                "원본 입력",
+                "기존 설명",
+                1_000_000L,
+                2_000_000L,
+                ProposalWorkType.SITE,
+                "서울",
+                3L
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.service;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -91,6 +92,7 @@ class OpenAiAiBriefGeneratorTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.model").value("gpt-4.1-mini"))
                 .andExpect(jsonPath("$.input").value("프로젝트 원본 입력"))
+                .andExpect(jsonPath("$.instructions").value(containsString("expectedPeriod는 주 단위 기준 정수로 반환한다.")))
                 .andExpect(jsonPath("$.text.format.type").value("json_schema"))
                 .andRespond(withSuccess(
                         objectMapper.writeValueAsString(Map.of("output_text", briefJson)),

--- a/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
@@ -1,0 +1,165 @@
+package com.generic4.itda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.AiBriefProperties;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class OpenAiAiBriefGeneratorTest {
+
+    private static final String API_URL = "https://api.openai.com/v1/responses";
+    private static final String API_KEY = "test-api-key";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer server;
+
+    private OpenAiAiBriefGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        AiBriefProperties properties = new AiBriefProperties();
+        properties.setEnabled(true);
+        properties.setApiUrl(API_URL);
+        properties.setApiKey(API_KEY);
+        properties.setModel("gpt-4.1-mini");
+        properties.setMaxOutputTokens(2000);
+
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        generator = new OpenAiAiBriefGenerator(builder, objectMapper, properties);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("정상 응답이면 AI 브리프 결과를 Proposal 저장 구조로 파싱한다")
+    void generate_parsesAiBriefResult() throws JsonProcessingException {
+        String briefJson = objectMapper.writeValueAsString(Map.of(
+                "title", "AI가 정리한 프로젝트 제목",
+                "description", "백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.",
+                "totalBudgetMin", 5000000,
+                "totalBudgetMax", 8000000,
+                "workType", "HYBRID",
+                "workPlace", "판교",
+                "expectedPeriod", 6,
+                "positions", List.of(
+                        Map.of(
+                                "positionName", "백엔드 개발자",
+                                "headCount", 1,
+                                "unitBudgetMin", 3000000,
+                                "unitBudgetMax", 4000000,
+                                "skills", List.of(
+                                        Map.of("skillName", "Java", "importance", "ESSENTIAL"),
+                                        Map.of("skillName", "Spring Boot", "importance", "PREFERENCE")
+                                )
+                        )
+                )
+        ));
+
+        server.expect(requestTo(API_URL))
+                .andExpect(method(POST))
+                .andExpect(header(AUTHORIZATION, "Bearer " + API_KEY))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.model").value("gpt-4.1-mini"))
+                .andExpect(jsonPath("$.input").value("프로젝트 원본 입력"))
+                .andExpect(jsonPath("$.text.format.type").value("json_schema"))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(Map.of("output_text", briefJson)),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        AiBriefResult result = generator.generate(AiBriefGenerateRequest.from("프로젝트 원본 입력"));
+
+        assertThat(result.getTitle()).isEqualTo("AI가 정리한 프로젝트 제목");
+        assertThat(result.getDescription()).isEqualTo("백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.");
+        assertThat(result.getTotalBudgetMin()).isEqualTo(5_000_000L);
+        assertThat(result.getTotalBudgetMax()).isEqualTo(8_000_000L);
+        assertThat(result.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(result.getWorkPlace()).isEqualTo("판교");
+        assertThat(result.getExpectedPeriod()).isEqualTo(6L);
+        assertThat(result.getPositions()).hasSize(1);
+        assertThat(result.getPositions().get(0).getPositionName()).isEqualTo("백엔드 개발자");
+        assertThat(result.getPositions().get(0).getSkills()).hasSize(2);
+        assertThat(result.getPositions().get(0).getSkills().get(0).getSkillName()).isEqualTo("Java");
+        assertThat(result.getPositions().get(0).getSkills().get(0).getImportance())
+                .isEqualTo(ProposalPositionSkillImportance.ESSENTIAL);
+    }
+
+    @Test
+    @DisplayName("응답 본문이 없으면 AI 브리프 생성 예외가 발생한다")
+    void failWhenResponseHasNoTextBody() throws JsonProcessingException {
+        server.expect(requestTo(API_URL))
+                .andExpect(method(POST))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(Map.of("output", List.of())),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        assertThatThrownBy(() -> generator.generate(AiBriefGenerateRequest.from("원본 입력")))
+                .isInstanceOf(AiBriefGenerationException.class)
+                .hasMessage("AI 브리프 응답에서 본문을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 근무 형태가 오면 파싱에 실패한다")
+    void failWhenWorkTypeIsUnsupported() throws JsonProcessingException {
+        String briefJson = objectMapper.writeValueAsString(Map.of(
+                "title", "제목",
+                "description", "설명",
+                "workType", "OFFICE",
+                "positions", List.of()
+        ));
+
+        server.expect(requestTo(API_URL))
+                .andExpect(method(POST))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(Map.of("output_text", briefJson)),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        assertThatThrownBy(() -> generator.generate(AiBriefGenerateRequest.from("원본 입력")))
+                .isInstanceOf(AiBriefGenerationException.class)
+                .hasMessage("지원하지 않는 근무 형태입니다. value=OFFICE");
+    }
+
+    @Test
+    @DisplayName("OpenAI 호출이 실패하면 AI 브리프 생성 예외로 감싼다")
+    void failWhenOpenAiCallFails() {
+        server.expect(requestTo(API_URL))
+                .andExpect(method(POST))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> generator.generate(AiBriefGenerateRequest.from("원본 입력")))
+                .isInstanceOf(AiBriefGenerationException.class)
+                .hasMessage("OpenAI AI 브리프 호출에 실패했습니다.");
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
@@ -1,0 +1,133 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProposalAiBriefServiceTest {
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
+    private AiBriefGenerator aiBriefGenerator;
+
+    @Mock
+    private AiBriefProposalMapper aiBriefProposalMapper;
+
+    @InjectMocks
+    private ProposalAiBriefService proposalAiBriefService;
+
+    @Captor
+    private ArgumentCaptor<AiBriefGenerateRequest> requestCaptor;
+
+    @Test
+    @DisplayName("작성 중인 제안서의 raw input text로 AI 브리프를 생성하고 결과를 반영한다")
+    void generateAiBriefAndApplyToProposal() {
+        Proposal proposal = createProposal("AI 브리프용 원본 입력");
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "AI가 만든 제목",
+                "AI가 만든 설명",
+                3_000_000L,
+                5_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                6L,
+                null
+        );
+
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class))).willReturn(aiBriefResult);
+
+        AiBriefResult result = proposalAiBriefService.generate(1L);
+
+        assertThat(result).isSameAs(aiBriefResult);
+        then(aiBriefGenerator).should().generate(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getRawInputText()).isEqualTo("AI 브리프용 원본 입력");
+        then(aiBriefProposalMapper).should().apply(proposal, aiBriefResult);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서이면 AI 브리프 생성을 중단한다")
+    void failWhenProposalDoesNotExist() {
+        given(proposalRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+                .isInstanceOf(ProposalNotFoundException.class)
+                .hasMessage("제안서를 찾을 수 없습니다. id=1");
+
+        then(aiBriefGenerator).should(never()).generate(any());
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    @Test
+    @DisplayName("작성 중이 아닌 제안서는 AI 브리프를 생성할 수 없다")
+    void failWhenProposalStatusIsNotWriting() {
+        Proposal proposal = createProposal("원본 입력");
+        proposal.startMatching();
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
+
+        then(aiBriefGenerator).should(never()).generate(any());
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    @Test
+    @DisplayName("AI 생성기가 예외를 던지면 Proposal 변경 없이 AiBriefGenerationException으로 감싼다")
+    void failWhenAiGeneratorThrowsException() {
+        Proposal proposal = createProposal("실패용 원본 입력");
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class)))
+                .willThrow(new RuntimeException("llm failure"));
+
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+                .isInstanceOf(AiBriefGenerationException.class)
+                .hasMessage("AI 브리프 생성에 실패했습니다.")
+                .cause()
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("llm failure");
+
+        assertThat(proposal.getTitle()).isEqualTo("제안서 제목");
+        assertThat(proposal.getDescription()).isEqualTo("제안서 본문");
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    private Proposal createProposal(String rawInputText) {
+        return Proposal.create(
+                createMember(),
+                "제안서 제목",
+                rawInputText,
+                "제안서 본문",
+                1_000_000L,
+                2_000_000L,
+                ProposalWorkType.SITE,
+                "서울",
+                3L
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
@@ -24,9 +24,12 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 
 @ExtendWith(MockitoExtension.class)
 class ProposalAiBriefServiceTest {
+
+    private static final String OWNER_EMAIL = "test@example.com";
 
     @Mock
     private ProposalRepository proposalRepository;
@@ -61,7 +64,7 @@ class ProposalAiBriefServiceTest {
         given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
         given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class))).willReturn(aiBriefResult);
 
-        AiBriefResult result = proposalAiBriefService.generate(1L);
+        AiBriefResult result = proposalAiBriefService.generate(1L, OWNER_EMAIL);
 
         assertThat(result).isSameAs(aiBriefResult);
         then(aiBriefGenerator).should().generate(requestCaptor.capture());
@@ -74,7 +77,7 @@ class ProposalAiBriefServiceTest {
     void failWhenProposalDoesNotExist() {
         given(proposalRepository.findById(1L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L, OWNER_EMAIL))
                 .isInstanceOf(ProposalNotFoundException.class)
                 .hasMessage("제안서를 찾을 수 없습니다. id=1");
 
@@ -89,7 +92,7 @@ class ProposalAiBriefServiceTest {
         proposal.startMatching();
         given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
 
-        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L, OWNER_EMAIL))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
 
@@ -105,7 +108,7 @@ class ProposalAiBriefServiceTest {
         given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class)))
                 .willThrow(new RuntimeException("llm failure"));
 
-        assertThatThrownBy(() -> proposalAiBriefService.generate(1L))
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L, OWNER_EMAIL))
                 .isInstanceOf(AiBriefGenerationException.class)
                 .hasMessage("AI 브리프 생성에 실패했습니다.")
                 .cause()
@@ -114,6 +117,20 @@ class ProposalAiBriefServiceTest {
 
         assertThat(proposal.getTitle()).isEqualTo("제안서 제목");
         assertThat(proposal.getDescription()).isEqualTo("제안서 본문");
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 AI 브리프 생성을 거부한다")
+    void failWhenProposalOwnerDoesNotMatch() {
+        Proposal proposal = createProposal("권한 확인용 원본 입력");
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalAiBriefService.generate(1L, "other@example.com"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("본인 제안서에 대해서만 AI 브리프를 생성할 수 있습니다.");
+
+        then(aiBriefGenerator).should(never()).generate(any());
         then(aiBriefProposalMapper).should(never()).apply(any(), any());
     }
 


### PR DESCRIPTION
## 🔎 What

- raw_input_text 기반 AI 브리프 생성 구조 설계
- AI 호출을 위한 인터페이스 정의 (Service 또는 Adapter)
- AI 브리프 응답 DTO 정의
- AI 브리프 생성 서비스 구현
- Proposal과 AI 브리프 결과 매핑 로직 구현
- 생성된 결과를 Proposal.description에 반영하는 로직 구현
- 예외 처리 및 실패 케이스 대응 (AI 호출 실패 등)
- 테스트 코드 작성 (mock 기반)

## 🔗 Issue

- Closes: #12 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?