### PR TITLE
[Feat] Resume 작성/수정 기능 노출

### DIFF
--- a/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
+++ b/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
@@ -1,0 +1,514 @@
+package com.generic4.itda.config;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkill;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.repository.SkillRepository;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+@Profile("!test")
+@Transactional
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.seed", name = "enabled", havingValue = "true")
+public class SeedDataInitializer implements ApplicationRunner {
+
+    private static final String SEED_CLIENT_EMAIL = "seed.client@itda.local";
+    private static final String SEED_BACKEND_EMAIL = "seed.backend@itda.local";
+    private static final String SEED_FULLSTACK_EMAIL = "seed.fullstack@itda.local";
+    private static final String SEED_AI_EMAIL = "seed.ai@itda.local";
+    private static final String SEED_HIDDEN_EMAIL = "seed.hidden@itda.local";
+
+    private static final String MATCHING_PROPOSAL_TITLE = "[SEED] AI 프리랜서 추천 플랫폼 고도화";
+    private static final String WRITING_PROPOSAL_TITLE = "[SEED] 관리자 대시보드 프론트 개편";
+
+    private final MemberRepository memberRepository;
+    private final PositionRepository positionRepository;
+    private final SkillRepository skillRepository;
+    private final ResumeRepository resumeRepository;
+    private final ProposalRepository proposalRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.seed.default-password:demo1234}")
+    private String defaultPassword;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, Position> positions = ensurePositions();
+        Map<String, Skill> skills = ensureSkills();
+
+        Member client = ensureMember(SEED_CLIENT_EMAIL, "시드 클라이언트", "추천 테스트용 발주자", "010-9000-1000");
+        Member backend = ensureMember(SEED_BACKEND_EMAIL, "김백엔드", "백엔드 시드", "010-9000-1001");
+        Member fullstack = ensureMember(SEED_FULLSTACK_EMAIL, "이풀스택", "풀스택 시드", "010-9000-1002");
+        Member aiEngineer = ensureMember(SEED_AI_EMAIL, "박에이아이", "AI 시드", "010-9000-1003");
+        Member hidden = ensureMember(SEED_HIDDEN_EMAIL, "최히든", "비공개 시드", "010-9000-1004");
+
+        ensureResume(
+                backend,
+                "Spring Boot와 PostgreSQL 기반 B2B 백엔드 서비스를 설계하고 운영해 온 백엔드 개발자입니다.",
+                (byte) 6,
+                careerPayload(
+                        careerItem(
+                                "ITDA Labs",
+                                "백엔드 개발자",
+                                CareerEmploymentType.FULL_TIME,
+                                "2021-03",
+                                null,
+                                true,
+                                "매칭/추천 API와 운영용 백오피스를 설계하고 성능 튜닝을 담당했습니다.",
+                                List.of("Java", "Spring", "PostgreSQL", "Redis")
+                        )
+                ),
+                WorkType.HYBRID,
+                ResumeWritingStatus.DONE,
+                "https://backend.seed.itda.local",
+                true,
+                true,
+                skillLevels(
+                        skillLevel("Java", Proficiency.ADVANCED),
+                        skillLevel("Spring", Proficiency.ADVANCED),
+                        skillLevel("PostgreSQL", Proficiency.ADVANCED),
+                        skillLevel("Redis", Proficiency.INTERMEDIATE)
+                ),
+                skills
+        );
+
+        ensureResume(
+                fullstack,
+                "백엔드와 프론트를 모두 다루며 관리자 화면과 고객용 서비스 UI를 함께 구축하는 풀스택 개발자입니다.",
+                (byte) 5,
+                careerPayload(
+                        careerItem(
+                                "Product Studio",
+                                "풀스택 개발자",
+                                CareerEmploymentType.FULL_TIME,
+                                "2020-07",
+                                null,
+                                true,
+                                "관리자 대시보드와 API 서버를 한 팀에서 개발했습니다.",
+                                List.of("Java", "Spring", "React", "TypeScript", "Docker")
+                        )
+                ),
+                WorkType.HYBRID,
+                ResumeWritingStatus.DONE,
+                "https://fullstack.seed.itda.local",
+                true,
+                true,
+                skillLevels(
+                        skillLevel("Java", Proficiency.INTERMEDIATE),
+                        skillLevel("Spring", Proficiency.INTERMEDIATE),
+                        skillLevel("React", Proficiency.ADVANCED),
+                        skillLevel("TypeScript", Proficiency.ADVANCED),
+                        skillLevel("Docker", Proficiency.INTERMEDIATE)
+                ),
+                skills
+        );
+
+        ensureResume(
+                aiEngineer,
+                "LLM 기능 기획부터 Python 기반 추론 서비스 운영까지 경험한 AI 엔지니어입니다.",
+                (byte) 4,
+                careerPayload(
+                        careerItem(
+                                "AI Matching Team",
+                                "AI 엔지니어",
+                                CareerEmploymentType.CONTRACT,
+                                "2022-01",
+                                null,
+                                true,
+                                "추천 설명 생성과 검색 증강 워크플로를 구현했습니다.",
+                                List.of("Python", "PostgreSQL", "LLM", "AWS")
+                        )
+                ),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                "https://ai.seed.itda.local",
+                true,
+                true,
+                skillLevels(
+                        skillLevel("Python", Proficiency.ADVANCED),
+                        skillLevel("LLM", Proficiency.ADVANCED),
+                        skillLevel("PostgreSQL", Proficiency.INTERMEDIATE),
+                        skillLevel("AWS", Proficiency.INTERMEDIATE)
+                ),
+                skills
+        );
+
+        ensureResume(
+                hidden,
+                "화면 구현은 가능하지만 아직 외부 공개 전 검수 중인 프론트엔드 개발자입니다.",
+                (byte) 2,
+                careerPayload(
+                        careerItem(
+                                "Stealth UI Team",
+                                "프론트엔드 개발자",
+                                CareerEmploymentType.FREELANCE,
+                                "2024-01",
+                                null,
+                                true,
+                                "초기 대시보드 프로토타입과 공통 컴포넌트를 개발했습니다.",
+                                List.of("React", "TypeScript")
+                        )
+                ),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                "https://hidden.seed.itda.local",
+                false,
+                false,
+                skillLevels(
+                        skillLevel("React", Proficiency.INTERMEDIATE),
+                        skillLevel("TypeScript", Proficiency.INTERMEDIATE)
+                ),
+                skills
+        );
+
+        Proposal matchingProposal = ensureProposal(
+                client,
+                MATCHING_PROPOSAL_TITLE,
+                """
+                AI로 프로젝트 요구사항을 브리프화하고 프리랜서 추천까지 연결하는 플랫폼을 고도화하려고 합니다.
+                추천 설명, 필터링, 결과 비교 흐름까지 한 번에 다듬을 수 있는 팀이 필요합니다.
+                """,
+                "추천 엔진 MVP를 운영 가능한 수준으로 끌어올리는 고도화 프로젝트",
+                45_000_000L,
+                70_000_000L,
+                ProposalWorkType.HYBRID,
+                "서울 강남 / 주 2회 협업",
+                16L,
+                true
+        );
+        ensureProposalPosition(
+                matchingProposal,
+                positions.get("백엔드 개발자"),
+                2L,
+                6_000_000L,
+                8_000_000L,
+                skillRequirements(
+                        skillRequirement("Java", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("Spring", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("PostgreSQL", ProposalPositionSkillImportance.PREFERENCE),
+                        skillRequirement("Redis", ProposalPositionSkillImportance.PREFERENCE)
+                ),
+                skills
+        );
+        ensureProposalPosition(
+                matchingProposal,
+                positions.get("AI 엔지니어"),
+                1L,
+                7_000_000L,
+                9_000_000L,
+                skillRequirements(
+                        skillRequirement("Python", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("LLM", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("AWS", ProposalPositionSkillImportance.PREFERENCE)
+                ),
+                skills
+        );
+
+        Proposal writingProposal = ensureProposal(
+                client,
+                WRITING_PROPOSAL_TITLE,
+                """
+                내부 운영 대시보드의 프론트 개편을 준비 중입니다.
+                아직 초안 단계라 추천 실행 전 상태로 테스트할 수 있어야 합니다.
+                """,
+                "운영자용 프론트 대시보드 개편 제안서 초안",
+                12_000_000L,
+                18_000_000L,
+                ProposalWorkType.REMOTE,
+                "원격",
+                8L,
+                false
+        );
+        ensureProposalPosition(
+                writingProposal,
+                positions.get("프론트엔드 개발자"),
+                1L,
+                5_000_000L,
+                7_000_000L,
+                skillRequirements(
+                        skillRequirement("React", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("TypeScript", ProposalPositionSkillImportance.ESSENTIAL),
+                        skillRequirement("Docker", ProposalPositionSkillImportance.PREFERENCE)
+                ),
+                skills
+        );
+
+        log.info(
+                """
+                Seed data is ready.
+                Seed client email={} matchingProposalId={} writingProposalId={}
+                Seed freelancer emails=[{}, {}, {}, {}]
+                """,
+                client.getEmail().getValue(),
+                matchingProposal.getId(),
+                writingProposal.getId(),
+                backend.getEmail().getValue(),
+                fullstack.getEmail().getValue(),
+                aiEngineer.getEmail().getValue(),
+                hidden.getEmail().getValue()
+        );
+    }
+
+    private Map<String, Position> ensurePositions() {
+        Map<String, Position> positions = new LinkedHashMap<>();
+        positions.put("백엔드 개발자", ensurePosition("백엔드 개발자"));
+        positions.put("프론트엔드 개발자", ensurePosition("프론트엔드 개발자"));
+        positions.put("AI 엔지니어", ensurePosition("AI 엔지니어"));
+        return positions;
+    }
+
+    private Map<String, Skill> ensureSkills() {
+        Map<String, Skill> skills = new LinkedHashMap<>();
+        skills.put("Java", ensureSkill("Java", "Spring 기반 서버 구현에 사용하는 백엔드 핵심 언어"));
+        skills.put("Spring", ensureSkill("Spring", "Spring Boot 기반 서비스 개발 역량"));
+        skills.put("PostgreSQL", ensureSkill("PostgreSQL", "운영형 관계형 데이터베이스 설계 및 튜닝"));
+        skills.put("React", ensureSkill("React", "관리자/사용자 화면 프론트엔드 구현 역량"));
+        skills.put("TypeScript", ensureSkill("TypeScript", "타입 안전성을 갖춘 프론트엔드 개발 역량"));
+        skills.put("Redis", ensureSkill("Redis", "캐시 및 세션, 큐 기반 성능 개선 역량"));
+        skills.put("Docker", ensureSkill("Docker", "로컬/운영 환경 컨테이너 기반 배포 역량"));
+        skills.put("Python", ensureSkill("Python", "데이터/AI 서비스와 스크립팅 개발 역량"));
+        skills.put("AWS", ensureSkill("AWS", "클라우드 인프라 운영 및 배포 역량"));
+        skills.put("LLM", ensureSkill("LLM", "대규모 언어 모델 연동 및 프롬프트 설계 역량"));
+        return skills;
+    }
+
+    private Member ensureMember(String email, String name, String nickname, String phone) {
+        Member member = Optional.ofNullable(memberRepository.findByEmail_Value(email))
+                .orElseGet(() -> memberRepository.save(
+                        Member.create(
+                                email,
+                                passwordEncoder.encode(defaultPassword),
+                                name,
+                                nickname,
+                                null,
+                                phone
+                        )
+                ));
+
+        member.changeHashedPassword(passwordEncoder.encode(defaultPassword));
+        member.update(name, nickname, phone);
+        return member;
+    }
+
+    private Resume ensureResume(
+            Member member,
+            String introduction,
+            byte careerYears,
+            CareerPayload career,
+            WorkType preferredWorkType,
+            ResumeWritingStatus writingStatus,
+            String portfolioUrl,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            List<SeedSkillLevel> skillLevels,
+            Map<String, Skill> skills
+    ) {
+        Resume resume = resumeRepository.findByMemberId(member.getId())
+                .orElseGet(() -> resumeRepository.save(
+                        Resume.create(
+                                member,
+                                introduction,
+                                careerYears,
+                                career,
+                                preferredWorkType,
+                                writingStatus,
+                                portfolioUrl
+                        )
+                ));
+
+        resume.update(introduction, careerYears, career, preferredWorkType, writingStatus, portfolioUrl);
+
+        if (resume.getStatus() == ResumeStatus.INACTIVE) {
+            resume.restore();
+        }
+        if (resume.isPubliclyVisible() != publiclyVisible) {
+            resume.togglePubliclyVisible();
+        }
+        if (resume.isAiMatchingEnabled() != aiMatchingEnabled) {
+            resume.toggleAiMatchingEnabled();
+        }
+
+        for (SeedSkillLevel skillLevel : skillLevels) {
+            Skill skill = skills.get(skillLevel.skillName());
+            Optional<ResumeSkill> existingSkill = resume.getSkills().stream()
+                    .filter(resumeSkill -> resumeSkill.getSkill().getName().equals(skillLevel.skillName()))
+                    .findFirst();
+
+            if (existingSkill.isPresent()) {
+                existingSkill.get().update(skill, skillLevel.proficiency());
+                continue;
+            }
+
+            resume.addSkill(skill, skillLevel.proficiency());
+        }
+
+        return resumeRepository.save(resume);
+    }
+
+    private Proposal ensureProposal(
+            Member member,
+            String title,
+            String rawInputText,
+            String description,
+            Long totalBudgetMin,
+            Long totalBudgetMax,
+            ProposalWorkType workType,
+            String workPlace,
+            Long expectedPeriod,
+            boolean matching
+    ) {
+        Proposal proposal = proposalRepository.findByMemberIdAndTitle(member.getId(), title)
+                .orElseGet(() -> proposalRepository.save(
+                        Proposal.create(
+                                member,
+                                title,
+                                rawInputText,
+                                description,
+                                totalBudgetMin,
+                                totalBudgetMax,
+                                workType,
+                                workPlace,
+                                expectedPeriod
+                        )
+                ));
+
+        proposal.update(title, rawInputText, description, totalBudgetMin, totalBudgetMax, workType, workPlace,
+                expectedPeriod);
+
+        if (matching && proposal.getStatus().name().equals("WRITING")) {
+            proposal.startMatching();
+        }
+
+        return proposalRepository.save(proposal);
+    }
+
+    private ProposalPosition ensureProposalPosition(
+            Proposal proposal,
+            Position position,
+            Long headCount,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            List<SeedSkillRequirement> skillRequirements,
+            Map<String, Skill> skills
+    ) {
+        ProposalPosition proposalPosition = proposal.getPositions().stream()
+                .filter(existing -> existing.getPosition().getName().equals(position.getName()))
+                .findFirst()
+                .orElseGet(() -> proposal.addPosition(position, headCount, unitBudgetMin, unitBudgetMax));
+
+        proposalPosition.update(position, headCount, unitBudgetMin, unitBudgetMax);
+
+        for (SeedSkillRequirement requirement : skillRequirements) {
+            Skill skill = skills.get(requirement.skillName());
+            Optional<ProposalPositionSkill> existingSkill = proposalPosition.getSkills().stream()
+                    .filter(proposalSkill -> proposalSkill.getSkill().getName().equals(requirement.skillName()))
+                    .findFirst();
+
+            if (existingSkill.isPresent()) {
+                existingSkill.get().changeImportance(requirement.importance());
+                continue;
+            }
+
+            proposalPosition.addSkill(skill, requirement.importance());
+        }
+
+        proposalRepository.save(proposal);
+        return proposalPosition;
+    }
+
+    private Position ensurePosition(String name) {
+        return positionRepository.findByName(name)
+                .orElseGet(() -> positionRepository.save(Position.create(name)));
+    }
+
+    private Skill ensureSkill(String name, String description) {
+        Skill skill = skillRepository.findByName(name)
+                .orElseGet(() -> skillRepository.save(Skill.create(name, description)));
+
+        skill.update(name, description);
+        return skill;
+    }
+
+    private CareerPayload careerPayload(CareerItemPayload... items) {
+        CareerPayload payload = new CareerPayload();
+        payload.setItems(List.of(items));
+        return payload;
+    }
+
+    private CareerItemPayload careerItem(
+            String companyName,
+            String position,
+            CareerEmploymentType employmentType,
+            String startYearMonth,
+            String endYearMonth,
+            boolean currentlyWorking,
+            String summary,
+            List<String> techStack
+    ) {
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName(companyName);
+        item.setPosition(position);
+        item.setEmploymentType(employmentType);
+        item.setStartYearMonth(startYearMonth);
+        item.setEndYearMonth(endYearMonth);
+        item.setCurrentlyWorking(currentlyWorking);
+        item.setSummary(summary);
+        item.setTechStack(techStack);
+        return item;
+    }
+
+    private List<SeedSkillLevel> skillLevels(SeedSkillLevel... levels) {
+        return List.of(levels);
+    }
+
+    private SeedSkillLevel skillLevel(String skillName, Proficiency proficiency) {
+        return new SeedSkillLevel(skillName, proficiency);
+    }
+
+    private List<SeedSkillRequirement> skillRequirements(SeedSkillRequirement... requirements) {
+        return List.of(requirements);
+    }
+
+    private SeedSkillRequirement skillRequirement(String skillName, ProposalPositionSkillImportance importance) {
+        return new SeedSkillRequirement(skillName, importance);
+    }
+
+    private record SeedSkillLevel(String skillName, Proficiency proficiency) {
+    }
+
+    private record SeedSkillRequirement(String skillName, ProposalPositionSkillImportance importance) {
+    }
+}

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -14,7 +14,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/resume")
@@ -38,7 +42,8 @@ public class ResumeController {
         try {
             resumeService.findByEmail(principal.getEmail());
             return "redirect:/resume/edit";
-        } catch (IllegalStateException ignored) {}
+        } catch (IllegalStateException ignored) {
+        }
 
         ResumeForm form = new ResumeForm();
         form.setCareerYears((byte) 0);
@@ -54,14 +59,6 @@ public class ResumeController {
         model.addAttribute("isNew", true);
 
         return "freelancer/resumeForm";
-        } catch (IllegalStateException e) {
-            // 이력서 없음 → 작성 페이지 진행
-        }
-
-        addCommonAttributes(model);
-        model.addAttribute("resumeForm", new ResumeForm());
-        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
-        return "resume/form";
     }
 
     @PostMapping("/new")
@@ -76,7 +73,6 @@ public class ResumeController {
             addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
             model.addAttribute("isNew", true);
-            model.addAttribute("editing", true);
             return "freelancer/resumeForm";
         }
 
@@ -96,7 +92,6 @@ public class ResumeController {
             addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
             model.addAttribute("isNew", true);
-            model.addAttribute("editing", true);
             return "freelancer/resumeForm";
         }
 
@@ -110,16 +105,12 @@ public class ResumeController {
             Model model
     ) {
         Resume resume = resumeService.findByEmail(principal.getEmail());
-
-        // DTO 변환 로직을 하단 전용 메서드로 호출
         ResumeForm form = convertToForm(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
 
-        // mode=modify가 있으면 수정 가능(true), 없으면 조회 전용(false)
         boolean isEditable = "modify".equals(mode);
-
         model.addAttribute("resumeForm", form);
         model.addAttribute("resumeSkillForm", new ResumeSkillForm());
         model.addAttribute("resume", resume);
@@ -136,12 +127,16 @@ public class ResumeController {
             BindingResult bindingResult,
             Model model
     ) {
-        // 1. 유효성 검사 실패 시
         if (bindingResult.hasErrors()) {
+            Resume resume = resumeService.findByEmail(principal.getEmail());
+
             addCommonAttributes(model);
             addMemberAttributes(model, principal);
+            model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+            model.addAttribute("resumeForm", form);
+            model.addAttribute("resume", resume);
             model.addAttribute("isNew", false);
-            model.addAttribute("editable", true); // 에러가 났으니 다시 수정할 수 있게 true 유지
+            model.addAttribute("editable", true);
             return "freelancer/resumeForm";
         }
 
@@ -161,11 +156,9 @@ public class ResumeController {
             return "redirect:/resume/new";
         }
 
-        // 2. 저장 완료 후: 파라미터 없이 리다이렉트 -> mode가 없으므로 다시 '조회 모드(readonly)'가 됨
         return "redirect:/resume/edit";
     }
 
-    // 중복 코드 방지를 위한 변환 메서드
     private ResumeForm convertToForm(Resume resume) {
         ResumeForm form = new ResumeForm();
         form.setIntroduction(resume.getIntroduction());
@@ -247,30 +240,16 @@ public class ResumeController {
         model.addAttribute("memberPhone", principal.getPhone());
     }
 
-    private String renderEditPageForSkillForm(ItDaPrincipal principal, Model model, boolean editing) {
-        Resume resume;
-        try {
-            resume = resumeService.findByEmail(principal.getEmail());
-        } catch (IllegalStateException e) {
-            return "redirect:/resume/new";
-        }
-
-        ResumeForm form = new ResumeForm();
-        form.setIntroduction(resume.getIntroduction());
-        form.setCareerYears(resume.getCareerYears());
-        form.setCareer(resume.getCareer());
-        form.setPreferredWorkType(resume.getPreferredWorkType());
-        form.setPortfolioUrl(resume.getPortfolioUrl());
-        form.setWritingStatus(resume.getWritingStatus());
-        form.setPubliclyVisible(resume.isPubliclyVisible());
-        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
+    private String renderEditPageForSkillForm(ItDaPrincipal principal, Model model, boolean editable) {
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        ResumeForm form = convertToForm(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
         model.addAttribute("resumeForm", form);
         model.addAttribute("resume", resume);
         model.addAttribute("isNew", false);
-        model.addAttribute("editable", editing);
+        model.addAttribute("editable", editable);
         return "freelancer/resumeForm";
     }
 }

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -54,6 +54,14 @@ public class ResumeController {
         model.addAttribute("isNew", true);
 
         return "freelancer/resumeForm";
+        } catch (IllegalStateException e) {
+            // 이력서 없음 → 작성 페이지 진행
+        }
+
+        addCommonAttributes(model);
+        model.addAttribute("resumeForm", new ResumeForm());
+        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+        return "resume/form";
     }
 
     @PostMapping("/new")

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -10,18 +10,15 @@ import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.ResumeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
-@RequestMapping("/resume")
+@RequestMapping("/resumes")
 @RequiredArgsConstructor
 public class ResumeController {
 
@@ -31,17 +28,33 @@ public class ResumeController {
     public String index(@AuthenticationPrincipal ItDaPrincipal principal) {
         try {
             resumeService.findByEmail(principal.getEmail());
-            return "redirect:/resume/edit";
+            return "redirect:/resumes/me";
         } catch (IllegalStateException ignored) {
-            return "redirect:/resume/new";
+            return "redirect:/resumes/new";
         }
+    }
+
+    @GetMapping("/me")
+    public String viewFrom (@AuthenticationPrincipal ItDaPrincipal principal, Model model){
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        ResumeForm form = convertToForm(resume);
+
+        addCommonAttributes(model);
+        addMemberAttributes(model, principal);
+
+        model.addAttribute("resumeForm", form);
+        model.addAttribute("resume", resume);
+        model.addAttribute("isNew", false);
+        model.addAttribute("editable", false);
+
+        return "freelancer/resumeForm";
     }
 
     @GetMapping("/new")
     public String newForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
         try {
             resumeService.findByEmail(principal.getEmail());
-            return "redirect:/resume/edit";
+            return "redirect:/resumes/edit";
         } catch (IllegalStateException ignored) {
         }
 
@@ -95,27 +108,22 @@ public class ResumeController {
             return "freelancer/resumeForm";
         }
 
-        return "redirect:/resume/edit";
+        return "redirect:/resumes/edit";
     }
 
     @GetMapping("/edit")
-    public String editForm(
-            @AuthenticationPrincipal ItDaPrincipal principal,
-            @RequestParam(value = "mode", required = false) String mode,
-            Model model
-    ) {
+    public String editForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
         Resume resume = resumeService.findByEmail(principal.getEmail());
         ResumeForm form = convertToForm(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
 
-        boolean isEditable = "modify".equals(mode);
         model.addAttribute("resumeForm", form);
         model.addAttribute("resumeSkillForm", new ResumeSkillForm());
         model.addAttribute("resume", resume);
         model.addAttribute("isNew", false);
-        model.addAttribute("editable", isEditable);
+        model.addAttribute("editable", true);
 
         return "freelancer/resumeForm";
     }
@@ -153,10 +161,10 @@ public class ResumeController {
                     form.isAiMatchingEnabled()
             );
         } catch (IllegalStateException e) {
-            return "redirect:/resume/new";
+            return "redirect:/resumes/new";
         }
 
-        return "redirect:/resume/edit";
+        return "redirect:/resumes/me";
     }
 
     private ResumeForm convertToForm(Resume resume) {
@@ -179,52 +187,64 @@ public class ResumeController {
             BindingResult bindingResult,
             Model model
     ) {
-        if (bindingResult.hasErrors()) {
-            return renderEditPageForSkillForm(principal, model, true);
+        // 1. 검증 오류가 없을 때만 저장 로직 실행
+        if (!bindingResult.hasErrors()) {
+            try {
+                resumeService.addSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+            } catch (IllegalStateException e) {
+                // 중복 스킬 등 비즈니스 예외 처리
+                bindingResult.rejectValue("skillId", "duplicate", e.getMessage());
+            }
         }
 
-        try {
-            resumeService.addSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
-        } catch (IllegalStateException e) {
-            bindingResult.reject("skillAddFailed", e.getMessage());
-            return renderEditPageForSkillForm(principal, model, true);
-        }
+        // 2. 조각을 다시 그리기 위한 데이터 준비 (핵심)
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        addCommonAttributes(model); // skills, proficiencies 목록 담기
+        model.addAttribute("resume", resume);
+        model.addAttribute("isEditing", true);
+        // 에러가 있다면 입력하던 폼을 그대로, 없다면 빈 폼을 전달
+        model.addAttribute("resumeSkillForm", bindingResult.hasErrors() ? form : new ResumeSkillForm());
 
-        return "redirect:/resume/edit?mode=modify";
-    }
-
-    @PostMapping("/skill/update")
-    public String updateSkill(
-            @AuthenticationPrincipal ItDaPrincipal principal,
-            @Valid @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
-            BindingResult bindingResult,
-            Model model
-    ) {
-        if (bindingResult.hasErrors()) {
-            return renderEditPageForSkillForm(principal, model, true);
-        }
-
-        try {
-            resumeService.updateSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
-        } catch (IllegalStateException e) {
-            bindingResult.reject("skillUpdateFailed", e.getMessage());
-            return renderEditPageForSkillForm(principal, model, true);
-        }
-
-        return "redirect:/resume/edit?mode=modify";
+        // 3. 파일명 :: #ID 반환 (이 부분을 본인의 파일명에 맞게 수정하세요)
+        return "freelancer/resumeForm :: #skillSection";
     }
 
     @PostMapping("/skill/remove")
     public String removeSkill(
             @AuthenticationPrincipal ItDaPrincipal principal,
-            @ModelAttribute("resumeSkillForm") ResumeSkillForm form
+            @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
+            Model model
     ) {
-        if (form.getSkillId() == null) {
-            return "redirect:/resume/edit";
+        if (form.getSkillId() != null) {
+            resumeService.removeSkill(principal.getEmail(), form.getSkillId());
         }
 
-        resumeService.removeSkill(principal.getEmail(), form.getSkillId());
-        return "redirect:/resume/edit?mode=modify";
+        // 삭제 후에도 목록을 갱신해서 조각 반환
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        addCommonAttributes(model);
+        model.addAttribute("resume", resume);
+        model.addAttribute("isEditing", true);
+        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+
+        return "freelancer/resumeForm :: #skillSection";
+    }
+    @PostMapping("/skill/update")
+    public String updateSkill(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
+            Model model
+    ) {
+        // 특정 스킬의 숙련도 업데이트
+        resumeService.updateSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+
+        // 갱신된 데이터로 조각 반환
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        addCommonAttributes(model);
+        model.addAttribute("resume", resume);
+        model.addAttribute("isEditing", true);
+        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+
+        return "freelancer/resumeForm :: #skillSection";
     }
 
     private void addCommonAttributes(Model model) {

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -37,7 +37,7 @@ public class ResumeController {
     @GetMapping("/me")
     public String viewFrom (@AuthenticationPrincipal ItDaPrincipal principal, Model model){
         Resume resume = resumeService.findByEmail(principal.getEmail());
-        ResumeForm form = convertToForm(resume);
+        ResumeForm form = ResumeForm.from(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
@@ -58,12 +58,7 @@ public class ResumeController {
         } catch (IllegalStateException ignored) {
         }
 
-        ResumeForm form = new ResumeForm();
-        form.setCareerYears((byte) 0);
-        form.setWritingStatus(ResumeWritingStatus.WRITING);
-        form.setIntroduction("");
-        form.setPubliclyVisible(true);
-        form.setAiMatchingEnabled(true);
+        ResumeForm form = ResumeForm.createDefault();
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
@@ -114,7 +109,7 @@ public class ResumeController {
     @GetMapping("/edit")
     public String editForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
         Resume resume = resumeService.findByEmail(principal.getEmail());
-        ResumeForm form = convertToForm(resume);
+        ResumeForm form = ResumeForm.from(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
@@ -165,19 +160,6 @@ public class ResumeController {
         }
 
         return "redirect:/resumes/me";
-    }
-
-    private ResumeForm convertToForm(Resume resume) {
-        ResumeForm form = new ResumeForm();
-        form.setIntroduction(resume.getIntroduction());
-        form.setCareerYears(resume.getCareerYears());
-        form.setCareer(resume.getCareer());
-        form.setPreferredWorkType(resume.getPreferredWorkType());
-        form.setPortfolioUrl(resume.getPortfolioUrl());
-        form.setWritingStatus(resume.getWritingStatus());
-        form.setPubliclyVisible(resume.isPubliclyVisible());
-        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
-        return form;
     }
 
     @PostMapping("/skill/add")
@@ -262,7 +244,7 @@ public class ResumeController {
 
     private String renderEditPageForSkillForm(ItDaPrincipal principal, Model model, boolean editable) {
         Resume resume = resumeService.findByEmail(principal.getEmail());
-        ResumeForm form = convertToForm(resume);
+        ResumeForm form = ResumeForm.from(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -85,15 +85,7 @@ public class ResumeController {
         }
 
         try {
-            resumeService.create(
-                    principal.getEmail(),
-                    form.getIntroduction(),
-                    form.getCareerYears(),
-                    form.getCareer(),
-                    form.getPreferredWorkType(),
-                    form.getWritingStatus(),
-                    form.getPortfolioUrl()
-            );
+            resumeService.create(principal.getEmail(), form);
         } catch (IllegalStateException e) {
             bindingResult.reject("resumeExists", e.getMessage());
             addCommonAttributes(model);
@@ -144,17 +136,7 @@ public class ResumeController {
         }
 
         try {
-            resumeService.update(
-                    principal.getEmail(),
-                    form.getIntroduction(),
-                    form.getCareerYears(),
-                    form.getCareer(),
-                    form.getPreferredWorkType(),
-                    form.getWritingStatus(),
-                    form.getPortfolioUrl(),
-                    form.isPubliclyVisible(),
-                    form.isAiMatchingEnabled()
-            );
+            resumeService.update(principal.getEmail(), form);
         } catch (IllegalStateException e) {
             return "redirect:/resumes/new";
         }

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -14,11 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/resume")
@@ -72,6 +68,7 @@ public class ResumeController {
             addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
             model.addAttribute("isNew", true);
+            model.addAttribute("editing", true);
             return "freelancer/resumeForm";
         }
 
@@ -91,6 +88,7 @@ public class ResumeController {
             addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
             model.addAttribute("isNew", true);
+            model.addAttribute("editing", true);
             return "freelancer/resumeForm";
         }
 
@@ -98,25 +96,28 @@ public class ResumeController {
     }
 
     @GetMapping("/edit")
-    public String editForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
+    public String editForm(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @RequestParam(value = "mode", required = false) String mode,
+            Model model
+    ) {
         Resume resume = resumeService.findByEmail(principal.getEmail());
 
-        ResumeForm form = new ResumeForm();
-        form.setIntroduction(resume.getIntroduction());
-        form.setCareerYears(resume.getCareerYears());
-        form.setCareer(resume.getCareer());
-        form.setPreferredWorkType(resume.getPreferredWorkType());
-        form.setPortfolioUrl(resume.getPortfolioUrl());
-        form.setWritingStatus(resume.getWritingStatus());
-        form.setPubliclyVisible(resume.isPubliclyVisible());
-        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
+        // DTO 변환 로직을 하단 전용 메서드로 호출
+        ResumeForm form = convertToForm(resume);
 
         addCommonAttributes(model);
         addMemberAttributes(model, principal);
+
+        // mode=modify가 있으면 수정 가능(true), 없으면 조회 전용(false)
+        boolean isEditable = "modify".equals(mode);
+
         model.addAttribute("resumeForm", form);
         model.addAttribute("resumeSkillForm", new ResumeSkillForm());
         model.addAttribute("resume", resume);
         model.addAttribute("isNew", false);
+        model.addAttribute("editable", isEditable);
+
         return "freelancer/resumeForm";
     }
 
@@ -127,16 +128,12 @@ public class ResumeController {
             BindingResult bindingResult,
             Model model
     ) {
+        // 1. 유효성 검사 실패 시
         if (bindingResult.hasErrors()) {
-            Resume resume = null;
-            try {
-                resume = resumeService.findByEmail(principal.getEmail());
-            } catch (IllegalStateException ignored) {}
             addCommonAttributes(model);
             addMemberAttributes(model, principal);
-            model.addAttribute("resumeSkillForm", new ResumeSkillForm());
-            model.addAttribute("resume", resume);
             model.addAttribute("isNew", false);
+            model.addAttribute("editable", true); // 에러가 났으니 다시 수정할 수 있게 true 유지
             return "freelancer/resumeForm";
         }
 
@@ -153,40 +150,67 @@ public class ResumeController {
                     form.isAiMatchingEnabled()
             );
         } catch (IllegalStateException e) {
-            // "이력서가 존재하지 않습니다" 에러가 터지면 여기로 들어옵니다.
-            // 데이터가 없으니 신규 생성(/resume/new)으로 보내버리거나 에러 메시지를 띄웁니다.
             return "redirect:/resume/new";
         }
 
+        // 2. 저장 완료 후: 파라미터 없이 리다이렉트 -> mode가 없으므로 다시 '조회 모드(readonly)'가 됨
         return "redirect:/resume/edit";
+    }
+
+    // 중복 코드 방지를 위한 변환 메서드
+    private ResumeForm convertToForm(Resume resume) {
+        ResumeForm form = new ResumeForm();
+        form.setIntroduction(resume.getIntroduction());
+        form.setCareerYears(resume.getCareerYears());
+        form.setCareer(resume.getCareer());
+        form.setPreferredWorkType(resume.getPreferredWorkType());
+        form.setPortfolioUrl(resume.getPortfolioUrl());
+        form.setWritingStatus(resume.getWritingStatus());
+        form.setPubliclyVisible(resume.isPubliclyVisible());
+        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
+        return form;
     }
 
     @PostMapping("/skill/add")
     public String addSkill(
             @AuthenticationPrincipal ItDaPrincipal principal,
             @Valid @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
-            BindingResult bindingResult
+            BindingResult bindingResult,
+            Model model
     ) {
-        if (!bindingResult.hasErrors()) {
-            try {
-                resumeService.addSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
-            } catch (IllegalStateException e) {
-                // 이미 등록된 스킬
-            }
+        if (bindingResult.hasErrors()) {
+            return renderEditPageForSkillForm(principal, model, true);
         }
-        return "redirect:/resume/edit";
+
+        try {
+            resumeService.addSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+        } catch (IllegalStateException e) {
+            bindingResult.reject("skillAddFailed", e.getMessage());
+            return renderEditPageForSkillForm(principal, model, true);
+        }
+
+        return "redirect:/resume/edit?mode=modify";
     }
 
     @PostMapping("/skill/update")
     public String updateSkill(
             @AuthenticationPrincipal ItDaPrincipal principal,
             @Valid @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
-            BindingResult bindingResult
+            BindingResult bindingResult,
+            Model model
     ) {
-        if (!bindingResult.hasErrors()) {
-            resumeService.updateSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+        if (bindingResult.hasErrors()) {
+            return renderEditPageForSkillForm(principal, model, true);
         }
-        return "redirect:/resume/edit";
+
+        try {
+            resumeService.updateSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+        } catch (IllegalStateException e) {
+            bindingResult.reject("skillUpdateFailed", e.getMessage());
+            return renderEditPageForSkillForm(principal, model, true);
+        }
+
+        return "redirect:/resume/edit?mode=modify";
     }
 
     @PostMapping("/skill/remove")
@@ -194,8 +218,12 @@ public class ResumeController {
             @AuthenticationPrincipal ItDaPrincipal principal,
             @ModelAttribute("resumeSkillForm") ResumeSkillForm form
     ) {
+        if (form.getSkillId() == null) {
+            return "redirect:/resume/edit";
+        }
+
         resumeService.removeSkill(principal.getEmail(), form.getSkillId());
-        return "redirect:/resume/edit";
+        return "redirect:/resume/edit?mode=modify";
     }
 
     private void addCommonAttributes(Model model) {
@@ -209,5 +237,32 @@ public class ResumeController {
         model.addAttribute("memberName", principal.getName());
         model.addAttribute("memberEmail", principal.getEmail());
         model.addAttribute("memberPhone", principal.getPhone());
+    }
+
+    private String renderEditPageForSkillForm(ItDaPrincipal principal, Model model, boolean editing) {
+        Resume resume;
+        try {
+            resume = resumeService.findByEmail(principal.getEmail());
+        } catch (IllegalStateException e) {
+            return "redirect:/resume/new";
+        }
+
+        ResumeForm form = new ResumeForm();
+        form.setIntroduction(resume.getIntroduction());
+        form.setCareerYears(resume.getCareerYears());
+        form.setCareer(resume.getCareer());
+        form.setPreferredWorkType(resume.getPreferredWorkType());
+        form.setPortfolioUrl(resume.getPortfolioUrl());
+        form.setWritingStatus(resume.getWritingStatus());
+        form.setPubliclyVisible(resume.isPubliclyVisible());
+        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
+
+        addCommonAttributes(model);
+        addMemberAttributes(model, principal);
+        model.addAttribute("resumeForm", form);
+        model.addAttribute("resume", resume);
+        model.addAttribute("isNew", false);
+        model.addAttribute("editable", editing);
+        return "freelancer/resumeForm";
     }
 }

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -4,13 +4,11 @@ import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
-import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.resume.ResumeForm;
 import com.generic4.itda.dto.resume.ResumeSkillForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.ResumeService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -21,6 +19,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+
 @Controller
 @RequestMapping("/resume")
 @RequiredArgsConstructor
@@ -28,19 +27,37 @@ public class ResumeController {
 
     private final ResumeService resumeService;
 
+    @GetMapping("")
+    public String index(@AuthenticationPrincipal ItDaPrincipal principal) {
+        try {
+            resumeService.findByEmail(principal.getEmail());
+            return "redirect:/resume/edit";
+        } catch (IllegalStateException ignored) {
+            return "redirect:/resume/new";
+        }
+    }
+
     @GetMapping("/new")
     public String newForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
         try {
             resumeService.findByEmail(principal.getEmail());
             return "redirect:/resume/edit";
-        } catch (IllegalStateException e) {
-            // 이력서 없음 → 작성 페이지 진행
-        }
+        } catch (IllegalStateException ignored) {}
+
+        ResumeForm form = new ResumeForm();
+        form.setCareerYears((byte) 0);
+        form.setWritingStatus(ResumeWritingStatus.WRITING);
+        form.setIntroduction("");
+        form.setPubliclyVisible(true);
+        form.setAiMatchingEnabled(true);
 
         addCommonAttributes(model);
-        model.addAttribute("resumeForm", new ResumeForm());
+        addMemberAttributes(model, principal);
+        model.addAttribute("resumeForm", form);
         model.addAttribute("resumeSkillForm", new ResumeSkillForm());
-        return "resume/form";
+        model.addAttribute("isNew", true);
+
+        return "freelancer/resumeForm";
     }
 
     @PostMapping("/new")
@@ -52,8 +69,10 @@ public class ResumeController {
     ) {
         if (bindingResult.hasErrors()) {
             addCommonAttributes(model);
+            addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
-            return "resume/form";
+            model.addAttribute("isNew", true);
+            return "freelancer/resumeForm";
         }
 
         try {
@@ -69,8 +88,10 @@ public class ResumeController {
         } catch (IllegalStateException e) {
             bindingResult.reject("resumeExists", e.getMessage());
             addCommonAttributes(model);
+            addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
-            return "resume/form";
+            model.addAttribute("isNew", true);
+            return "freelancer/resumeForm";
         }
 
         return "redirect:/resume/edit";
@@ -87,12 +108,16 @@ public class ResumeController {
         form.setPreferredWorkType(resume.getPreferredWorkType());
         form.setPortfolioUrl(resume.getPortfolioUrl());
         form.setWritingStatus(resume.getWritingStatus());
+        form.setPubliclyVisible(resume.isPubliclyVisible());
+        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
 
         addCommonAttributes(model);
+        addMemberAttributes(model, principal);
         model.addAttribute("resumeForm", form);
         model.addAttribute("resumeSkillForm", new ResumeSkillForm());
         model.addAttribute("resume", resume);
-        return "resume/form";
+        model.addAttribute("isNew", false);
+        return "freelancer/resumeForm";
     }
 
     @PostMapping("/edit")
@@ -103,22 +128,35 @@ public class ResumeController {
             Model model
     ) {
         if (bindingResult.hasErrors()) {
-            Resume resume = resumeService.findByEmail(principal.getEmail());
+            Resume resume = null;
+            try {
+                resume = resumeService.findByEmail(principal.getEmail());
+            } catch (IllegalStateException ignored) {}
             addCommonAttributes(model);
+            addMemberAttributes(model, principal);
             model.addAttribute("resumeSkillForm", new ResumeSkillForm());
             model.addAttribute("resume", resume);
-            return "resume/form";
+            model.addAttribute("isNew", false);
+            return "freelancer/resumeForm";
         }
 
-        resumeService.update(
-                principal.getEmail(),
-                form.getIntroduction(),
-                form.getCareerYears(),
-                form.getCareer(),
-                form.getPreferredWorkType(),
-                form.getWritingStatus(),
-                form.getPortfolioUrl()
-        );
+        try {
+            resumeService.update(
+                    principal.getEmail(),
+                    form.getIntroduction(),
+                    form.getCareerYears(),
+                    form.getCareer(),
+                    form.getPreferredWorkType(),
+                    form.getWritingStatus(),
+                    form.getPortfolioUrl(),
+                    form.isPubliclyVisible(),
+                    form.isAiMatchingEnabled()
+            );
+        } catch (IllegalStateException e) {
+            // "이력서가 존재하지 않습니다" 에러가 터지면 여기로 들어옵니다.
+            // 데이터가 없으니 신규 생성(/resume/new)으로 보내버리거나 에러 메시지를 띄웁니다.
+            return "redirect:/resume/new";
+        }
 
         return "redirect:/resume/edit";
     }
@@ -165,5 +203,11 @@ public class ResumeController {
         model.addAttribute("workTypes", WorkType.values());
         model.addAttribute("proficiencies", Proficiency.values());
         model.addAttribute("writingStatuses", ResumeWritingStatus.values());
+    }
+
+    private void addMemberAttributes(Model model, ItDaPrincipal principal) {
+        model.addAttribute("memberName", principal.getName());
+        model.addAttribute("memberEmail", principal.getEmail());
+        model.addAttribute("memberPhone", principal.getPhone());
     }
 }

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -1,0 +1,169 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.resume.ResumeForm;
+import com.generic4.itda.dto.resume.ResumeSkillForm;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.ResumeService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/resume")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    @GetMapping("/new")
+    public String newForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
+        try {
+            resumeService.findByEmail(principal.getEmail());
+            return "redirect:/resume/edit";
+        } catch (IllegalStateException e) {
+            // 이력서 없음 → 작성 페이지 진행
+        }
+
+        addCommonAttributes(model);
+        model.addAttribute("resumeForm", new ResumeForm());
+        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+        return "resume/form";
+    }
+
+    @PostMapping("/new")
+    public String create(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @Valid @ModelAttribute("resumeForm") ResumeForm form,
+            BindingResult bindingResult,
+            Model model
+    ) {
+        if (bindingResult.hasErrors()) {
+            addCommonAttributes(model);
+            model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+            return "resume/form";
+        }
+
+        try {
+            resumeService.create(
+                    principal.getEmail(),
+                    form.getIntroduction(),
+                    form.getCareerYears(),
+                    form.getCareer(),
+                    form.getPreferredWorkType(),
+                    form.getWritingStatus(),
+                    form.getPortfolioUrl()
+            );
+        } catch (IllegalStateException e) {
+            bindingResult.reject("resumeExists", e.getMessage());
+            addCommonAttributes(model);
+            model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+            return "resume/form";
+        }
+
+        return "redirect:/resume/edit";
+    }
+
+    @GetMapping("/edit")
+    public String editForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+
+        ResumeForm form = new ResumeForm();
+        form.setIntroduction(resume.getIntroduction());
+        form.setCareerYears(resume.getCareerYears());
+        form.setCareer(resume.getCareer());
+        form.setPreferredWorkType(resume.getPreferredWorkType());
+        form.setPortfolioUrl(resume.getPortfolioUrl());
+        form.setWritingStatus(resume.getWritingStatus());
+
+        addCommonAttributes(model);
+        model.addAttribute("resumeForm", form);
+        model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+        model.addAttribute("resume", resume);
+        return "resume/form";
+    }
+
+    @PostMapping("/edit")
+    public String update(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @Valid @ModelAttribute("resumeForm") ResumeForm form,
+            BindingResult bindingResult,
+            Model model
+    ) {
+        if (bindingResult.hasErrors()) {
+            Resume resume = resumeService.findByEmail(principal.getEmail());
+            addCommonAttributes(model);
+            model.addAttribute("resumeSkillForm", new ResumeSkillForm());
+            model.addAttribute("resume", resume);
+            return "resume/form";
+        }
+
+        resumeService.update(
+                principal.getEmail(),
+                form.getIntroduction(),
+                form.getCareerYears(),
+                form.getCareer(),
+                form.getPreferredWorkType(),
+                form.getWritingStatus(),
+                form.getPortfolioUrl()
+        );
+
+        return "redirect:/resume/edit";
+    }
+
+    @PostMapping("/skill/add")
+    public String addSkill(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @Valid @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
+            BindingResult bindingResult
+    ) {
+        if (!bindingResult.hasErrors()) {
+            try {
+                resumeService.addSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+            } catch (IllegalStateException e) {
+                // 이미 등록된 스킬
+            }
+        }
+        return "redirect:/resume/edit";
+    }
+
+    @PostMapping("/skill/update")
+    public String updateSkill(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @Valid @ModelAttribute("resumeSkillForm") ResumeSkillForm form,
+            BindingResult bindingResult
+    ) {
+        if (!bindingResult.hasErrors()) {
+            resumeService.updateSkill(principal.getEmail(), form.getSkillId(), form.getProficiency());
+        }
+        return "redirect:/resume/edit";
+    }
+
+    @PostMapping("/skill/remove")
+    public String removeSkill(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @ModelAttribute("resumeSkillForm") ResumeSkillForm form
+    ) {
+        resumeService.removeSkill(principal.getEmail(), form.getSkillId());
+        return "redirect:/resume/edit";
+    }
+
+    private void addCommonAttributes(Model model) {
+        model.addAttribute("skills", resumeService.findAllSkills());
+        model.addAttribute("workTypes", WorkType.values());
+        model.addAttribute("proficiencies", Proficiency.values());
+        model.addAttribute("writingStatuses", ResumeWritingStatus.values());
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
@@ -1,9 +1,6 @@
 package com.generic4.itda.dto.resume;
 
-import com.generic4.itda.domain.resume.CareerPayload;
-import com.generic4.itda.domain.resume.Proficiency;
-import com.generic4.itda.domain.resume.ResumeWritingStatus;
-import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.resume.*;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -42,4 +39,27 @@ public class ResumeForm {
     private boolean publiclyVisible = true;
 
     private boolean aiMatchingEnabled = true;
+
+    public static ResumeForm from(Resume resume) {
+        ResumeForm form = new ResumeForm();
+        form.setIntroduction(resume.getIntroduction());
+        form.setCareerYears(resume.getCareerYears());
+        form.setCareer(resume.getCareer());
+        form.setPreferredWorkType(resume.getPreferredWorkType());
+        form.setPortfolioUrl(resume.getPortfolioUrl());
+        form.setWritingStatus(resume.getWritingStatus());
+        form.setPubliclyVisible(resume.isPubliclyVisible());
+        form.setAiMatchingEnabled(resume.isAiMatchingEnabled());
+        return form;
+    }
+
+    public static ResumeForm createDefault() {
+        ResumeForm form = new ResumeForm();
+        form.setCareerYears((byte) 0);
+        form.setWritingStatus(ResumeWritingStatus.WRITING);
+        form.setIntroduction("");
+        form.setPubliclyVisible(true);
+        form.setAiMatchingEnabled(true);
+        return form;
+    }
 }

--- a/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
@@ -1,0 +1,41 @@
+package com.generic4.itda.dto.resume;
+
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ResumeForm {
+
+    @NotBlank(message = "자기소개는 필수값입니다.")
+    @Size(max = 2000, message = "자기소개는 2000자를 초과할 수 없습니다.")
+    private String introduction;
+
+    @NotNull(message = "경력 연차는 필수값입니다.")
+    @Min(value = 0, message = "경력 연차는 0 이상이어야 합니다.")
+    @Max(value = 50, message = "경력 연차는 50을 초과할 수 없습니다.")
+    private Byte careerYears;
+
+    @Valid
+    @NotNull(message = "경력 정보는 필수값입니다.")
+    private CareerPayload career = new CareerPayload();
+
+    private WorkType preferredWorkType;
+
+    private String portfolioUrl;
+
+    @NotNull(message = "작성 상태는 필수값입니다.")
+    private ResumeWritingStatus writingStatus;
+}

--- a/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/ResumeForm.java
@@ -38,4 +38,8 @@ public class ResumeForm {
 
     @NotNull(message = "작성 상태는 필수값입니다.")
     private ResumeWritingStatus writingStatus;
+
+    private boolean publiclyVisible = true;
+
+    private boolean aiMatchingEnabled = true;
 }

--- a/src/main/java/com/generic4/itda/dto/resume/ResumeSkillForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/ResumeSkillForm.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.dto.resume;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ResumeSkillForm {
+
+    @NotNull(message = "스킬은 필수값입니다.")
+    private Long skillId;
+
+    @NotNull(message = "숙련도는 필수값입니다.")
+    private Proficiency proficiency;
+}

--- a/src/main/java/com/generic4/itda/repository/ProposalRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ProposalRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
+    Optional<Proposal> findByMemberIdAndTitle(Long memberId, String title);
+
     @Query("""
             select distinct p
             from Proposal p

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -15,6 +15,6 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     @Query("select r from Resume r " +
             "left join fetch r.skills " +
             "left join fetch r.attachments " +
-            "where r.member.email = :email")
+            "where r.member.email.value = :email")
     Optional<Resume> findByMemberEmailWithDetails(@Param("email") String email);
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -2,6 +2,8 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.resume.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,4 +11,10 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     Optional<Resume> findByMemberId(Long memberId);
 
     boolean existsByMemberEmail(String email);
+
+    @Query("select r from Resume r " +
+            "left join fetch r.skills " +
+            "left join fetch r.attachments " +
+            "where r.member.email = :email")
+    Optional<Resume> findByMemberEmailWithDetails(@Param("email") String email);
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
     Optional<Resume> findByMemberId(Long memberId);
+
+    boolean existsByMemberEmail(String email);
 }

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -96,7 +96,8 @@ public class ResumeService {
         Member member = getMemberByEmail(email);
         Resume resume = resumeRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new IllegalStateException("이력서가 존재하지 않습니다."));
-        resume.getSkills().size(); // open-in-view: false 환경에서 트랜잭션 안에 Lazy 컬렉션 강제 초기화
+        resume.getSkills().size();       // open-in-view: false → Lazy 컬렉션 강제 초기화
+        resume.getAttachments().size();  // open-in-view: false → Lazy 컬렉션 강제 초기화
         return resume;
     }
 

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -55,10 +55,18 @@ public class ResumeService {
             CareerPayload career,
             WorkType workType,
             ResumeWritingStatus writingStatus,
-            String portfolioUrl
+            String portfolioUrl,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled
     ) {
         Resume resume = getResumeByEmail(email);
         resume.update(introduction, careerYears, career, workType, writingStatus, portfolioUrl);
+        if (resume.isPubliclyVisible() != publiclyVisible) {
+            resume.togglePubliclyVisible();
+        }
+        if (resume.isAiMatchingEnabled() != aiMatchingEnabled) {
+            resume.toggleAiMatchingEnabled();
+        }
     }
 
     // 스킬 추가
@@ -86,8 +94,10 @@ public class ResumeService {
     @Transactional(readOnly = true)
     public Resume findByEmail(String email) {
         Member member = getMemberByEmail(email);
-        return resumeRepository.findByMemberId(member.getId())
+        Resume resume = resumeRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new IllegalStateException("이력서가 존재하지 않습니다."));
+        resume.getSkills().size(); // open-in-view: false 환경에서 트랜잭션 안에 Lazy 컬렉션 강제 초기화
+        return resume;
     }
 
     // 전체 스킬 목록 조회

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -1,0 +1,118 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+    private final SkillRepository skillRepository;
+
+    // 이력서 생성
+    public Resume create(
+            String email,
+            String introduction,
+            Byte careerYears,
+            CareerPayload career,
+            WorkType preferredWorkType,
+            ResumeWritingStatus writingStatus,
+            String portfolioUrl
+    ) {
+        Member member = getMemberByEmail(email);
+
+        if (resumeRepository.findByMemberId(member.getId()).isPresent()) {
+            throw new IllegalStateException("이미 이력서가 존재합니다.");
+        }
+
+        Resume resume = Resume.create(member, introduction, careerYears, career,
+                preferredWorkType, writingStatus, portfolioUrl);
+
+        return resumeRepository.save(resume);
+    }
+
+    // 이력서 수정
+    public void update(
+            String email,
+            String introduction,
+            Byte careerYears,
+            CareerPayload career,
+            WorkType workType,
+            ResumeWritingStatus writingStatus,
+            String portfolioUrl
+    ) {
+        Resume resume = getResumeByEmail(email);
+        resume.update(introduction, careerYears, career, workType, writingStatus, portfolioUrl);
+    }
+
+    // 스킬 추가
+    public void addSkill(String email, Long skillId, Proficiency proficiency) {
+        Resume resume = getResumeByEmail(email);
+        Skill skill = getSkillById(skillId);
+        resume.addSkill(skill, proficiency);
+    }
+
+    // 스킬 수정
+    public void updateSkill(String email, Long skillId, Proficiency proficiency) {
+        Resume resume = getResumeByEmail(email);
+        Skill skill = getSkillById(skillId);
+        resume.updateSkill(skill, proficiency);
+    }
+
+    // 스킬 삭제
+    public void removeSkill(String email, Long skillId) {
+        Resume resume = getResumeByEmail(email);
+        Skill skill = getSkillById(skillId);
+        resume.removeSkill(skill);
+    }
+
+    // 이력서 조회
+    @Transactional(readOnly = true)
+    public Resume findByEmail(String email) {
+        Member member = getMemberByEmail(email);
+        return resumeRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new IllegalStateException("이력서가 존재하지 않습니다."));
+    }
+
+    // 전체 스킬 목록 조회
+    @Transactional(readOnly = true)
+    public List<Skill> findAllSkills() {
+        return skillRepository.findAll();
+    }
+
+    // 내부 헬퍼
+    private Member getMemberByEmail(String email) {
+        Member member = memberRepository.findByEmail_Value(email);
+        if (member == null) {
+            throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+        }
+        return member;
+    }
+
+    private Resume getResumeByEmail(String email) {
+        Member member = getMemberByEmail(email);
+        return resumeRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new IllegalStateException("이력서가 존재하지 않습니다."));
+    }
+
+    private Skill getSkillById(Long skillId) {
+        return skillRepository.findById(skillId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스킬입니다."));
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -7,6 +7,7 @@ import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.resume.ResumeForm;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.ResumeRepository;
 import com.generic4.itda.repository.SkillRepository;
@@ -26,45 +27,51 @@ public class ResumeService {
     private final SkillRepository skillRepository;
 
     // 이력서 생성
-    public Resume create(
-            String email,
-            String introduction,
-            Byte careerYears,
-            CareerPayload career,
-            WorkType preferredWorkType,
-            ResumeWritingStatus writingStatus,
-            String portfolioUrl
-    ) {
-        Member member = getMemberByEmail(email);
-
-        if (resumeRepository.findByMemberId(member.getId()).isPresent()) {
+    @Transactional
+    public Resume create(String email, ResumeForm form) {
+        // 1. 존재 여부 확인 (리뷰어 제안 적용)
+        if (resumeRepository.existsByMemberEmail(email)) {
             throw new IllegalStateException("이미 이력서가 존재합니다.");
         }
 
-        Resume resume = Resume.create(member, introduction, careerYears, career,
-                preferredWorkType, writingStatus, portfolioUrl);
+        // 2. 회원 정보 조회
+        Member member = getMemberByEmail(email);
+
+        // 3. 엔티티 생성 시 form에서 데이터를 하나씩 꺼내서 전달
+        // ※ 여기서 에러가 났을 겁니다. Resume.create가 요구하는 인자 개수를 맞춰주세요.
+        Resume resume = Resume.create(
+                member,
+                form.getIntroduction(),
+                form.getCareerYears(),
+                form.getCareer(),
+                form.getPreferredWorkType(),
+                form.getWritingStatus(),
+                form.getPortfolioUrl()
+        );
 
         return resumeRepository.save(resume);
     }
 
     // 이력서 수정
-    public void update(
-            String email,
-            String introduction,
-            Byte careerYears,
-            CareerPayload career,
-            WorkType workType,
-            ResumeWritingStatus writingStatus,
-            String portfolioUrl,
-            boolean publiclyVisible,
-            boolean aiMatchingEnabled
-    ) {
+    public void update(String email, ResumeForm form) {
+        // 1. 이메일로 이력서 조회
         Resume resume = getResumeByEmail(email);
-        resume.update(introduction, careerYears, career, workType, writingStatus, portfolioUrl);
-        if (resume.isPubliclyVisible() != publiclyVisible) {
+
+        // 2. form에서 데이터를 꺼내서 엔티티 업데이트
+        resume.update(
+                form.getIntroduction(),
+                form.getCareerYears(),
+                form.getCareer(),
+                form.getPreferredWorkType(), // 서비스에서는 preferredWorkType, 엔티티는 workType일 수 있으니 이름 확인!
+                form.getWritingStatus(),
+                form.getPortfolioUrl()
+        );
+
+        // 3. 토글 로직도 form의 값으로 처리
+        if (resume.isPubliclyVisible() != form.isPubliclyVisible()) {
             resume.togglePubliclyVisible();
         }
-        if (resume.isAiMatchingEnabled() != aiMatchingEnabled) {
+        if (resume.isAiMatchingEnabled() != form.isAiMatchingEnabled()) {
             resume.toggleAiMatchingEnabled();
         }
     }

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -100,12 +100,10 @@ public class ResumeService {
     // 이력서 조회
     @Transactional(readOnly = true)
     public Resume findByEmail(String email) {
-        Member member = getMemberByEmail(email);
-        Resume resume = resumeRepository.findByMemberId(member.getId())
+        // 이제 여기서 Fetch Join으로 한 번에 다 가져옵니다.
+        // .size() 같은 강제 초기화 코드가 더 이상 필요 없습니다!
+        return resumeRepository.findByMemberEmailWithDetails(email)
                 .orElseThrow(() -> new IllegalStateException("이력서가 존재하지 않습니다."));
-        resume.getSkills().size();       // open-in-view: false → Lazy 컬렉션 강제 초기화
-        resume.getAttachments().size();  // open-in-view: false → Lazy 컬렉션 강제 초기화
-        return resume;
     }
 
     // 전체 스킬 목록 조회

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,3 +40,8 @@ ai:
     api-key: ${AI_BRIEF_API_KEY:}
     model: ${AI_BRIEF_MODEL:gpt-5-mini}
     max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:2000}
+
+app:
+  seed:
+    enabled: ${APP_SEED_ENABLED:true}
+    default-password: ${APP_SEED_PASSWORD:demo1234}

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -3,128 +3,55 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-    <title>프로필 관리 | IT-da</title>
+    <title>프로필 편집 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 py-10 px-6">
+        <div class="max-w-4xl mx-auto space-y-8">
 
-    <!-- Alpine.js: isNew면 처음부터 editing=true, 기존 이력서면 editing=false(읽기 전용) -->
-    <main class="min-h-screen bg-slate-50 py-10 px-6"
-          th:x-data="${' { editing: ' + isNew + ' } '}"
-          x-cloak>
-        <div class="max-w-4xl mx-auto space-y-6">
-
-            <!-- ===== 헤더 ===== -->
-            <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm">
-                <div class="flex items-start justify-between gap-6">
-                    <!-- 프로필 사진 + 이름 + 뱃지 -->
-                    <div class="flex items-center gap-6">
-                        <div class="w-20 h-20 rounded-2xl bg-slate-100 border border-slate-200 flex items-center justify-center flex-shrink-0">
-                            <i data-lucide="camera" class="w-8 h-8 text-slate-300"></i>
-                        </div>
-                        <div class="space-y-2">
-                            <h2 class="text-2xl font-bold text-slate-900" th:text="${memberName}">이름</h2>
-                            <p class="text-sm text-slate-400" th:text="${memberEmail}">이메일</p>
-                            <!-- 상태 뱃지 (기존 이력서에서만 표시) -->
-                            <div class="flex flex-wrap items-center gap-2" th:if="${resume != null}">
-                                <span th:if="${resume.publiclyVisible}"
-                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 border border-emerald-100">
-                                    <i data-lucide="eye" class="w-3 h-3"></i> 공개 중
-                                </span>
-                                <span th:unless="${resume.publiclyVisible}"
-                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-slate-100 text-slate-400 border border-slate-200">
-                                    <i data-lucide="eye-off" class="w-3 h-3"></i> 비공개
-                                </span>
-                                <span th:if="${resume.aiMatchingEnabled}"
-                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-blue-50 text-blue-600 border border-blue-100">
-                                    <i data-lucide="zap" class="w-3 h-3"></i> AI 추천 포함
-                                </span>
-                                <span th:if="${resume?.writingStatus?.name() == 'DONE'}"
-                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-violet-50 text-violet-600 border border-violet-100">
-                                    <i data-lucide="file-check" class="w-3 h-3"></i> 작성 완료
-                                </span>
-                                <span th:if="${resume?.writingStatus?.name() == 'WRITING'}"
-                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
-                                    <i data-lucide="pencil" class="w-3 h-3"></i> 작성 중
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- 버튼 영역 -->
-                    <div class="flex gap-3 flex-shrink-0">
-                        <!-- 수정하기 버튼: 읽기 전용 상태에서만 표시 -->
-                        <button type="button"
-                                x-show="!editing"
-                                @click="editing = true"
-                                class="inline-flex items-center gap-2 border border-slate-300 text-slate-700 px-6 py-3 rounded-2xl font-bold text-sm hover:border-blue-400 hover:text-blue-600 transition-all">
-                            <i data-lucide="pencil" class="w-4 h-4"></i> 수정하기
-                        </button>
-                        <!-- 취소 버튼: 기존 이력서(isNew=false)일 때만 렌더링, 편집 중에만 표시 -->
-                        <button type="button"
-                                th:if="${!isNew}"
-                                x-show="editing"
-                                @click="editing = false"
-                                class="inline-flex items-center gap-2 border border-slate-200 text-slate-400 px-6 py-3 rounded-2xl font-bold text-sm hover:bg-slate-50 transition-all">
-                            취소
-                        </button>
-                        <!-- 저장하기 버튼: 편집 중일 때만 표시 -->
-                        <button type="submit" form="profileForm"
-                                x-show="editing"
-                                class="inline-flex items-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-2xl font-bold text-sm hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95">
-                            <i data-lucide="save" class="w-4 h-4"></i> 저장하기
-                        </button>
-                    </div>
+            <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm flex items-center justify-between">
+                <div>
+                    <h2 class="text-2xl font-bold text-slate-900" th:text="${isNew ? '새 이력서 작성' : '이력서 수정'}">제목</h2>
+                    <p class="text-sm text-slate-400">정보를 입력하고 저장하기를 눌러주세요.</p>
+                </div>
+                <div class="flex gap-3">
+                    <a th:href="@{/resume}" class="px-6 py-3 text-slate-400 font-bold text-sm hover:text-slate-600 transition-all">취소</a>
+                    <button type="submit" form="profileForm"
+                            class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95">
+                        <i data-lucide="save" class="w-4 h-4 inline-block mr-2"></i>저장하기
+                    </button>
                 </div>
             </div>
 
-            <!-- ===== 메인 폼 ===== -->
-            <form id="profileForm"
-                  th:with="formAction=${isNew} ? '/resume/new' : '/resume/edit'"
-                  th:action="@{${formAction}}"
-                  th:object="${resumeForm}" method="post" class="space-y-6">
+            <form id="profileForm" th:action="${isNew ? '/resume/new' : '/resume/edit'}" th:object="${resumeForm}" method="post" class="space-y-8">
 
-                <!-- 글로벌 에러 -->
-                <div th:if="${#fields.hasGlobalErrors()}"
-                     class="bg-red-50 border border-red-200 rounded-2xl px-6 py-4">
-                    <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"
-                       class="text-sm text-red-600 font-medium"></p>
-                </div>
-
-                <!-- ===== 공개 및 추천 설정 ===== -->
-                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                <section class="space-y-5">
                     <h3 class="text-base font-bold text-slate-700">공개 및 추천 설정</h3>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-
-                        <!-- 프로필 공개 여부 -->
-                        <label class="flex items-center justify-between p-5 border border-slate-200 rounded-2xl transition-all"
-                               :class="editing ? 'cursor-pointer hover:border-blue-300' : 'cursor-default'">
+                        <label class="flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all">
                             <div class="space-y-1">
-                                <div class="flex items-center gap-2">
+                                <div class="flex items-center gap-3">
                                     <i data-lucide="eye" class="w-5 h-5 text-slate-400"></i>
-                                    <span class="text-sm font-bold text-slate-800">프로필 공개 여부</span>
+                                    <span class="text-sm font-bold text-slate-800">프로필 공개</span>
                                 </div>
-                                <p class="text-xs text-slate-400 ml-7">검색 결과 및 리스트에 내 프로필이 노출됩니다.</p>
+                                <p class="text-xs text-slate-400 ml-8">검색 결과에 노출됩니다.</p>
                             </div>
-                            <div class="relative flex-shrink-0 ml-4" :class="editing ? '' : 'pointer-events-none'">
+                            <div class="relative">
                                 <input type="checkbox" th:field="*{publiclyVisible}" class="sr-only peer">
                                 <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
                                 <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
                             </div>
                         </label>
-
-                        <!-- AI 추천 포함 여부 -->
-                        <label class="flex items-center justify-between p-5 border border-slate-200 rounded-2xl transition-all"
-                               :class="editing ? 'cursor-pointer hover:border-blue-300' : 'cursor-default'">
+                        <label class="flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all">
                             <div class="space-y-1">
-                                <div class="flex items-center gap-2">
+                                <div class="flex items-center gap-3">
                                     <i data-lucide="zap" class="w-5 h-5 text-slate-400"></i>
-                                    <span class="text-sm font-bold text-slate-800">AI 추천 포함 여부</span>
+                                    <span class="text-sm font-bold text-slate-800">AI 추천 포함</span>
                                 </div>
-                                <p class="text-xs text-slate-400 ml-7">클라이언트에게 AI 추천 후보로 제안됩니다.</p>
-                                <p class="text-xs text-slate-300 ml-7">* 직접 지원은 이 설정과 무관하게 언제나 가능합니다.</p>
+                                <p class="text-xs text-slate-400 ml-8">AI 매칭 후보로 제안됩니다.</p>
                             </div>
-                            <div class="relative flex-shrink-0 ml-4" :class="editing ? '' : 'pointer-events-none'">
+                            <div class="relative">
                                 <input type="checkbox" th:field="*{aiMatchingEnabled}" class="sr-only peer">
                                 <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
                                 <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
@@ -133,264 +60,36 @@
                     </div>
                 </section>
 
-                <!-- ===== 자기소개 ===== -->
-                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-4">
-                    <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
-                        <i data-lucide="message-square" class="w-5 h-5 text-blue-500"></i> 자기소개
-                    </h3>
-                    <!-- 읽기 전용 -->
-                    <p x-show="!editing"
-                       class="text-sm text-slate-600 leading-relaxed min-h-[80px] whitespace-pre-wrap"
-                       th:text="${resumeForm.introduction}"></p>
-                    <!-- 편집 모드 -->
-                    <textarea x-show="editing"
-                              th:field="*{introduction}" rows="5"
-                              class="w-full p-5 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all resize-none"
-                              placeholder="본인의 전문성을 나타낼 수 있는 소개글을 작성해주세요."></textarea>
-                    <span th:if="${#fields.hasErrors('introduction')}" th:errors="*{introduction}"
-                          class="text-red-500 text-xs"></span>
+                <section class="space-y-4">
+                    <h3 class="text-base font-bold text-slate-700">자기소개</h3>
+                    <textarea th:field="*{introduction}" rows="6"
+                              class="w-full p-6 bg-white border border-slate-200 rounded-2xl text-sm focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all resize-none"></textarea>
                 </section>
 
-                <!-- ===== 선호 근무 형태 및 연락처 ===== -->
-                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-6">
-                    <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
-                        <i data-lucide="briefcase" class="w-5 h-5 text-blue-500"></i> 선호 근무 형태 및 연락처
-                    </h3>
+                <section class="space-y-6">
+                    <h3 class="text-base font-bold text-slate-700">근무 형태 및 연락처</h3>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-
-                        <!-- 경력 연차 -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">경력 연차</label>
-                            <!-- 읽기 -->
-                            <div x-show="!editing"
-                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
-                                <span th:text="${resumeForm.careerYears != null ? resumeForm.careerYears + '년' : '-'}"></span>
-                            </div>
-                            <!-- 편집 -->
-                            <input x-show="editing" type="number" th:field="*{careerYears}" min="0" max="50"
-                                   class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all">
-                            <span th:if="${#fields.hasErrors('careerYears')}" th:errors="*{careerYears}"
-                                  class="text-red-500 text-xs ml-1"></span>
+                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">경력 연차</label>
+                            <input type="number" th:field="*{careerYears}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm">
                         </div>
-
-                        <!-- 근무 방식 -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">근무 방식</label>
-                            <!-- 읽기 -->
-                            <div x-show="!editing"
-                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
-                                <span th:text="${resumeForm.preferredWorkType != null ? resumeForm.preferredWorkType.description : '-'}"></span>
-                            </div>
-                            <!-- 편집 -->
-                            <select x-show="editing" th:field="*{preferredWorkType}"
-                                    class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all appearance-none">
+                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">근무 방식</label>
+                            <select th:field="*{preferredWorkType}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm appearance-none">
                                 <option value="">선택 안함</option>
                                 <option th:each="wt : ${workTypes}" th:value="${wt}" th:text="${wt.description}"></option>
                             </select>
                         </div>
-
-                        <!-- 작성 상태 -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">작성 상태</label>
-                            <!-- 읽기 -->
-                            <div x-show="!editing"
-                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
-                                <span th:text="${resumeForm.writingStatus != null ? resumeForm.writingStatus.description : '-'}"></span>
-                            </div>
-                            <!-- 편집 -->
-                            <select x-show="editing" th:field="*{writingStatus}"
-                                    class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all appearance-none">
+                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">작성 상태</label>
+                            <select th:field="*{writingStatus}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm appearance-none">
                                 <option th:each="ws : ${writingStatuses}" th:value="${ws}" th:text="${ws.description}"></option>
                             </select>
-                            <span th:if="${#fields.hasErrors('writingStatus')}" th:errors="*{writingStatus}"
-                                  class="text-red-500 text-xs ml-1"></span>
-                        </div>
-
-                        <!-- 이메일 (항상 읽기 전용) -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">이메일</label>
-                            <div class="relative">
-                                <i data-lucide="mail" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
-                                <input type="text" th:value="${memberEmail}" readonly
-                                       class="w-full pl-11 pr-4 py-4 bg-slate-100 border border-slate-100 rounded-2xl text-sm text-slate-400 cursor-not-allowed">
-                            </div>
-                        </div>
-
-                        <!-- 연락처 (항상 읽기 전용) -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">연락처</label>
-                            <div class="relative">
-                                <i data-lucide="phone" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
-                                <input type="text" th:value="${memberPhone}" readonly
-                                       class="w-full pl-11 pr-4 py-4 bg-slate-100 border border-slate-100 rounded-2xl text-sm text-slate-400 cursor-not-allowed">
-                            </div>
-                        </div>
-
-                        <!-- 포트폴리오 URL -->
-                        <div class="space-y-2">
-                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">포트폴리오 URL</label>
-                            <!-- 읽기 -->
-                            <div x-show="!editing" class="relative">
-                                <i data-lucide="link" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
-                                <div class="pl-11 pr-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium truncate"
-                                     th:text="${resumeForm.portfolioUrl != null ? resumeForm.portfolioUrl : '-'}"></div>
-                            </div>
-                            <!-- 편집 -->
-                            <div x-show="editing" class="relative">
-                                <i data-lucide="link" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
-                                <input type="text" th:field="*{portfolioUrl}" placeholder="https://..."
-                                       class="w-full pl-11 pr-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all">
-                            </div>
                         </div>
                     </div>
                 </section>
-
-                <!-- hidden -->
                 <input type="hidden" th:if="${resumeForm.career != null}" th:field="*{career.version}">
-
             </form>
-
-            <!-- ===== 보유 스킬 ===== -->
-            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
-                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
-                    <i data-lucide="code-2" class="w-5 h-5 text-blue-500"></i> 보유 스킬
-                </h3>
-
-                <!-- 스킬 태그 목록 -->
-                <div class="flex flex-wrap gap-2">
-                    <th:block th:if="${resume != null}">
-                        <th:block th:each="rs : ${resume.skills}">
-                            <!-- 편집 모드: 삭제 버튼 있는 폼 -->
-                            <form x-show="editing"
-                                  th:action="@{/resume/skill/remove}" method="post"
-                                  class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-blue-50 border border-blue-100 rounded-xl text-sm font-semibold text-blue-700 hover:border-red-200 hover:bg-red-50 hover:text-red-600 group transition-all">
-                                <input type="hidden" name="skillId" th:value="${rs.skill.id}">
-                                <span th:text="${rs.skill.name}"></span>
-                                <span class="text-xs opacity-60" th:text="${rs.proficiency.description}"></span>
-                                <button type="submit" class="ml-1 opacity-50 group-hover:opacity-100 transition-opacity">
-                                    <i data-lucide="x" class="w-3 h-3"></i>
-                                </button>
-                            </form>
-                            <!-- 읽기 모드: 태그만 표시 -->
-                            <span x-show="!editing"
-                                  class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-blue-50 border border-blue-100 rounded-xl text-sm font-semibold text-blue-700">
-                                <span th:text="${rs.skill.name}"></span>
-                                <span class="text-xs opacity-60" th:text="${rs.proficiency.description}"></span>
-                            </span>
-                        </th:block>
-                    </th:block>
-                    <p th:if="${resume == null or (resume != null and #lists.isEmpty(resume.skills))}"
-                       class="text-sm text-slate-400 italic">등록된 기술 스택이 없습니다.</p>
-                </div>
-
-                <!-- 스킬 추가 폼: 편집 모드에서만 표시 -->
-                <form x-show="editing"
-                      th:action="@{/resume/skill/add}" th:object="${resumeSkillForm}" method="post"
-                      class="flex flex-wrap gap-3 pt-4 border-t border-slate-100">
-                    <div class="flex-1 min-w-[180px]">
-                        <select th:field="*{skillId}"
-                                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 transition-all appearance-none">
-                            <option value="">스킬 선택</option>
-                            <option th:each="skill : ${skills}" th:value="${skill.id}" th:text="${skill.name}"></option>
-                        </select>
-                    </div>
-                    <div class="flex-1 min-w-[140px]">
-                        <select th:field="*{proficiency}"
-                                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 transition-all appearance-none">
-                            <option value="">숙련도 선택</option>
-                            <option th:each="p : ${proficiencies}" th:value="${p}" th:text="${p.description}"></option>
-                        </select>
-                    </div>
-                    <button type="submit"
-                            class="inline-flex items-center gap-2 px-5 py-3 bg-blue-600 text-white rounded-2xl text-sm font-bold hover:bg-blue-700 transition-all active:scale-95 flex-shrink-0">
-                        <i data-lucide="plus" class="w-4 h-4"></i> 추가
-                    </button>
-                </form>
-            </section>
-
-            <!-- ===== 경력 사항 ===== -->
-            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
-                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
-                    <i data-lucide="building-2" class="w-5 h-5 text-blue-500"></i> 경력 사항
-                </h3>
-                <th:block th:if="${resume != null and resume.career != null and not #lists.isEmpty(resume.career.items)}">
-                    <th:block th:each="item : ${resume.career.items}">
-                        <div class="border border-slate-200 rounded-2xl p-6 space-y-2 hover:border-blue-200 transition-all">
-                            <div class="flex items-center justify-between">
-                                <span class="font-bold text-slate-800" th:text="${item.companyName}">회사명</span>
-                                <span class="text-xs text-slate-400"
-                                      th:text="${item.currentlyWorking} ? (${item.startYearMonth} + ' - 현재') : (${item.startYearMonth} + ' - ' + ${item.endYearMonth})">기간</span>
-                            </div>
-                            <p class="text-sm font-semibold text-blue-600" th:text="${item.position}">직무</p>
-                            <p class="text-sm text-slate-500" th:if="${item.summary != null}" th:text="${item.summary}">요약</p>
-                        </div>
-                    </th:block>
-                </th:block>
-                <p th:if="${resume == null or resume.career == null or #lists.isEmpty(resume.career.items)}"
-                   class="text-sm text-slate-400 italic">등록된 경력 사항이 없습니다.</p>
-            </section>
-
-            <!-- ===== 포트폴리오 / 첨부 파일 ===== -->
-            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
-                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
-                    <i data-lucide="paperclip" class="w-5 h-5 text-blue-500"></i> 포트폴리오 / 첨부 파일
-                </h3>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <th:block th:if="${resume != null and not #lists.isEmpty(resume.attachments)}">
-                        <th:block th:each="att : ${resume.attachments}">
-                            <div class="flex items-center justify-between p-4 border border-slate-200 rounded-2xl bg-slate-50 hover:border-blue-200 transition-all">
-                                <div class="flex items-center gap-3">
-                                    <i data-lucide="file-text" class="w-5 h-5 text-slate-400 flex-shrink-0"></i>
-                                    <p class="text-sm font-semibold text-slate-700 truncate" th:text="${att.file.originalName}">파일명</p>
-                                </div>
-                                <button x-show="editing" type="button" class="text-slate-300 hover:text-red-400 transition-colors flex-shrink-0 ml-3">
-                                    <i data-lucide="trash-2" class="w-4 h-4"></i>
-                                </button>
-                            </div>
-                        </th:block>
-                    </th:block>
-                    <p th:if="${resume == null or #lists.isEmpty(resume.attachments)}"
-                       class="text-sm text-slate-400 italic col-span-2">등록된 첨부 파일이 없습니다.</p>
-                </div>
-            </section>
-
-            <!-- ===== DANGER ZONE ===== -->
-            <div class="border border-red-200 rounded-3xl overflow-hidden bg-white shadow-sm">
-                <div class="px-8 py-4 border-b border-red-100 bg-red-50/30">
-                    <h3 class="text-red-600 font-bold text-base tracking-tight">DANGER ZONE</h3>
-                </div>
-                <div class="divide-y divide-red-100">
-                    <div class="p-6 flex items-center justify-between">
-                        <div>
-                            <h4 class="text-slate-800 font-bold mb-1">이력서 활성화 상태 변경</h4>
-                            <div class="flex items-center gap-2 mb-1">
-                                <span class="text-sm text-slate-500">현재 상태:</span>
-                                <span th:if="${resume != null and resume?.status?.name() == 'ACTIVE'}"
-                                      class="text-sm font-bold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">활성</span>
-                                <span th:if="${resume == null or resume?.status?.name() != 'ACTIVE'}" ...>
-                                      class="text-sm font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded-full">비활성</span>
-                            </div>
-                            <p class="text-xs text-slate-400">비활성화 시 클라이언트 검색 결과에서 제외되며 AI 추천 대상에서 빠지게 됩니다.</p>
-                        </div>
-                        <button type="button"
-                                class="border border-red-200 text-red-500 px-5 py-2.5 rounded-xl font-bold text-sm hover:bg-red-50 transition-all active:scale-95 whitespace-nowrap">
-                            이력서 비활성화
-                        </button>
-                    </div>
-                    <div class="p-6 flex items-center justify-between">
-                        <div>
-                            <h4 class="text-red-600 font-bold mb-1">이력서 삭제</h4>
-                            <p class="text-sm text-slate-500 mb-1">이 이력서의 모든 정보, 경력 사항, 포트폴리오 데이터가 영구적으로 삭제됩니다.</p>
-                            <p class="text-xs text-red-400 font-medium italic">이 작업은 되돌릴 수 없습니다. 신중하게 결정해 주세요.</p>
-                        </div>
-                        <button type="button"
-                                class="bg-red-600 text-white px-5 py-2.5 rounded-xl font-bold text-sm hover:bg-red-700 shadow-lg shadow-red-200 transition-all active:scale-95 whitespace-nowrap">
-                            이력서 삭제하기
-                        </button>
-                    </div>
-                </div>
-            </div>
-
         </div>
     </main>
 </div>

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -258,8 +258,15 @@
 
                                     <!-- 읽기 전용: 숙련도 텍스트 -->
                                     <span th:if="${!isEditing}"
-                                          class="text-xs text-slate-400 bg-white rounded-lg px-2 py-0.5 border border-slate-200"
-                                          th:text="${rs.proficiency.description}">중급</span>
+                                          class="text-xs font-bold px-2 py-0.5 rounded-lg border transition-colors"
+                                          th:text="${rs.proficiency.description}"
+                                          th:classappend="${
+                                              rs.proficiency.name() == 'BEGINNER' ? 'bg-emerald-50 text-emerald-600 border-emerald-200' :
+                                              rs.proficiency.name() == 'INTERMEDIATE' ? 'bg-blue-50 text-blue-600 border-blue-200' :
+                                              rs.proficiency.name() == 'ADVANCED' ? 'bg-amber-50 text-amber-600 border-amber-200' :
+                                              'bg-slate-50 text-slate-400 border-slate-200'
+                                          }">중급
+                                    </span>
 
                                     <!-- 편집 모드: 삭제 버튼 (AJAX) -->
                                     <th:block th:if="${isEditing}">

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -3,95 +3,312 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-    <title>프로필 편집 | IT-da</title>
+    <title>이력서 관리 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
-    <main class="min-h-screen bg-slate-50 py-10 px-6">
-        <div class="max-w-4xl mx-auto space-y-8">
+    <!--
+        isEditing 로컬 변수:
+          isNew=true                        → 신규 작성, 항상 편집 가능
+          isNew=false + editable=true       → ?mode=modify, 편집 모드
+          isNew=false + editable=false/null → 기본, 읽기 전용
+    -->
+    <div th:with="isEditing=${isNew eq true or editable eq true}">
+        <main class="min-h-screen bg-slate-50 py-10 px-6">
+            <div class="max-w-4xl mx-auto space-y-6">
 
-            <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm flex items-center justify-between">
-                <div>
-                    <h2 class="text-2xl font-bold text-slate-900" th:text="${isNew ? '새 이력서 작성' : '이력서 수정'}">제목</h2>
-                    <p class="text-sm text-slate-400">정보를 입력하고 저장하기를 눌러주세요.</p>
+                <!-- ===== 프로필 헤더 카드 ===== -->
+                <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm">
+                    <div class="flex items-center justify-between flex-wrap gap-4">
+
+                        <!-- 프로필 정보 -->
+                        <div class="flex items-center gap-5">
+                            <div class="w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl flex items-center justify-center shadow-lg flex-shrink-0">
+                                <span class="text-white text-2xl font-bold"
+                                      th:text="${(memberName != null and !#strings.isEmpty(memberName)) ? #strings.substring(memberName,0,1) : '?'}">이</span>
+                            </div>
+                            <div>
+                                <h2 class="text-xl font-bold text-slate-900" th:text="${memberName}">이름</h2>
+                                <p class="text-sm text-slate-400" th:text="${memberEmail}">email@example.com</p>
+                                <p class="text-sm text-slate-400" th:text="${memberPhone}">010-0000-0000</p>
+                            </div>
+                        </div>
+
+                        <!-- 액션 버튼 -->
+                        <div class="flex items-center gap-3">
+
+                            <!-- [신규 작성] 저장하기만 -->
+                            <th:block th:if="${isNew eq true}">
+                                <button type="submit" form="profileForm"
+                                        class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95 flex items-center gap-2">
+                                    <i data-lucide="save" class="w-4 h-4"></i>저장하기
+                                </button>
+                            </th:block>
+
+                            <!-- [기존 이력서 - 읽기 전용] 수정하기 -->
+                            <th:block th:if="${isNew eq false and isEditing eq false}">
+                                <a th:href="@{/resume/edit(mode='modify')}"
+                                   class="bg-white border border-slate-300 text-slate-700 px-8 py-3 rounded-2xl font-bold text-sm hover:border-blue-400 hover:text-blue-600 transition-all inline-flex items-center gap-2">
+                                    <i data-lucide="pencil" class="w-4 h-4"></i>수정하기
+                                </a>
+                            </th:block>
+
+                            <!-- [기존 이력서 - 편집 모드] 취소 + 저장하기 -->
+                            <th:block th:if="${isNew eq false and isEditing eq true}">
+                                <a th:href="@{/resume/edit}"
+                                   class="px-6 py-3 text-slate-500 font-bold text-sm hover:text-slate-700 transition-all">취소</a>
+                                <button type="submit" form="profileForm"
+                                        class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95 flex items-center gap-2">
+                                    <i data-lucide="save" class="w-4 h-4"></i>저장하기
+                                </button>
+                            </th:block>
+
+                        </div>
+                    </div>
                 </div>
-                <div class="flex gap-3">
-                    <a th:href="@{/resume}" class="px-6 py-3 text-slate-400 font-bold text-sm hover:text-slate-600 transition-all">취소</a>
-                    <button type="submit" form="profileForm"
-                            class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95">
-                        <i data-lucide="save" class="w-4 h-4 inline-block mr-2"></i>저장하기
-                    </button>
+
+                <!-- ===== 메인 폼 ===== -->
+                <form id="profileForm"
+                      th:action="${isNew eq true ? '/resume/new' : '/resume/edit'}"
+                      th:object="${resumeForm}"
+                      method="post"
+                      class="space-y-6">
+
+                    <!-- 전역 오류 -->
+                    <div th:if="${#fields.hasGlobalErrors()}"
+                         class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-2xl px-5 py-4">
+                        <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+                    </div>
+
+                    <!-- ===== 공개 및 AI 추천 설정 ===== -->
+                    <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                        <h3 class="text-base font-bold text-slate-700">공개 및 추천 설정</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+                            <!-- 프로필 공개 토글 -->
+                            <label th:class="${isEditing}
+                                        ? 'flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all'
+                                        : 'flex items-center justify-between p-6 border border-slate-100 rounded-2xl bg-slate-50 cursor-default'">
+                                <div class="space-y-1">
+                                    <div class="flex items-center gap-3">
+                                        <i data-lucide="eye" class="w-5 h-5 text-slate-400"></i>
+                                        <span class="text-sm font-bold text-slate-800">프로필 공개</span>
+                                    </div>
+                                    <p class="text-xs text-slate-400 ml-8">검색 결과에 노출됩니다.</p>
+                                </div>
+                                <div class="relative">
+                                    <input type="checkbox" th:field="*{publiclyVisible}"
+                                           th:disabled="${!isEditing}"
+                                           class="sr-only peer">
+                                    <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
+                                    <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5 pointer-events-none"></div>
+                                </div>
+                            </label>
+
+                            <!-- AI 추천 토글 -->
+                            <label th:class="${isEditing}
+                                        ? 'flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all'
+                                        : 'flex items-center justify-between p-6 border border-slate-100 rounded-2xl bg-slate-50 cursor-default'">
+                                <div class="space-y-1">
+                                    <div class="flex items-center gap-3">
+                                        <i data-lucide="zap" class="w-5 h-5 text-slate-400"></i>
+                                        <span class="text-sm font-bold text-slate-800">AI 추천 포함</span>
+                                    </div>
+                                    <p class="text-xs text-slate-400 ml-8">AI 매칭 후보로 제안됩니다.</p>
+                                </div>
+                                <div class="relative">
+                                    <input type="checkbox" th:field="*{aiMatchingEnabled}"
+                                           th:disabled="${!isEditing}"
+                                           class="sr-only peer">
+                                    <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
+                                    <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5 pointer-events-none"></div>
+                                </div>
+                            </label>
+
+                        </div>
+                    </div>
+
+                    <!-- ===== 자기소개 ===== -->
+                    <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-4">
+                        <h3 class="text-base font-bold text-slate-700">자기소개</h3>
+                        <textarea th:field="*{introduction}"
+                                  rows="6"
+                                  th:readonly="${!isEditing}"
+                                  placeholder="자신을 소개해주세요."
+                                  th:class="${isEditing}
+                                      ? 'w-full p-5 bg-white border border-slate-200 rounded-2xl text-sm focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all resize-none outline-none'
+                                      : 'w-full p-5 bg-slate-50 border border-slate-100 rounded-2xl text-sm resize-none text-slate-700 outline-none cursor-default'">
+                        </textarea>
+                        <p th:if="${#fields.hasErrors('introduction')}"
+                           class="text-xs text-red-500"
+                           th:errors="*{introduction}"></p>
+                    </div>
+
+                    <!-- ===== 근무 형태 및 정보 ===== -->
+                    <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                        <h3 class="text-base font-bold text-slate-700">근무 형태 및 정보</h3>
+
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+                            <!-- 경력 연차 -->
+                            <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                                <label class="text-xs font-bold text-slate-400 uppercase tracking-wide mb-2 block">경력 연차</label>
+                                <input type="number"
+                                       th:field="*{careerYears}"
+                                       th:readonly="${!isEditing}"
+                                       min="0" max="50"
+                                       th:class="${isEditing}
+                                           ? 'w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none'
+                                           : 'w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm text-slate-700 cursor-default'">
+                                <p th:if="${#fields.hasErrors('careerYears')}"
+                                   class="text-xs text-red-500 mt-1"
+                                   th:errors="*{careerYears}"></p>
+                            </div>
+
+                            <!-- 근무 방식 -->
+                            <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                                <label class="text-xs font-bold text-slate-400 uppercase tracking-wide mb-2 block">근무 방식</label>
+                                <!-- 읽기 전용: 텍스트 표시 -->
+                                <div th:if="${!isEditing}"
+                                     class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm text-slate-700"
+                                     th:text="${resumeForm.preferredWorkType != null ? resumeForm.preferredWorkType.description : '선택 안함'}">상주</div>
+                                <!-- 편집 모드: select -->
+                                <select th:if="${isEditing}"
+                                        th:field="*{preferredWorkType}"
+                                        class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                    <option value="">선택 안함</option>
+                                    <option th:each="wt : ${workTypes}"
+                                            th:value="${wt}"
+                                            th:text="${wt.description}"></option>
+                                </select>
+                            </div>
+
+                            <!-- 작성 상태 -->
+                            <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                                <label class="text-xs font-bold text-slate-400 uppercase tracking-wide mb-2 block">작성 상태</label>
+                                <!-- 읽기 전용: 텍스트 표시 -->
+                                <div th:if="${!isEditing}"
+                                     class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm text-slate-700"
+                                     th:text="${resumeForm.writingStatus != null ? resumeForm.writingStatus.description : ''}">작성 중</div>
+                                <!-- 편집 모드: select -->
+                                <select th:if="${isEditing}"
+                                        th:field="*{writingStatus}"
+                                        class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                    <option th:each="ws : ${writingStatuses}"
+                                            th:value="${ws}"
+                                            th:text="${ws.description}"></option>
+                                </select>
+                                <p th:if="${#fields.hasErrors('writingStatus')}"
+                                   class="text-xs text-red-500 mt-1"
+                                   th:errors="*{writingStatus}"></p>
+                            </div>
+
+                        </div>
+
+                        <!-- 포트폴리오 URL -->
+                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wide mb-2 block">포트폴리오 URL</label>
+                            <input type="text"
+                                   th:field="*{portfolioUrl}"
+                                   th:readonly="${!isEditing}"
+                                   placeholder="https://..."
+                                   th:class="${isEditing}
+                                       ? 'w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none'
+                                       : 'w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm text-slate-700 cursor-default'">
+                        </div>
+
+                    </div>
+
+                    <!-- career.version (Bean Validation 통과용 hidden) -->
+                    <input type="hidden" th:field="*{career.version}">
+
+                </form>
+
+                <!-- ===== 기술 스택 (폼 외부 — 별도 POST) ===== -->
+                <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                    <h3 class="text-base font-bold text-slate-700">기술 스택</h3>
+
+                    <!-- 신규: 이력서 저장 전 안내 -->
+                    <th:block th:if="${resume == null}">
+                        <p class="text-sm text-slate-400">이력서를 먼저 저장한 후 스킬을 등록할 수 있습니다.</p>
+                    </th:block>
+
+                    <!-- 기존 이력서: 스킬 목록 -->
+                    <th:block th:if="${resume != null}">
+
+                        <div th:if="${!resume.skills.isEmpty()}" class="flex flex-wrap gap-3">
+                            <th:block th:each="rs : ${resume.skills}">
+                                <div class="flex items-center gap-2 bg-slate-100 rounded-xl px-4 py-2.5">
+                                    <span class="text-sm font-semibold text-slate-700"
+                                          th:text="${rs.skill.name}">스킬명</span>
+                                    <span class="text-xs text-slate-400 bg-white rounded-lg px-2 py-0.5 border border-slate-200"
+                                          th:text="${rs.proficiency.description}">중급</span>
+                                    <!-- 삭제 버튼: 편집 모드에서만 -->
+                                    <th:block th:if="${isEditing}">
+                                        <form th:action="@{/resume/skill/remove}" method="post" class="inline">
+                                            <input type="hidden" name="skillId" th:value="${rs.skill.id}">
+                                            <button type="submit"
+                                                    class="text-slate-300 hover:text-red-400 transition-colors ml-1 flex items-center">
+                                                <i data-lucide="x" class="w-3 h-3"></i>
+                                            </button>
+                                        </form>
+                                    </th:block>
+                                </div>
+                            </th:block>
+                        </div>
+
+                        <p th:if="${resume.skills.isEmpty()}"
+                           class="text-sm text-slate-400">등록된 스킬이 없습니다.</p>
+
+                        <!-- 스킬 추가 폼: 편집 모드에서만 -->
+                        <div th:if="${isEditing}" class="border-t border-slate-100 pt-5">
+                            <form th:action="@{/resume/skill/add}"
+                                  th:object="${resumeSkillForm}"
+                                  method="post"
+                                  class="flex flex-wrap gap-3 items-end">
+
+                                <div class="flex-1 min-w-[160px]">
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">스킬 선택</label>
+                                    <select th:field="*{skillId}"
+                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                        <option value="">스킬 선택</option>
+                                        <option th:each="skill : ${skills}"
+                                                th:value="${skill.id}"
+                                                th:text="${skill.name}"></option>
+                                    </select>
+                                    <p th:if="${#fields.hasErrors('skillId')}"
+                                       class="text-xs text-red-500 mt-1"
+                                       th:errors="*{skillId}"></p>
+                                </div>
+
+                                <div class="flex-1 min-w-[120px]">
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">숙련도</label>
+                                    <select th:field="*{proficiency}"
+                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                        <option value="">선택</option>
+                                        <option th:each="p : ${proficiencies}"
+                                                th:value="${p}"
+                                                th:text="${p.description}"></option>
+                                    </select>
+                                    <p th:if="${#fields.hasErrors('proficiency')}"
+                                       class="text-xs text-red-500 mt-1"
+                                       th:errors="*{proficiency}"></p>
+                                </div>
+
+                                <button type="submit"
+                                        class="px-6 py-3 bg-slate-800 text-white text-sm font-bold rounded-xl hover:bg-slate-700 transition-all active:scale-95">
+                                    + 추가
+                                </button>
+
+                            </form>
+                        </div>
+
+                    </th:block>
                 </div>
+
             </div>
-
-            <form id="profileForm" th:action="${isNew ? '/resume/new' : '/resume/edit'}" th:object="${resumeForm}" method="post" class="space-y-8">
-
-                <section class="space-y-5">
-                    <h3 class="text-base font-bold text-slate-700">공개 및 추천 설정</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <label class="flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all">
-                            <div class="space-y-1">
-                                <div class="flex items-center gap-3">
-                                    <i data-lucide="eye" class="w-5 h-5 text-slate-400"></i>
-                                    <span class="text-sm font-bold text-slate-800">프로필 공개</span>
-                                </div>
-                                <p class="text-xs text-slate-400 ml-8">검색 결과에 노출됩니다.</p>
-                            </div>
-                            <div class="relative">
-                                <input type="checkbox" th:field="*{publiclyVisible}" class="sr-only peer">
-                                <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
-                                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
-                            </div>
-                        </label>
-                        <label class="flex items-center justify-between p-6 border border-slate-200 rounded-2xl bg-white shadow-sm cursor-pointer hover:border-blue-300 transition-all">
-                            <div class="space-y-1">
-                                <div class="flex items-center gap-3">
-                                    <i data-lucide="zap" class="w-5 h-5 text-slate-400"></i>
-                                    <span class="text-sm font-bold text-slate-800">AI 추천 포함</span>
-                                </div>
-                                <p class="text-xs text-slate-400 ml-8">AI 매칭 후보로 제안됩니다.</p>
-                            </div>
-                            <div class="relative">
-                                <input type="checkbox" th:field="*{aiMatchingEnabled}" class="sr-only peer">
-                                <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
-                                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
-                            </div>
-                        </label>
-                    </div>
-                </section>
-
-                <section class="space-y-4">
-                    <h3 class="text-base font-bold text-slate-700">자기소개</h3>
-                    <textarea th:field="*{introduction}" rows="6"
-                              class="w-full p-6 bg-white border border-slate-200 rounded-2xl text-sm focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all resize-none"></textarea>
-                </section>
-
-                <section class="space-y-6">
-                    <h3 class="text-base font-bold text-slate-700">근무 형태 및 연락처</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
-                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">경력 연차</label>
-                            <input type="number" th:field="*{careerYears}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm">
-                        </div>
-                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
-                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">근무 방식</label>
-                            <select th:field="*{preferredWorkType}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm appearance-none">
-                                <option value="">선택 안함</option>
-                                <option th:each="wt : ${workTypes}" th:value="${wt}" th:text="${wt.description}"></option>
-                            </select>
-                        </div>
-                        <div class="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
-                            <label class="text-xs font-bold text-slate-400 uppercase ml-1 mb-2 block">작성 상태</label>
-                            <select th:field="*{writingStatus}" class="w-full p-3 bg-slate-50 border border-slate-100 rounded-xl text-sm appearance-none">
-                                <option th:each="ws : ${writingStatuses}" th:value="${ws}" th:text="${ws.description}"></option>
-                            </select>
-                        </div>
-                    </div>
-                </section>
-                <input type="hidden" th:if="${resumeForm.career != null}" th:field="*{career.version}">
-            </form>
-        </div>
-    </main>
+        </main>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -47,7 +47,7 @@
 
                             <!-- [기존 이력서 - 읽기 전용] 수정하기 -->
                             <th:block th:if="${isNew eq false and isEditing eq false}">
-                                <a th:href="@{/resume/edit(mode='modify')}"
+                                <a th:href="@{/resumes/edit}"
                                    class="bg-white border border-slate-300 text-slate-700 px-8 py-3 rounded-2xl font-bold text-sm hover:border-blue-400 hover:text-blue-600 transition-all inline-flex items-center gap-2">
                                     <i data-lucide="pencil" class="w-4 h-4"></i>수정하기
                                 </a>
@@ -55,7 +55,7 @@
 
                             <!-- [기존 이력서 - 편집 모드] 취소 + 저장하기 -->
                             <th:block th:if="${isNew eq false and isEditing eq true}">
-                                <a th:href="@{/resume/edit}"
+                                <a th:href="@{/resumes/me}"
                                    class="px-6 py-3 text-slate-500 font-bold text-sm hover:text-slate-700 transition-all">취소</a>
                                 <button type="submit" form="profileForm"
                                         class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95 flex items-center gap-2">
@@ -69,7 +69,7 @@
 
                 <!-- ===== 메인 폼 ===== -->
                 <form id="profileForm"
-                      th:action="${isNew eq true ? '/resume/new' : '/resume/edit'}"
+                      th:action="${isNew eq true ? '/resumes/new' : '/resumes/edit'}"
                       th:object="${resumeForm}"
                       method="post"
                       class="space-y-6">
@@ -224,8 +224,8 @@
 
                 </form>
 
-                <!-- ===== 기술 스택 (폼 외부 — 별도 POST) ===== -->
-                <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                <!-- ===== 기술 스택 (AJAX — 별도 POST, #skillSection 전체 교체) ===== -->
+                <div id="skillSection" class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
                     <h3 class="text-base font-bold text-slate-700">기술 스택</h3>
 
                     <!-- 신규: 이력서 저장 전 안내 -->
@@ -239,13 +239,31 @@
                         <div th:if="${!resume.skills.isEmpty()}" class="flex flex-wrap gap-3">
                             <th:block th:each="rs : ${resume.skills}">
                                 <div class="flex items-center gap-2 bg-slate-100 rounded-xl px-4 py-2.5">
-                                    <span class="text-sm font-semibold text-slate-700"
-                                          th:text="${rs.skill.name}">스킬명</span>
-                                    <span class="text-xs text-slate-400 bg-white rounded-lg px-2 py-0.5 border border-slate-200"
-                                          th:text="${rs.proficiency.description}">중급</span>
-                                    <!-- 삭제 버튼: 편집 모드에서만 -->
+                                    <span class="text-sm font-semibold text-slate-700" th:text="${rs.skill.name}">스킬명</span>
+
+                                    <!-- 편집 모드: 숙련도 선택 (변경 즉시 AJAX) -->
                                     <th:block th:if="${isEditing}">
-                                        <form th:action="@{/resume/skill/remove}" method="post" class="inline">
+                                        <form th:action="@{/resumes/skill/update}" method="post" class="inline skill-update-form">
+                                            <input type="hidden" name="skillId" th:value="${rs.skill.id}">
+                                            <select name="proficiency"
+                                                    onchange="this.form.requestSubmit()"
+                                                    class="text-xs text-slate-600 bg-white rounded-lg px-2 py-0.5 border border-slate-200 focus:outline-none cursor-pointer">
+                                                <option th:each="p : ${proficiencies}"
+                                                        th:value="${p}"
+                                                        th:text="${p.description}"
+                                                        th:selected="${rs.proficiency == p}"></option>
+                                            </select>
+                                        </form>
+                                    </th:block>
+
+                                    <!-- 읽기 전용: 숙련도 텍스트 -->
+                                    <span th:if="${!isEditing}"
+                                          class="text-xs text-slate-400 bg-white rounded-lg px-2 py-0.5 border border-slate-200"
+                                          th:text="${rs.proficiency.description}">중급</span>
+
+                                    <!-- 편집 모드: 삭제 버튼 (AJAX) -->
+                                    <th:block th:if="${isEditing}">
+                                        <form th:action="@{/resumes/skill/remove}" method="post" class="inline skill-delete-form">
                                             <input type="hidden" name="skillId" th:value="${rs.skill.id}">
                                             <button type="submit"
                                                     class="text-slate-300 hover:text-red-400 transition-colors ml-1 flex items-center">
@@ -257,12 +275,12 @@
                             </th:block>
                         </div>
 
-                        <p th:if="${resume.skills.isEmpty()}"
-                           class="text-sm text-slate-400">등록된 스킬이 없습니다.</p>
+                        <p th:if="${resume.skills.isEmpty()}" class="text-sm text-slate-400">등록된 스킬이 없습니다.</p>
 
-                        <!-- 스킬 추가 폼: 편집 모드에서만 -->
+                        <!-- 스킬 추가 폼: 편집 모드에서만 (AJAX) -->
                         <div th:if="${isEditing}" class="border-t border-slate-100 pt-5">
-                            <form th:action="@{/resume/skill/add}"
+                            <form id="skillAddForm"
+                                  th:action="@{/resumes/skill/add}"
                                   th:object="${resumeSkillForm}"
                                   method="post"
                                   class="flex flex-wrap gap-3 items-end">
@@ -310,5 +328,42 @@
         </main>
     </div>
 </div>
+
+<th:block layout:fragment="scripts">
+<script>
+    /**
+     * 스킬 AJAX 처리
+     *   #skillAddForm      — 스킬 추가
+     *   .skill-delete-form — 스킬 삭제 (X 버튼)
+     *   .skill-update-form — 숙련도 변경 (select onchange → requestSubmit)
+     *
+     * 서버는 "freelancer/resumeForm :: #skillSection" fragment 반환
+     * → outerHTML 교체로 DOM 업데이트
+     */
+    document.addEventListener('submit', async function (e) {
+        const form = e.target;
+        if (!form.matches('#skillAddForm, .skill-delete-form, .skill-update-form')) return;
+
+        e.preventDefault();
+
+        try {
+            const response = await fetch(form.action, {
+                method: 'POST',
+                body: new FormData(form)
+            });
+            if (!response.ok) return;
+
+            const html = await response.text();
+            const section = document.getElementById('skillSection');
+            if (section) {
+                section.outerHTML = html;
+                if (window.lucide) lucide.createIcons();
+            }
+        } catch (err) {
+            console.error('스킬 처리 중 오류:', err);
+        }
+    });
+</script>
+</th:block>
 </body>
 </html>

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -293,31 +293,36 @@
                                   class="flex flex-wrap gap-3 items-end">
 
                                 <div class="flex-1 min-w-[160px]">
-                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">스킬 선택</label>
+                                    <div class="flex justify-between items-end mb-1.5">
+                                        <label class="text-xs font-bold text-slate-400 block">스킬 선택</label>
+                                        <span th:if="${#fields.hasErrors('skillId')}"
+                                              class="text-[10px] text-red-500 font-bold animate-pulse"
+                                              th:errors="*{skillId}">필수값입니다.</span>
+                                    </div>
                                     <select th:field="*{skillId}"
+                                            th:classappend="${#fields.hasErrors('skillId')} ? 'border-red-400 ring-1 ring-red-400/10' : ''"
                                             class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
                                         <option value="">스킬 선택</option>
-                                        <option th:each="skill : ${skills}"
-                                                th:value="${skill.id}"
-                                                th:text="${skill.name}"></option>
+                                        <option th:each="skill : ${skills}" th:value="${skill.id}" th:text="${skill.name}"></option>
                                     </select>
-                                    <p th:if="${#fields.hasErrors('skillId')}"
-                                       class="text-xs text-red-500 mt-1"
-                                       th:errors="*{skillId}"></p>
                                 </div>
 
                                 <div class="flex-1 min-w-[120px]">
-                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">숙련도</label>
+                                    <div class="flex justify-between items-end mb-1.5">
+                                        <label class="text-xs font-bold text-slate-400 block">숙련도</label>
+                                        <span th:if="${#fields.hasErrors('proficiency')}"
+                                              class="text-[10px] text-red-500 font-bold animate-pulse"
+                                              th:errors="*{proficiency}">필수값입니다.</span>
+                                    </div>
+
                                     <select th:field="*{proficiency}"
-                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                            th:classappend="${#fields.hasErrors('proficiency')} ? 'border-red-400 ring-1 ring-red-400/10' : ''"
+                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none transition-all">
                                         <option value="">선택</option>
                                         <option th:each="p : ${proficiencies}"
                                                 th:value="${p}"
                                                 th:text="${p.description}"></option>
                                     </select>
-                                    <p th:if="${#fields.hasErrors('proficiency')}"
-                                       class="text-xs text-red-500 mt-1"
-                                       th:errors="*{proficiency}"></p>
                                 </div>
 
                                 <button type="submit"

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>프로필 관리 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+
+    <!-- Alpine.js: isNew면 처음부터 editing=true, 기존 이력서면 editing=false(읽기 전용) -->
+    <main class="min-h-screen bg-slate-50 py-10 px-6"
+          th:x-data="${' { editing: ' + isNew + ' } '}"
+          x-cloak>
+        <div class="max-w-4xl mx-auto space-y-6">
+
+            <!-- ===== 헤더 ===== -->
+            <div class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm">
+                <div class="flex items-start justify-between gap-6">
+                    <!-- 프로필 사진 + 이름 + 뱃지 -->
+                    <div class="flex items-center gap-6">
+                        <div class="w-20 h-20 rounded-2xl bg-slate-100 border border-slate-200 flex items-center justify-center flex-shrink-0">
+                            <i data-lucide="camera" class="w-8 h-8 text-slate-300"></i>
+                        </div>
+                        <div class="space-y-2">
+                            <h2 class="text-2xl font-bold text-slate-900" th:text="${memberName}">이름</h2>
+                            <p class="text-sm text-slate-400" th:text="${memberEmail}">이메일</p>
+                            <!-- 상태 뱃지 (기존 이력서에서만 표시) -->
+                            <div class="flex flex-wrap items-center gap-2" th:if="${resume != null}">
+                                <span th:if="${resume.publiclyVisible}"
+                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-emerald-50 text-emerald-600 border border-emerald-100">
+                                    <i data-lucide="eye" class="w-3 h-3"></i> 공개 중
+                                </span>
+                                <span th:unless="${resume.publiclyVisible}"
+                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-slate-100 text-slate-400 border border-slate-200">
+                                    <i data-lucide="eye-off" class="w-3 h-3"></i> 비공개
+                                </span>
+                                <span th:if="${resume.aiMatchingEnabled}"
+                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-blue-50 text-blue-600 border border-blue-100">
+                                    <i data-lucide="zap" class="w-3 h-3"></i> AI 추천 포함
+                                </span>
+                                <span th:if="${resume?.writingStatus?.name() == 'DONE'}"
+                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-violet-50 text-violet-600 border border-violet-100">
+                                    <i data-lucide="file-check" class="w-3 h-3"></i> 작성 완료
+                                </span>
+                                <span th:if="${resume?.writingStatus?.name() == 'WRITING'}"
+                                      class="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
+                                    <i data-lucide="pencil" class="w-3 h-3"></i> 작성 중
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 버튼 영역 -->
+                    <div class="flex gap-3 flex-shrink-0">
+                        <!-- 수정하기 버튼: 읽기 전용 상태에서만 표시 -->
+                        <button type="button"
+                                x-show="!editing"
+                                @click="editing = true"
+                                class="inline-flex items-center gap-2 border border-slate-300 text-slate-700 px-6 py-3 rounded-2xl font-bold text-sm hover:border-blue-400 hover:text-blue-600 transition-all">
+                            <i data-lucide="pencil" class="w-4 h-4"></i> 수정하기
+                        </button>
+                        <!-- 취소 버튼: 기존 이력서(isNew=false)일 때만 렌더링, 편집 중에만 표시 -->
+                        <button type="button"
+                                th:if="${!isNew}"
+                                x-show="editing"
+                                @click="editing = false"
+                                class="inline-flex items-center gap-2 border border-slate-200 text-slate-400 px-6 py-3 rounded-2xl font-bold text-sm hover:bg-slate-50 transition-all">
+                            취소
+                        </button>
+                        <!-- 저장하기 버튼: 편집 중일 때만 표시 -->
+                        <button type="submit" form="profileForm"
+                                x-show="editing"
+                                class="inline-flex items-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-2xl font-bold text-sm hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95">
+                            <i data-lucide="save" class="w-4 h-4"></i> 저장하기
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ===== 메인 폼 ===== -->
+            <form id="profileForm"
+                  th:with="formAction=${isNew} ? '/resume/new' : '/resume/edit'"
+                  th:action="@{${formAction}}"
+                  th:object="${resumeForm}" method="post" class="space-y-6">
+
+                <!-- 글로벌 에러 -->
+                <div th:if="${#fields.hasGlobalErrors()}"
+                     class="bg-red-50 border border-red-200 rounded-2xl px-6 py-4">
+                    <p th:each="err : ${#fields.globalErrors()}" th:text="${err}"
+                       class="text-sm text-red-600 font-medium"></p>
+                </div>
+
+                <!-- ===== 공개 및 추천 설정 ===== -->
+                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                    <h3 class="text-base font-bold text-slate-700">공개 및 추천 설정</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+                        <!-- 프로필 공개 여부 -->
+                        <label class="flex items-center justify-between p-5 border border-slate-200 rounded-2xl transition-all"
+                               :class="editing ? 'cursor-pointer hover:border-blue-300' : 'cursor-default'">
+                            <div class="space-y-1">
+                                <div class="flex items-center gap-2">
+                                    <i data-lucide="eye" class="w-5 h-5 text-slate-400"></i>
+                                    <span class="text-sm font-bold text-slate-800">프로필 공개 여부</span>
+                                </div>
+                                <p class="text-xs text-slate-400 ml-7">검색 결과 및 리스트에 내 프로필이 노출됩니다.</p>
+                            </div>
+                            <div class="relative flex-shrink-0 ml-4" :class="editing ? '' : 'pointer-events-none'">
+                                <input type="checkbox" th:field="*{publiclyVisible}" class="sr-only peer">
+                                <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
+                                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
+                            </div>
+                        </label>
+
+                        <!-- AI 추천 포함 여부 -->
+                        <label class="flex items-center justify-between p-5 border border-slate-200 rounded-2xl transition-all"
+                               :class="editing ? 'cursor-pointer hover:border-blue-300' : 'cursor-default'">
+                            <div class="space-y-1">
+                                <div class="flex items-center gap-2">
+                                    <i data-lucide="zap" class="w-5 h-5 text-slate-400"></i>
+                                    <span class="text-sm font-bold text-slate-800">AI 추천 포함 여부</span>
+                                </div>
+                                <p class="text-xs text-slate-400 ml-7">클라이언트에게 AI 추천 후보로 제안됩니다.</p>
+                                <p class="text-xs text-slate-300 ml-7">* 직접 지원은 이 설정과 무관하게 언제나 가능합니다.</p>
+                            </div>
+                            <div class="relative flex-shrink-0 ml-4" :class="editing ? '' : 'pointer-events-none'">
+                                <input type="checkbox" th:field="*{aiMatchingEnabled}" class="sr-only peer">
+                                <div class="w-11 h-6 bg-slate-200 rounded-full peer peer-checked:bg-blue-600 transition-colors"></div>
+                                <div class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
+                            </div>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- ===== 자기소개 ===== -->
+                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-4">
+                    <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
+                        <i data-lucide="message-square" class="w-5 h-5 text-blue-500"></i> 자기소개
+                    </h3>
+                    <!-- 읽기 전용 -->
+                    <p x-show="!editing"
+                       class="text-sm text-slate-600 leading-relaxed min-h-[80px] whitespace-pre-wrap"
+                       th:text="${resumeForm.introduction}"></p>
+                    <!-- 편집 모드 -->
+                    <textarea x-show="editing"
+                              th:field="*{introduction}" rows="5"
+                              class="w-full p-5 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all resize-none"
+                              placeholder="본인의 전문성을 나타낼 수 있는 소개글을 작성해주세요."></textarea>
+                    <span th:if="${#fields.hasErrors('introduction')}" th:errors="*{introduction}"
+                          class="text-red-500 text-xs"></span>
+                </section>
+
+                <!-- ===== 선호 근무 형태 및 연락처 ===== -->
+                <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-6">
+                    <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
+                        <i data-lucide="briefcase" class="w-5 h-5 text-blue-500"></i> 선호 근무 형태 및 연락처
+                    </h3>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+                        <!-- 경력 연차 -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">경력 연차</label>
+                            <!-- 읽기 -->
+                            <div x-show="!editing"
+                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
+                                <span th:text="${resumeForm.careerYears != null ? resumeForm.careerYears + '년' : '-'}"></span>
+                            </div>
+                            <!-- 편집 -->
+                            <input x-show="editing" type="number" th:field="*{careerYears}" min="0" max="50"
+                                   class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all">
+                            <span th:if="${#fields.hasErrors('careerYears')}" th:errors="*{careerYears}"
+                                  class="text-red-500 text-xs ml-1"></span>
+                        </div>
+
+                        <!-- 근무 방식 -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">근무 방식</label>
+                            <!-- 읽기 -->
+                            <div x-show="!editing"
+                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
+                                <span th:text="${resumeForm.preferredWorkType != null ? resumeForm.preferredWorkType.description : '-'}"></span>
+                            </div>
+                            <!-- 편집 -->
+                            <select x-show="editing" th:field="*{preferredWorkType}"
+                                    class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all appearance-none">
+                                <option value="">선택 안함</option>
+                                <option th:each="wt : ${workTypes}" th:value="${wt}" th:text="${wt.description}"></option>
+                            </select>
+                        </div>
+
+                        <!-- 작성 상태 -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">작성 상태</label>
+                            <!-- 읽기 -->
+                            <div x-show="!editing"
+                                 class="px-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium">
+                                <span th:text="${resumeForm.writingStatus != null ? resumeForm.writingStatus.description : '-'}"></span>
+                            </div>
+                            <!-- 편집 -->
+                            <select x-show="editing" th:field="*{writingStatus}"
+                                    class="w-full px-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all appearance-none">
+                                <option th:each="ws : ${writingStatuses}" th:value="${ws}" th:text="${ws.description}"></option>
+                            </select>
+                            <span th:if="${#fields.hasErrors('writingStatus')}" th:errors="*{writingStatus}"
+                                  class="text-red-500 text-xs ml-1"></span>
+                        </div>
+
+                        <!-- 이메일 (항상 읽기 전용) -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">이메일</label>
+                            <div class="relative">
+                                <i data-lucide="mail" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
+                                <input type="text" th:value="${memberEmail}" readonly
+                                       class="w-full pl-11 pr-4 py-4 bg-slate-100 border border-slate-100 rounded-2xl text-sm text-slate-400 cursor-not-allowed">
+                            </div>
+                        </div>
+
+                        <!-- 연락처 (항상 읽기 전용) -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">연락처</label>
+                            <div class="relative">
+                                <i data-lucide="phone" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
+                                <input type="text" th:value="${memberPhone}" readonly
+                                       class="w-full pl-11 pr-4 py-4 bg-slate-100 border border-slate-100 rounded-2xl text-sm text-slate-400 cursor-not-allowed">
+                            </div>
+                        </div>
+
+                        <!-- 포트폴리오 URL -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-bold text-slate-400 uppercase tracking-wider ml-1">포트폴리오 URL</label>
+                            <!-- 읽기 -->
+                            <div x-show="!editing" class="relative">
+                                <i data-lucide="link" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
+                                <div class="pl-11 pr-4 py-4 bg-slate-50 border border-slate-100 rounded-2xl text-sm text-slate-700 font-medium truncate"
+                                     th:text="${resumeForm.portfolioUrl != null ? resumeForm.portfolioUrl : '-'}"></div>
+                            </div>
+                            <!-- 편집 -->
+                            <div x-show="editing" class="relative">
+                                <i data-lucide="link" class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 w-4 h-4"></i>
+                                <input type="text" th:field="*{portfolioUrl}" placeholder="https://..."
+                                       class="w-full pl-11 pr-4 py-4 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all">
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- hidden -->
+                <input type="hidden" th:if="${resumeForm.career != null}" th:field="*{career.version}">
+
+            </form>
+
+            <!-- ===== 보유 스킬 ===== -->
+            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
+                    <i data-lucide="code-2" class="w-5 h-5 text-blue-500"></i> 보유 스킬
+                </h3>
+
+                <!-- 스킬 태그 목록 -->
+                <div class="flex flex-wrap gap-2">
+                    <th:block th:if="${resume != null}">
+                        <th:block th:each="rs : ${resume.skills}">
+                            <!-- 편집 모드: 삭제 버튼 있는 폼 -->
+                            <form x-show="editing"
+                                  th:action="@{/resume/skill/remove}" method="post"
+                                  class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-blue-50 border border-blue-100 rounded-xl text-sm font-semibold text-blue-700 hover:border-red-200 hover:bg-red-50 hover:text-red-600 group transition-all">
+                                <input type="hidden" name="skillId" th:value="${rs.skill.id}">
+                                <span th:text="${rs.skill.name}"></span>
+                                <span class="text-xs opacity-60" th:text="${rs.proficiency.description}"></span>
+                                <button type="submit" class="ml-1 opacity-50 group-hover:opacity-100 transition-opacity">
+                                    <i data-lucide="x" class="w-3 h-3"></i>
+                                </button>
+                            </form>
+                            <!-- 읽기 모드: 태그만 표시 -->
+                            <span x-show="!editing"
+                                  class="inline-flex items-center gap-1.5 px-3.5 py-2 bg-blue-50 border border-blue-100 rounded-xl text-sm font-semibold text-blue-700">
+                                <span th:text="${rs.skill.name}"></span>
+                                <span class="text-xs opacity-60" th:text="${rs.proficiency.description}"></span>
+                            </span>
+                        </th:block>
+                    </th:block>
+                    <p th:if="${resume == null or (resume != null and #lists.isEmpty(resume.skills))}"
+                       class="text-sm text-slate-400 italic">등록된 기술 스택이 없습니다.</p>
+                </div>
+
+                <!-- 스킬 추가 폼: 편집 모드에서만 표시 -->
+                <form x-show="editing"
+                      th:action="@{/resume/skill/add}" th:object="${resumeSkillForm}" method="post"
+                      class="flex flex-wrap gap-3 pt-4 border-t border-slate-100">
+                    <div class="flex-1 min-w-[180px]">
+                        <select th:field="*{skillId}"
+                                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 transition-all appearance-none">
+                            <option value="">스킬 선택</option>
+                            <option th:each="skill : ${skills}" th:value="${skill.id}" th:text="${skill.name}"></option>
+                        </select>
+                    </div>
+                    <div class="flex-1 min-w-[140px]">
+                        <select th:field="*{proficiency}"
+                                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-2xl text-sm text-slate-700 focus:outline-none focus:border-blue-500 transition-all appearance-none">
+                            <option value="">숙련도 선택</option>
+                            <option th:each="p : ${proficiencies}" th:value="${p}" th:text="${p.description}"></option>
+                        </select>
+                    </div>
+                    <button type="submit"
+                            class="inline-flex items-center gap-2 px-5 py-3 bg-blue-600 text-white rounded-2xl text-sm font-bold hover:bg-blue-700 transition-all active:scale-95 flex-shrink-0">
+                        <i data-lucide="plus" class="w-4 h-4"></i> 추가
+                    </button>
+                </form>
+            </section>
+
+            <!-- ===== 경력 사항 ===== -->
+            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
+                    <i data-lucide="building-2" class="w-5 h-5 text-blue-500"></i> 경력 사항
+                </h3>
+                <th:block th:if="${resume != null and resume.career != null and not #lists.isEmpty(resume.career.items)}">
+                    <th:block th:each="item : ${resume.career.items}">
+                        <div class="border border-slate-200 rounded-2xl p-6 space-y-2 hover:border-blue-200 transition-all">
+                            <div class="flex items-center justify-between">
+                                <span class="font-bold text-slate-800" th:text="${item.companyName}">회사명</span>
+                                <span class="text-xs text-slate-400"
+                                      th:text="${item.currentlyWorking} ? (${item.startYearMonth} + ' - 현재') : (${item.startYearMonth} + ' - ' + ${item.endYearMonth})">기간</span>
+                            </div>
+                            <p class="text-sm font-semibold text-blue-600" th:text="${item.position}">직무</p>
+                            <p class="text-sm text-slate-500" th:if="${item.summary != null}" th:text="${item.summary}">요약</p>
+                        </div>
+                    </th:block>
+                </th:block>
+                <p th:if="${resume == null or resume.career == null or #lists.isEmpty(resume.career.items)}"
+                   class="text-sm text-slate-400 italic">등록된 경력 사항이 없습니다.</p>
+            </section>
+
+            <!-- ===== 포트폴리오 / 첨부 파일 ===== -->
+            <section class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                <h3 class="text-base font-bold text-slate-700 flex items-center gap-2">
+                    <i data-lucide="paperclip" class="w-5 h-5 text-blue-500"></i> 포트폴리오 / 첨부 파일
+                </h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <th:block th:if="${resume != null and not #lists.isEmpty(resume.attachments)}">
+                        <th:block th:each="att : ${resume.attachments}">
+                            <div class="flex items-center justify-between p-4 border border-slate-200 rounded-2xl bg-slate-50 hover:border-blue-200 transition-all">
+                                <div class="flex items-center gap-3">
+                                    <i data-lucide="file-text" class="w-5 h-5 text-slate-400 flex-shrink-0"></i>
+                                    <p class="text-sm font-semibold text-slate-700 truncate" th:text="${att.file.originalName}">파일명</p>
+                                </div>
+                                <button x-show="editing" type="button" class="text-slate-300 hover:text-red-400 transition-colors flex-shrink-0 ml-3">
+                                    <i data-lucide="trash-2" class="w-4 h-4"></i>
+                                </button>
+                            </div>
+                        </th:block>
+                    </th:block>
+                    <p th:if="${resume == null or #lists.isEmpty(resume.attachments)}"
+                       class="text-sm text-slate-400 italic col-span-2">등록된 첨부 파일이 없습니다.</p>
+                </div>
+            </section>
+
+            <!-- ===== DANGER ZONE ===== -->
+            <div class="border border-red-200 rounded-3xl overflow-hidden bg-white shadow-sm">
+                <div class="px-8 py-4 border-b border-red-100 bg-red-50/30">
+                    <h3 class="text-red-600 font-bold text-base tracking-tight">DANGER ZONE</h3>
+                </div>
+                <div class="divide-y divide-red-100">
+                    <div class="p-6 flex items-center justify-between">
+                        <div>
+                            <h4 class="text-slate-800 font-bold mb-1">이력서 활성화 상태 변경</h4>
+                            <div class="flex items-center gap-2 mb-1">
+                                <span class="text-sm text-slate-500">현재 상태:</span>
+                                <span th:if="${resume != null and resume?.status?.name() == 'ACTIVE'}"
+                                      class="text-sm font-bold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">활성</span>
+                                <span th:if="${resume == null or resume?.status?.name() != 'ACTIVE'}" ...>
+                                      class="text-sm font-bold text-slate-400 bg-slate-100 px-2 py-0.5 rounded-full">비활성</span>
+                            </div>
+                            <p class="text-xs text-slate-400">비활성화 시 클라이언트 검색 결과에서 제외되며 AI 추천 대상에서 빠지게 됩니다.</p>
+                        </div>
+                        <button type="button"
+                                class="border border-red-200 text-red-500 px-5 py-2.5 rounded-xl font-bold text-sm hover:bg-red-50 transition-all active:scale-95 whitespace-nowrap">
+                            이력서 비활성화
+                        </button>
+                    </div>
+                    <div class="p-6 flex items-center justify-between">
+                        <div>
+                            <h4 class="text-red-600 font-bold mb-1">이력서 삭제</h4>
+                            <p class="text-sm text-slate-500 mb-1">이 이력서의 모든 정보, 경력 사항, 포트폴리오 데이터가 영구적으로 삭제됩니다.</p>
+                            <p class="text-xs text-red-400 font-medium italic">이 작업은 되돌릴 수 없습니다. 신중하게 결정해 주세요.</p>
+                        </div>
+                        <button type="button"
+                                class="bg-red-600 text-white px-5 py-2.5 rounded-xl font-bold text-sm hover:bg-red-700 shadow-lg shadow-red-200 transition-all active:scale-95 whitespace-nowrap">
+                            이력서 삭제하기
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -21,5 +21,6 @@
 <script>
     document.addEventListener('alpine:initialized', () => { lucide.createIcons(); });
 </script>
+<th:block layout:fragment="scripts"></th:block>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
@@ -1,7 +1,6 @@
 package com.generic4.itda.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.doThrow;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -25,6 +24,7 @@ import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.dto.resume.ResumeForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.ResumeService;
@@ -94,42 +94,75 @@ class ResumeControllerTest {
     }
 
     // =========================================================
-    // GET /resume
+    // GET /resumes
     // =========================================================
 
     @Nested
-    @DisplayName("GET /resume")
+    @DisplayName("GET /resumes")
     class IndexTest {
 
         @Test
-        @DisplayName("이력서가 없으면 /resume/new 로 리다이렉트한다")
+        @DisplayName("이력서가 없으면 /resumes/new 로 리다이렉트한다")
         void redirectsToNewWhenNoResume() throws Exception {
             given(resumeService.findByEmail("user@example.com"))
                     .willThrow(new IllegalStateException("이력서가 존재하지 않습니다."));
 
-            mockMvc.perform(get("/resume").with(authentication(auth)))
+            mockMvc.perform(get("/resumes").with(authentication(auth)))
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/new"));
+                    .andExpect(redirectedUrl("/resumes/new"));
         }
 
         @Test
-        @DisplayName("이력서가 있으면 /resume/edit 로 리다이렉트한다")
-        void redirectsToEditWhenResumeExists() throws Exception {
+        @DisplayName("이력서가 있으면 /resumes/me 로 리다이렉트한다")
+        void redirectsToMeWhenResumeExists() throws Exception {
             Resume resume = mockResume();
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
 
-            mockMvc.perform(get("/resume").with(authentication(auth)))
+            mockMvc.perform(get("/resumes").with(authentication(auth)))
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit"));
+                    .andExpect(redirectedUrl("/resumes/me"));
         }
     }
 
     // =========================================================
-    // GET /resume/new
+    // GET /resumes/me  (읽기 전용 조회)
     // =========================================================
 
     @Nested
-    @DisplayName("GET /resume/new")
+    @DisplayName("GET /resumes/me")
+    class ViewTest {
+
+        @Test
+        @DisplayName("이력서를 읽기 전용 모드(editable=false)로 렌더링한다")
+        void renderReadOnlyView() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resumes/me").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attribute("isNew", false))
+                    .andExpect(model().attribute("editable", false));
+        }
+
+        @Test
+        @DisplayName("폼 데이터가 이력서 내용으로 채워지고 resume 모델도 포함된다")
+        void formIsPopulatedWithResumeData() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resumes/me").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(model().attributeExists("resumeForm", "resume"));
+        }
+    }
+
+    // =========================================================
+    // GET /resumes/new
+    // =========================================================
+
+    @Nested
+    @DisplayName("GET /resumes/new")
     class NewFormTest {
 
         @Test
@@ -138,7 +171,7 @@ class ResumeControllerTest {
             given(resumeService.findByEmail("user@example.com"))
                     .willThrow(new IllegalStateException("이력서가 존재하지 않습니다."));
 
-            mockMvc.perform(get("/resume/new").with(authentication(auth)))
+            mockMvc.perform(get("/resumes/new").with(authentication(auth)))
                     .andExpect(status().isOk())
                     .andExpect(view().name("freelancer/resumeForm"))
                     .andExpect(model().attributeExists("resumeForm", "resumeSkillForm"))
@@ -146,29 +179,29 @@ class ResumeControllerTest {
         }
 
         @Test
-        @DisplayName("이미 이력서가 있으면 /resume/edit 로 리다이렉트한다")
+        @DisplayName("이미 이력서가 있으면 /resumes/edit 로 리다이렉트한다")
         void redirectsToEditWhenResumeAlreadyExists() throws Exception {
             Resume resume = mockResume();
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
 
-            mockMvc.perform(get("/resume/new").with(authentication(auth)))
+            mockMvc.perform(get("/resumes/new").with(authentication(auth)))
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit"));
+                    .andExpect(redirectedUrl("/resumes/edit"));
         }
     }
 
     // =========================================================
-    // POST /resume/new
+    // POST /resumes/new
     // =========================================================
 
     @Nested
-    @DisplayName("POST /resume/new")
+    @DisplayName("POST /resumes/new")
     class CreateTest {
 
         @Test
-        @DisplayName("유효한 입력이면 이력서를 생성하고 /resume/edit 로 리다이렉트한다")
+        @DisplayName("유효한 입력이면 이력서를 생성하고 /resumes/edit 로 리다이렉트한다")
         void createAndRedirectOnValidInput() throws Exception {
-            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+            mockMvc.perform(post("/resumes/new").with(authentication(auth)).with(csrf())
                             .param("introduction", "안녕하세요, 백엔드 개발자입니다.")
                             .param("careerYears", "3")
                             .param("career.version", "1")
@@ -176,15 +209,15 @@ class ResumeControllerTest {
                             .param("preferredWorkType", "REMOTE")
                             .param("portfolioUrl", ""))
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit"));
+                    .andExpect(redirectedUrl("/resumes/edit"));
 
-            then(resumeService).should().create(any(), any(), any(), any(), any(), any(), any());
+            then(resumeService).should().create(eq("user@example.com"), any(ResumeForm.class));
         }
 
         @Test
         @DisplayName("자기소개가 비어있으면 검증 오류로 폼을 다시 렌더링하고 서비스를 호출하지 않는다")
         void showValidationErrorWhenIntroductionIsBlank() throws Exception {
-            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+            mockMvc.perform(post("/resumes/new").with(authentication(auth)).with(csrf())
                             .param("introduction", "")
                             .param("careerYears", "3")
                             .param("career.version", "1")
@@ -193,13 +226,13 @@ class ResumeControllerTest {
                     .andExpect(view().name("freelancer/resumeForm"))
                     .andExpect(model().attributeHasFieldErrors("resumeForm", "introduction"));
 
-            then(resumeService).should(never()).create(any(), any(), any(), any(), any(), any(), any());
+            then(resumeService).should(never()).create(anyString(), any(ResumeForm.class));
         }
 
         @Test
         @DisplayName("경력 연차가 범위를 초과하면 검증 오류로 폼을 다시 렌더링한다")
         void showValidationErrorWhenCareerYearsIsOutOfRange() throws Exception {
-            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+            mockMvc.perform(post("/resumes/new").with(authentication(auth)).with(csrf())
                             .param("introduction", "안녕하세요.")
                             .param("careerYears", "99")   // max=50 초과
                             .param("career.version", "1")
@@ -208,16 +241,16 @@ class ResumeControllerTest {
                     .andExpect(view().name("freelancer/resumeForm"))
                     .andExpect(model().attributeHasFieldErrors("resumeForm", "careerYears"));
 
-            then(resumeService).should(never()).create(any(), any(), any(), any(), any(), any(), any());
+            then(resumeService).should(never()).create(anyString(), any(ResumeForm.class));
         }
 
         @Test
         @DisplayName("서비스에서 예외가 발생하면 전역 오류와 함께 폼을 다시 렌더링한다")
         void showGlobalErrorWhenServiceThrows() throws Exception {
             doThrow(new IllegalStateException("이미 이력서가 존재합니다."))
-                    .when(resumeService).create(any(), any(), any(), any(), any(), any(), any());
+                    .when(resumeService).create(any(String.class), any(ResumeForm.class));
 
-            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+            mockMvc.perform(post("/resumes/new").with(authentication(auth)).with(csrf())
                             .param("introduction", "안녕하세요.")
                             .param("careerYears", "3")
                             .param("career.version", "1")
@@ -229,33 +262,20 @@ class ResumeControllerTest {
     }
 
     // =========================================================
-    // GET /resume/edit
+    // GET /resumes/edit  (항상 편집 모드)
     // =========================================================
 
     @Nested
-    @DisplayName("GET /resume/edit")
+    @DisplayName("GET /resumes/edit")
     class EditFormTest {
 
         @Test
-        @DisplayName("mode 파라미터가 없으면 읽기 전용 모드(editable=false)로 렌더링한다")
-        void renderReadOnlyModeByDefault() throws Exception {
+        @DisplayName("편집 폼을 항상 editable=true 로 렌더링한다")
+        void renderEditableForm() throws Exception {
             Resume resume = mockResume();
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
 
-            mockMvc.perform(get("/resume/edit").with(authentication(auth)))
-                    .andExpect(status().isOk())
-                    .andExpect(view().name("freelancer/resumeForm"))
-                    .andExpect(model().attribute("isNew", false))
-                    .andExpect(model().attribute("editable", false));
-        }
-
-        @Test
-        @DisplayName("mode=modify 이면 편집 모드(editable=true)로 렌더링한다")
-        void renderEditModeWhenModeIsModify() throws Exception {
-            Resume resume = mockResume();
-            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
-
-            mockMvc.perform(get("/resume/edit").param("mode", "modify").with(authentication(auth)))
+            mockMvc.perform(get("/resumes/edit").with(authentication(auth)))
                     .andExpect(status().isOk())
                     .andExpect(view().name("freelancer/resumeForm"))
                     .andExpect(model().attribute("isNew", false))
@@ -263,30 +283,30 @@ class ResumeControllerTest {
         }
 
         @Test
-        @DisplayName("폼 데이터가 이력서 내용으로 채워진다")
+        @DisplayName("폼 데이터가 이력서 내용으로 채워지고 필수 모델 속성이 포함된다")
         void formIsPopulatedWithResumeData() throws Exception {
             Resume resume = mockResume();
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
 
-            mockMvc.perform(get("/resume/edit").with(authentication(auth)))
+            mockMvc.perform(get("/resumes/edit").with(authentication(auth)))
                     .andExpect(status().isOk())
-                    .andExpect(model().attributeExists("resumeForm", "resume"))
+                    .andExpect(model().attributeExists("resumeForm", "resume", "resumeSkillForm"))
                     .andExpect(model().attributeExists("workTypes", "proficiencies", "writingStatuses"));
         }
     }
 
     // =========================================================
-    // POST /resume/edit
+    // POST /resumes/edit
     // =========================================================
 
     @Nested
-    @DisplayName("POST /resume/edit")
+    @DisplayName("POST /resumes/edit")
     class UpdateTest {
 
         @Test
-        @DisplayName("유효한 입력이면 이력서를 수정하고 /resume/edit 로 리다이렉트한다")
-        void updateAndRedirectOnValidInput() throws Exception {
-            mockMvc.perform(post("/resume/edit").with(authentication(auth)).with(csrf())
+        @DisplayName("유효한 입력이면 이력서를 수정하고 /resumes/me 로 리다이렉트한다")
+        void updateAndRedirectToMeOnValidInput() throws Exception {
+            mockMvc.perform(post("/resumes/edit").with(authentication(auth)).with(csrf())
                             .param("introduction", "수정된 자기소개입니다.")
                             .param("careerYears", "5")
                             .param("career.version", "1")
@@ -295,16 +315,19 @@ class ResumeControllerTest {
                             .param("publiclyVisible", "true")
                             .param("aiMatchingEnabled", "false"))
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit"));
+                    .andExpect(redirectedUrl("/resumes/me"));
 
-            then(resumeService).should()
-                    .update(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean());
+            then(resumeService).should().update(any(String.class), any(ResumeForm.class));
         }
 
         @Test
         @DisplayName("검증 오류가 있으면 editable=true 로 폼을 다시 렌더링하고 서비스를 호출하지 않는다")
         void showFormWithEditableTrueOnValidationError() throws Exception {
-            mockMvc.perform(post("/resume/edit").with(authentication(auth)).with(csrf())
+            Resume resume = mockResume();
+            // 검증 오류 시 컨트롤러가 resume을 다시 조회함
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(post("/resumes/edit").with(authentication(auth)).with(csrf())
                             .param("introduction", "")   // 필수값 누락
                             .param("careerYears", "5")
                             .param("career.version", "1")
@@ -314,90 +337,137 @@ class ResumeControllerTest {
                     .andExpect(model().attribute("editable", true))
                     .andExpect(model().attributeHasFieldErrors("resumeForm", "introduction"));
 
-            then(resumeService).should(never())
-                    .update(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean());
+            then(resumeService).should(never()).update(any(String.class), any(ResumeForm.class));
         }
     }
 
     // =========================================================
-    // POST /resume/skill/add
+    // POST /resumes/skill/add
     // =========================================================
 
     @Nested
-    @DisplayName("POST /resume/skill/add")
+    @DisplayName("POST /resumes/skill/add")
     class AddSkillTest {
 
         @Test
-        @DisplayName("스킬 추가 성공 후 편집 모드(/resume/edit?mode=modify)로 리다이렉트한다")
-        void redirectToEditModeAfterAddingSkill() throws Exception {
-            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
+        @DisplayName("스킬 추가 성공 후 skillSection fragment를 반환한다")
+        void returnFragmentAfterAddingSkill() throws Exception {
+            // given
+            Resume resume = mock(Resume.class);
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            // when & then
+            mockMvc.perform(post("/resumes/skill/add").with(authentication(auth)).with(csrf())
                             .param("skillId", "1")
                             .param("proficiency", "INTERMEDIATE"))
-                    .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit?mode=modify"));
+                    .andExpect(status().isOk())
+                    // 1. 컨트롤러가 반환하는 View Name 확인
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"))
+                    // 2. 컨트롤러에서 넣은 모델 속성 확인
+                    .andExpect(model().attribute("isEditing", true))
+                    .andExpect(model().attributeExists("resume", "resumeSkillForm"));
 
             then(resumeService).should().addSkill("user@example.com", 1L, Proficiency.INTERMEDIATE);
         }
 
         @Test
-        @DisplayName("스킬 ID가 없으면 검증 오류로 폼을 다시 렌더링한다")
-        void showValidationErrorWhenSkillIdIsMissing() throws Exception {
-            Resume resume = mockResume();
+        @DisplayName("스킬 ID가 없으면 검증 오류와 함께 skillSection fragment를 반환한다")
+        void returnFragmentWithValidationErrorWhenSkillIdIsMissing() throws Exception {
+            // given
+            Resume resume = mock(Resume.class);
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
 
-            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
-                            .param("proficiency", "INTERMEDIATE"))   // skillId 누락
+            // when & then
+            mockMvc.perform(post("/resumes/skill/add").with(authentication(auth)).with(csrf())
+                            .param("proficiency", "INTERMEDIATE")) // skillId 누락
                     .andExpect(status().isOk())
-                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"))
                     .andExpect(model().attributeHasFieldErrors("resumeSkillForm", "skillId"));
 
             then(resumeService).should(never()).addSkill(any(), any(), any());
         }
 
         @Test
-        @DisplayName("이미 등록된 스킬이면 전역 오류와 함께 폼을 다시 렌더링한다")
-        void showGlobalErrorWhenSkillAlreadyExists() throws Exception {
-            Resume resume = mockResume();
+        @DisplayName("이미 등록된 스킬이면 필드 오류와 함께 skillSection fragment를 반환한다")
+        void returnFragmentWithErrorWhenSkillAlreadyExists() throws Exception {
+            // given
+            Resume resume = mock(Resume.class);
             given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            // 비즈니스 예외 상황 시뮬레이션
             doThrow(new IllegalStateException("이미 등록된 스킬입니다."))
                     .when(resumeService).addSkill(any(), any(), any());
 
-            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
+            // when & then
+            mockMvc.perform(post("/resumes/skill/add").with(authentication(auth)).with(csrf())
                             .param("skillId", "1")
                             .param("proficiency", "INTERMEDIATE"))
                     .andExpect(status().isOk())
-                    .andExpect(view().name("freelancer/resumeForm"))
-                    .andExpect(model().attributeHasErrors("resumeSkillForm"));
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"))
+                    // rejectValue를 통해 skillId 필드에 에러가 담겼는지 확인
+                    .andExpect(model().attributeHasFieldErrors("resumeSkillForm", "skillId"));
         }
     }
 
     // =========================================================
-    // POST /resume/skill/remove
+    // POST /resumes/skill/remove
     // =========================================================
 
     @Nested
-    @DisplayName("POST /resume/skill/remove")
+    @DisplayName("POST /resumes/skill/remove")
     class RemoveSkillTest {
 
         @Test
-        @DisplayName("스킬 삭제 성공 후 편집 모드(/resume/edit?mode=modify)로 리다이렉트한다")
-        void redirectToEditModeAfterRemovingSkill() throws Exception {
-            mockMvc.perform(post("/resume/skill/remove").with(authentication(auth)).with(csrf())
+        @DisplayName("스킬 삭제 성공 후 skillSection fragment 를 반환한다")
+        void returnFragmentAfterRemovingSkill() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(post("/resumes/skill/remove").with(authentication(auth)).with(csrf())
                             .param("skillId", "2"))
-                    .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit?mode=modify"));
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"))
+                    .andExpect(model().attribute("isEditing", true));
 
             then(resumeService).should().removeSkill("user@example.com", 2L);
         }
 
         @Test
-        @DisplayName("skillId가 없으면 서비스 호출 없이 /resume/edit 로 리다이렉트한다")
-        void skipRemoveAndRedirectWhenSkillIdIsNull() throws Exception {
-            mockMvc.perform(post("/resume/skill/remove").with(authentication(auth)).with(csrf()))
-                    .andExpect(status().is3xxRedirection())
-                    .andExpect(redirectedUrl("/resume/edit"));
+        @DisplayName("skillId가 없으면 서비스 호출 없이 skillSection fragment 를 반환한다")
+        void returnFragmentWithoutRemoveWhenSkillIdIsNull() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(post("/resumes/skill/remove").with(authentication(auth)).with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"));
 
             then(resumeService).should(never()).removeSkill(any(), any());
+        }
+    }
+
+    // =========================================================
+    // POST /resumes/skill/update
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resumes/skill/update")
+    class UpdateSkillTest {
+
+        @Test
+        @DisplayName("숙련도 변경 성공 후 skillSection fragment 를 반환한다")
+        void returnFragmentAfterUpdatingSkill() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(post("/resumes/skill/update").with(authentication(auth)).with(csrf())
+                            .param("skillId", "3")
+                            .param("proficiency", "ADVANCED"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm :: #skillSection"))
+                    .andExpect(model().attribute("isEditing", true));
+
+            then(resumeService).should().updateSkill("user@example.com", 3L, Proficiency.ADVANCED);
         }
     }
 }

--- a/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
@@ -1,0 +1,403 @@
+package com.generic4.itda.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.member.UserRole;
+import com.generic4.itda.domain.member.UserStatus;
+import com.generic4.itda.domain.member.UserType;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.ResumeService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(ResumeController.class)
+class ResumeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ResumeService resumeService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ItDaPrincipal principal;
+
+    private UsernamePasswordAuthenticationToken auth;
+
+    @BeforeEach
+    void setUp() {
+        given(principal.getEmail()).willReturn("user@example.com");
+        given(principal.getName()).willReturn("홍길동");
+        given(principal.getPhone()).willReturn("010-1234-5678");
+        given(principal.getRole()).willReturn(UserRole.USER);
+        given(principal.getStatus()).willReturn(UserStatus.ACTIVE);
+        given(principal.getType()).willReturn(UserType.INDIVIDUAL);
+        given(principal.isEnabled()).willReturn(true);
+
+        given(resumeService.findAllSkills()).willReturn(List.of());
+
+        auth = new UsernamePasswordAuthenticationToken(
+                principal, null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    /** 이력서 Mock 객체 생성 헬퍼 */
+    private Resume mockResume() {
+        Resume resume = mock(Resume.class);
+        given(resume.getIntroduction()).willReturn("안녕하세요, 개발자입니다.");
+        given(resume.getCareerYears()).willReturn((byte) 3);
+        given(resume.getCareer()).willReturn(new CareerPayload());
+        given(resume.getPreferredWorkType()).willReturn(WorkType.REMOTE);
+        given(resume.getWritingStatus()).willReturn(ResumeWritingStatus.DONE);
+        given(resume.getPortfolioUrl()).willReturn("https://portfolio.example.com");
+        given(resume.isPubliclyVisible()).willReturn(true);
+        given(resume.isAiMatchingEnabled()).willReturn(true);
+        given(resume.getSkills()).willReturn(new TreeSet<>());
+        given(resume.getAttachments()).willReturn(new ArrayList<>());
+        return resume;
+    }
+
+    // =========================================================
+    // GET /resume
+    // =========================================================
+
+    @Nested
+    @DisplayName("GET /resume")
+    class IndexTest {
+
+        @Test
+        @DisplayName("이력서가 없으면 /resume/new 로 리다이렉트한다")
+        void redirectsToNewWhenNoResume() throws Exception {
+            given(resumeService.findByEmail("user@example.com"))
+                    .willThrow(new IllegalStateException("이력서가 존재하지 않습니다."));
+
+            mockMvc.perform(get("/resume").with(authentication(auth)))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/new"));
+        }
+
+        @Test
+        @DisplayName("이력서가 있으면 /resume/edit 로 리다이렉트한다")
+        void redirectsToEditWhenResumeExists() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resume").with(authentication(auth)))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit"));
+        }
+    }
+
+    // =========================================================
+    // GET /resume/new
+    // =========================================================
+
+    @Nested
+    @DisplayName("GET /resume/new")
+    class NewFormTest {
+
+        @Test
+        @DisplayName("이력서가 없으면 신규 작성 폼을 렌더링한다")
+        void renderFormWhenNoResume() throws Exception {
+            given(resumeService.findByEmail("user@example.com"))
+                    .willThrow(new IllegalStateException("이력서가 존재하지 않습니다."));
+
+            mockMvc.perform(get("/resume/new").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeExists("resumeForm", "resumeSkillForm"))
+                    .andExpect(model().attribute("isNew", true));
+        }
+
+        @Test
+        @DisplayName("이미 이력서가 있으면 /resume/edit 로 리다이렉트한다")
+        void redirectsToEditWhenResumeAlreadyExists() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resume/new").with(authentication(auth)))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit"));
+        }
+    }
+
+    // =========================================================
+    // POST /resume/new
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resume/new")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 입력이면 이력서를 생성하고 /resume/edit 로 리다이렉트한다")
+        void createAndRedirectOnValidInput() throws Exception {
+            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+                            .param("introduction", "안녕하세요, 백엔드 개발자입니다.")
+                            .param("careerYears", "3")
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE")
+                            .param("preferredWorkType", "REMOTE")
+                            .param("portfolioUrl", ""))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit"));
+
+            then(resumeService).should().create(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("자기소개가 비어있으면 검증 오류로 폼을 다시 렌더링하고 서비스를 호출하지 않는다")
+        void showValidationErrorWhenIntroductionIsBlank() throws Exception {
+            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+                            .param("introduction", "")
+                            .param("careerYears", "3")
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeHasFieldErrors("resumeForm", "introduction"));
+
+            then(resumeService).should(never()).create(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("경력 연차가 범위를 초과하면 검증 오류로 폼을 다시 렌더링한다")
+        void showValidationErrorWhenCareerYearsIsOutOfRange() throws Exception {
+            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+                            .param("introduction", "안녕하세요.")
+                            .param("careerYears", "99")   // max=50 초과
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeHasFieldErrors("resumeForm", "careerYears"));
+
+            then(resumeService).should(never()).create(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("서비스에서 예외가 발생하면 전역 오류와 함께 폼을 다시 렌더링한다")
+        void showGlobalErrorWhenServiceThrows() throws Exception {
+            doThrow(new IllegalStateException("이미 이력서가 존재합니다."))
+                    .when(resumeService).create(any(), any(), any(), any(), any(), any(), any());
+
+            mockMvc.perform(post("/resume/new").with(authentication(auth)).with(csrf())
+                            .param("introduction", "안녕하세요.")
+                            .param("careerYears", "3")
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeHasErrors("resumeForm"));
+        }
+    }
+
+    // =========================================================
+    // GET /resume/edit
+    // =========================================================
+
+    @Nested
+    @DisplayName("GET /resume/edit")
+    class EditFormTest {
+
+        @Test
+        @DisplayName("mode 파라미터가 없으면 읽기 전용 모드(editable=false)로 렌더링한다")
+        void renderReadOnlyModeByDefault() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resume/edit").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attribute("isNew", false))
+                    .andExpect(model().attribute("editable", false));
+        }
+
+        @Test
+        @DisplayName("mode=modify 이면 편집 모드(editable=true)로 렌더링한다")
+        void renderEditModeWhenModeIsModify() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resume/edit").param("mode", "modify").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attribute("isNew", false))
+                    .andExpect(model().attribute("editable", true));
+        }
+
+        @Test
+        @DisplayName("폼 데이터가 이력서 내용으로 채워진다")
+        void formIsPopulatedWithResumeData() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(get("/resume/edit").with(authentication(auth)))
+                    .andExpect(status().isOk())
+                    .andExpect(model().attributeExists("resumeForm", "resume"))
+                    .andExpect(model().attributeExists("workTypes", "proficiencies", "writingStatuses"));
+        }
+    }
+
+    // =========================================================
+    // POST /resume/edit
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resume/edit")
+    class UpdateTest {
+
+        @Test
+        @DisplayName("유효한 입력이면 이력서를 수정하고 /resume/edit 로 리다이렉트한다")
+        void updateAndRedirectOnValidInput() throws Exception {
+            mockMvc.perform(post("/resume/edit").with(authentication(auth)).with(csrf())
+                            .param("introduction", "수정된 자기소개입니다.")
+                            .param("careerYears", "5")
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE")
+                            .param("preferredWorkType", "HYBRID")
+                            .param("publiclyVisible", "true")
+                            .param("aiMatchingEnabled", "false"))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit"));
+
+            then(resumeService).should()
+                    .update(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("검증 오류가 있으면 editable=true 로 폼을 다시 렌더링하고 서비스를 호출하지 않는다")
+        void showFormWithEditableTrueOnValidationError() throws Exception {
+            mockMvc.perform(post("/resume/edit").with(authentication(auth)).with(csrf())
+                            .param("introduction", "")   // 필수값 누락
+                            .param("careerYears", "5")
+                            .param("career.version", "1")
+                            .param("writingStatus", "DONE"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attribute("editable", true))
+                    .andExpect(model().attributeHasFieldErrors("resumeForm", "introduction"));
+
+            then(resumeService).should(never())
+                    .update(any(), any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        }
+    }
+
+    // =========================================================
+    // POST /resume/skill/add
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resume/skill/add")
+    class AddSkillTest {
+
+        @Test
+        @DisplayName("스킬 추가 성공 후 편집 모드(/resume/edit?mode=modify)로 리다이렉트한다")
+        void redirectToEditModeAfterAddingSkill() throws Exception {
+            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
+                            .param("skillId", "1")
+                            .param("proficiency", "INTERMEDIATE"))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit?mode=modify"));
+
+            then(resumeService).should().addSkill("user@example.com", 1L, Proficiency.INTERMEDIATE);
+        }
+
+        @Test
+        @DisplayName("스킬 ID가 없으면 검증 오류로 폼을 다시 렌더링한다")
+        void showValidationErrorWhenSkillIdIsMissing() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+
+            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
+                            .param("proficiency", "INTERMEDIATE"))   // skillId 누락
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeHasFieldErrors("resumeSkillForm", "skillId"));
+
+            then(resumeService).should(never()).addSkill(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("이미 등록된 스킬이면 전역 오류와 함께 폼을 다시 렌더링한다")
+        void showGlobalErrorWhenSkillAlreadyExists() throws Exception {
+            Resume resume = mockResume();
+            given(resumeService.findByEmail("user@example.com")).willReturn(resume);
+            doThrow(new IllegalStateException("이미 등록된 스킬입니다."))
+                    .when(resumeService).addSkill(any(), any(), any());
+
+            mockMvc.perform(post("/resume/skill/add").with(authentication(auth)).with(csrf())
+                            .param("skillId", "1")
+                            .param("proficiency", "INTERMEDIATE"))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("freelancer/resumeForm"))
+                    .andExpect(model().attributeHasErrors("resumeSkillForm"));
+        }
+    }
+
+    // =========================================================
+    // POST /resume/skill/remove
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resume/skill/remove")
+    class RemoveSkillTest {
+
+        @Test
+        @DisplayName("스킬 삭제 성공 후 편집 모드(/resume/edit?mode=modify)로 리다이렉트한다")
+        void redirectToEditModeAfterRemovingSkill() throws Exception {
+            mockMvc.perform(post("/resume/skill/remove").with(authentication(auth)).with(csrf())
+                            .param("skillId", "2"))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit?mode=modify"));
+
+            then(resumeService).should().removeSkill("user@example.com", 2L);
+        }
+
+        @Test
+        @DisplayName("skillId가 없으면 서비스 호출 없이 /resume/edit 로 리다이렉트한다")
+        void skipRemoveAndRedirectWhenSkillIdIsNull() throws Exception {
+            mockMvc.perform(post("/resume/skill/remove").with(authentication(auth)).with(csrf()))
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/resume/edit"));
+
+            then(resumeService).should(never()).removeSkill(any(), any());
+        }
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ResumeServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ResumeServiceTest.java
@@ -1,0 +1,137 @@
+package com.generic4.itda.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.*;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.resume.ResumeForm;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.repository.SkillRepository;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeServiceTest {
+
+    @InjectMocks
+    private ResumeService resumeService;
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SkillRepository skillRepository;
+
+    private final String EMAIL = "user@test.com";
+    private ResumeForm form;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        // ResumeForm.createDefault()는 존재하지 않음 → new ResumeForm() 사용
+        form = new ResumeForm();
+        form.setIntroduction("수정된 자기소개");
+        form.setCareerYears((byte) 5);
+        // Resume.create() 빌더 내부에서 Assert.notNull(writingStatus) 호출 → 필수 설정
+        form.setWritingStatus(ResumeWritingStatus.WRITING);
+
+        member = mock(Member.class);
+    }
+
+    @Test
+    @DisplayName("이력서 생성 성공 - 존재 확인 후 회원 조회 순서 보장")
+    void create_Success() {
+        // given
+        when(resumeRepository.existsByMemberEmail(EMAIL)).thenReturn(false);
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+
+        // when
+        resumeService.create(EMAIL, form);
+
+        // then
+        verify(resumeRepository).save(any(Resume.class));
+        verify(memberRepository).findByEmail_Value(EMAIL);
+    }
+
+    @Test
+    @DisplayName("이력서 생성 실패 - 이미 존재하면 회원 조회를 하지 않음")
+    void create_Fail_AlreadyExists() {
+        // given
+        when(resumeRepository.existsByMemberEmail(EMAIL)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> resumeService.create(EMAIL, form))
+                .isInstanceOf(IllegalStateException.class);
+
+        // 검증: 이미 존재하므로 멤버를 찾는 쿼리는 나가지 않아야 함 (리뷰어 포인트)
+        verify(memberRepository, never()).findByEmail_Value(anyString());
+    }
+
+    @Test
+    @DisplayName("이력서 수정 - 엔티티 업데이트 및 토글 로직 검증")
+    void update_Success() {
+        // given
+        Resume resume = mock(Resume.class);
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(any())).thenReturn(Optional.of(resume));
+
+        // 초기 상태 설정
+        when(resume.isPubliclyVisible()).thenReturn(true);
+        form.setPubliclyVisible(false); // 변경 대상
+
+        // when
+        resumeService.update(EMAIL, form);
+
+        // then
+        verify(resume).update(anyString(), anyByte(), any(), any(), any(), any());
+        verify(resume).togglePubliclyVisible(); // 값이 다르므로 호출되어야 함
+    }
+
+    @Test
+    @DisplayName("이력서 조회 - Fetch Join 메서드를 사용하는지 확인")
+    void findByEmail_WithFetchJoin() {
+        // given
+        Resume resume = mock(Resume.class);
+        when(resumeRepository.findByMemberEmailWithDetails(EMAIL)).thenReturn(Optional.of(resume));
+
+        // when
+        Resume result = resumeService.findByEmail(EMAIL);
+
+        // then
+        assertThat(result).isNotNull();
+        // 성능 최적화된 레포지토리 메서드 호출 확인
+        verify(resumeRepository).findByMemberEmailWithDetails(EMAIL);
+    }
+
+    @Test
+    @DisplayName("스킬 추가 - 이력서 조회 후 스킬 추가 메서드 호출")
+    void addSkill_Success() {
+        // given
+        Resume resume = mock(Resume.class);
+        Skill skill = mock(Skill.class);
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(any())).thenReturn(Optional.of(resume));
+        when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
+
+        // when
+        resumeService.addSkill(EMAIL, 1L, Proficiency.INTERMEDIATE);
+
+        // then
+        verify(resume).addSkill(skill, Proficiency.INTERMEDIATE);
+    }
+}


### PR DESCRIPTION
## 🔎 What


- 이력서 작성 페이지 GET 엔드포인트 구현
- 이력서 생성/수정 POST 엔드포인트 구현
- Resume 작성/수정용 폼 DTO 정의
- 컨트롤러 - 서비스 연결
- ResumeSkill 입력 처리 로직 구현 (스킬 선택/추가)
- 입력값 검증 (Validation) 적용
- 작성/수정 성공 후 리다이렉트 흐름 구성
- 기본 템플릿(Thymeleaf) 작성 또는 연결
- 에러 메시지 및 입력 유지 처리
- 컨트롤러 테스트 작성

## 🔗 Issue

- Closes: #15 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?