### PR TITLE
[Feat] 추천 진입 페이지 노출 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -1,0 +1,35 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
+import com.generic4.itda.dto.recommend.RecommendationRequestForm;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.recommend.RecommendationEntryService;
+import com.generic4.itda.service.recommend.RecommendationRunService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationEntryService recommendationEntryService;
+    private final RecommendationRunService recommendationRunService;
+
+    @GetMapping("/proposals/{proposalId}/recommendations")
+    public String entry(
+            @PathVariable Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model
+    ) {
+        RecommendationEntryViewModel entry = recommendationEntryService.getEntry(proposalId, principal.getEmail());
+
+        model.addAttribute("entry", entry);
+        model.addAttribute("requestForm", new RecommendationRequestForm(entry.selectedProposalPositionId()));
+
+        return "recommendation/entry";
+    }
+}

--- a/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
@@ -2,6 +2,7 @@ package com.generic4.itda.domain.recommendation;
 
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.converter.HardFilterStatConverter;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.domain.shared.BaseEntity;
@@ -63,7 +64,7 @@ public class RecommendationRun extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private RecommendationAlgorithm.RecommendationRunStatus status;
+    private RecommendationRunStatus status;
 
     @Column(columnDefinition = "TEXT")
     private String errorMessage;
@@ -84,7 +85,7 @@ public class RecommendationRun extends BaseEntity {
         this.algorithm = algorithm;
         this.topK = topK;
 
-        this.status = RecommendationAlgorithm.RecommendationRunStatus.PENDING;
+        this.status = RecommendationRunStatus.PENDING;
     }
 
     public static RecommendationRun create(
@@ -97,47 +98,47 @@ public class RecommendationRun extends BaseEntity {
     }
 
     public void markRunning() {
-        Assert.state(this.status == RecommendationAlgorithm.RecommendationRunStatus.PENDING,
+        Assert.state(this.status == RecommendationRunStatus.PENDING,
                 "PENDING 상태에서만 실행 시작할 수 있습니다.");
 
-        this.status = RecommendationAlgorithm.RecommendationRunStatus.RUNNING;
+        this.status = RecommendationRunStatus.RUNNING;
         this.errorMessage = null;
     }
 
     public void markCompleted(HardFilterStat stat) {
-        Assert.state(this.status == RecommendationAlgorithm.RecommendationRunStatus.RUNNING,
+        Assert.state(this.status == RecommendationRunStatus.RUNNING,
                 "RUNNING 상태에서만 완료 처리할 수 있습니다.");
         Assert.notNull(stat, "하드 필터 통계는 필수입니다.");
 
-        this.status = RecommendationAlgorithm.RecommendationRunStatus.COMPUTED;
+        this.status = RecommendationRunStatus.COMPUTED;
         this.hardFilterStats = stat;
         this.candidateCount = stat.finalCount();
         this.errorMessage = null;
     }
 
     public void markFailed(String errorMessage) {
-        Assert.state(this.status == RecommendationAlgorithm.RecommendationRunStatus.RUNNING,
+        Assert.state(this.status == RecommendationRunStatus.RUNNING,
                 "RUNNING 상태에서만 완료 처리할 수 있습니다.");
         Assert.hasText(errorMessage, "실패 사유는 필수입니다.");
 
-        this.status = RecommendationAlgorithm.RecommendationRunStatus.FAILED;
+        this.status = RecommendationRunStatus.FAILED;
         this.errorMessage = errorMessage;
     }
 
     public boolean isPending() {
-        return this.status == RecommendationAlgorithm.RecommendationRunStatus.PENDING;
+        return this.status == RecommendationRunStatus.PENDING;
     }
 
     public boolean isRunning() {
-        return this.status == RecommendationAlgorithm.RecommendationRunStatus.RUNNING;
+        return this.status == RecommendationRunStatus.RUNNING;
     }
 
     public boolean isComputed() {
-        return this.status == RecommendationAlgorithm.RecommendationRunStatus.COMPUTED;
+        return this.status == RecommendationRunStatus.COMPUTED;
     }
 
     public boolean isFailed() {
-        return this.status == RecommendationAlgorithm.RecommendationRunStatus.FAILED;
+        return this.status == RecommendationRunStatus.FAILED;
     }
 
     public boolean isTerminalStatus() {

--- a/src/main/java/com/generic4/itda/domain/recommendation/constant/RecommendationAlgorithm.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/constant/RecommendationAlgorithm.java
@@ -20,14 +20,4 @@ public enum RecommendationAlgorithm {
         this.code = code;
     }
 
-    @Getter
-    public enum RecommendationRunStatus {
-        PENDING("대기중"), RUNNING("실행중"), COMPUTED("계산 완료"), FAILED("실패");
-
-        private final String description;
-
-        RecommendationRunStatus(String description) {
-            this.description = description;
-        }
-    }
 }

--- a/src/main/java/com/generic4/itda/domain/recommendation/constant/RecommendationRunStatus.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/constant/RecommendationRunStatus.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.domain.recommendation.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum RecommendationRunStatus {
+    PENDING("대기중"), RUNNING("실행중"), COMPUTED("계산 완료"), FAILED("실패");
+
+    private final String description;
+
+    RecommendationRunStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationEntryPositionItem(
+        Long proposalPositionId,
+        String positionName,
+        Long headCount,
+        String budgetText,
+        List<RecommendationEntrySkillItem> skills,
+        boolean selected
+) {
+
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
@@ -7,8 +7,7 @@ public record RecommendationEntryPositionItem(
         String positionName,
         Long headCount,
         String budgetText,
-        List<RecommendationEntrySkillItem> skills,
-        boolean selected
+        List<RecommendationEntrySkillItem> skills
 ) {
 
 }

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntrySkillItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntrySkillItem.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.dto.recommend;
+
+public record RecommendationEntrySkillItem(
+        String skillName,
+        String importanceLabel
+) {
+
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryViewModel.java
@@ -1,0 +1,15 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationEntryViewModel(
+        Long proposalId,
+        String proposalTitle,
+        String proposalStatus,
+        boolean runnable,
+        String helperMessage,
+        Long selectedProposalPositionId,
+        List<RecommendationEntryPositionItem> positions
+) {
+
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationRequestForm.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationRequestForm.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.dto.recommend;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RecommendationRequestForm(
+        @NotNull(message = "추천 대상 포지션을 선택해주세요.")
+        Long proposalPositionId
+) {
+
+}

--- a/src/main/java/com/generic4/itda/repository/ProposalRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ProposalRepository.java
@@ -1,8 +1,29 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
+    @Query("""
+            select distinct p
+            from Proposal p
+            left join fetch p.positions pp
+            left join fetch pp.position pos
+            where p.id = :proposalId
+            """)
+    Optional<Proposal> findWithPositionsById(Long proposalId);
+
+    @Query("""
+            select pp
+            from ProposalPosition pp
+            left join fetch pp.skills pps
+            left join fetch pps.skill s
+            where pp.proposal.id = :proposalId
+            """)
+    List<ProposalPosition> findPositionsWithSkillsByProposalId(Long proposalId);
 }

--- a/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
@@ -1,8 +1,15 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecommendationRunRepository extends JpaRepository<RecommendationRun, Long> {
 
+    Optional<RecommendationRun> findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+            Long proposalPositionId,
+            String requestFingerprint,
+            RecommendationAlgorithm algorithm
+    );
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -1,0 +1,102 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.dto.recommend.RecommendationEntryPositionItem;
+import com.generic4.itda.dto.recommend.RecommendationEntrySkillItem;
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendationEntryService {
+
+    private final ProposalRepository proposalRepository;
+    private final MemberRepository memberRepository;
+
+    public RecommendationEntryViewModel getEntry(Long proposalId, String email) {
+        Proposal proposal = loadProposalDetail(proposalId);
+
+        Member member = Optional.ofNullable(memberRepository.findByEmail_Value(email))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        validateOwnership(proposal, member);
+
+        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING;
+
+        List<RecommendationEntryPositionItem> positions = proposal.getPositions().stream()
+                .sorted(Comparator.comparing(ProposalPosition::getId))
+                .map(this::toPositionItem)
+                .toList();
+
+        Long selectedProposalPositionId = positions.isEmpty() ? null : positions.get(0).proposalPositionId();
+
+        return new RecommendationEntryViewModel(
+                proposal.getId(),
+                proposal.getTitle(),
+                proposal.getStatus().getDescription(),
+                runnable,
+                buildHelperMessage(runnable),
+                selectedProposalPositionId,
+                positions
+        );
+    }
+
+    private Proposal loadProposalDetail(Long proposalId) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 제안서입니다."));
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
+    }
+
+    private static void validateOwnership(Proposal proposal, Member member) {
+        // member는 id 기반 equals & hashcode가 아님
+        if (!proposal.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인 제안서만 조회할 수 있습니다.");
+        }
+    }
+
+    private RecommendationEntryPositionItem toPositionItem(ProposalPosition position) {
+        return new RecommendationEntryPositionItem(
+                position.getId(),
+                position.getPosition().getName(),
+                position.getHeadCount(),
+                formatBudget(position.getUnitBudgetMin(), position.getUnitBudgetMax()),
+                position.getSkills().stream()
+                        .map(skill -> new RecommendationEntrySkillItem(
+                                skill.getSkill().getName(),
+                                skill.getImportance().getDescription()
+                        )).toList(),
+                false
+        );
+    }
+
+    private String formatBudget(Long min, Long max) {
+        if (min == null && max == null) {
+            return "예산 미정";
+        }
+        if (min != null && max != null) {
+            return String.format("%,d ~ %,d", min, max);
+        }
+        if (min != null) {
+            return String.format("%,d 이상", min);
+        }
+        return String.format("%,d 이하", max);
+    }
+
+    private String buildHelperMessage(boolean runnable) {
+        return runnable
+                ? "선택한 포지션 기준으로 추천을 시작할 수 있습니다."
+                : "제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.";
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -76,8 +76,7 @@ public class RecommendationEntryService {
                         .map(skill -> new RecommendationEntrySkillItem(
                                 skill.getSkill().getName(),
                                 skill.getImportance().getDescription()
-                        )).toList(),
-                false
+                        )).toList()
         );
     }
 

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
@@ -1,0 +1,84 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkill;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecommendationFingerprintGenerator {
+
+    public String generate(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            RecommendationAlgorithm algorithm,
+            int topK
+    ) {
+        String skillPart = proposalPosition.getSkills().stream()
+                .sorted(Comparator.comparing((ProposalPositionSkill skill) -> skill.getSkill().getName())
+                        .thenComparing(skill -> skill.getImportance().name()))
+                .map(this::toSkillToken)
+                .collect(Collectors.joining("|"));
+
+        String raw = String.join("::",
+                "proposal.id=" + proposal.getId(),
+                "proposal.title=" + nullSafe(proposal.getTitle()),
+                "proposal.description=" + nullSafe(proposal.getDescription()),
+                "proposal.totalBudgetMin=" + proposal.getTotalBudgetMin(),
+                "proposal.totalBudgetMax=" + proposal.getTotalBudgetMax(),
+                "proposal.workType=" + enumName(proposal.getWorkType()),
+                "proposal.workPlace=" + nullSafe(proposal.getWorkPlace()),
+                "proposal.expectedPeriod=" + proposal.getExpectedPeriod(),
+                "proposal.status=" + proposal.getStatus().name(),
+
+                "proposalPosition.id=" + proposalPosition.getId(),
+                "proposalPosition.positionId=" + proposalPosition.getPosition().getId(),
+                "proposalPosition.positionName=" + proposalPosition.getPosition().getName(),
+                "proposalPosition.headCount=" + proposalPosition.getHeadCount(),
+                "proposalPosition.status=" + proposalPosition.getStatus(),
+                "proposalPosition.unitBudgetMin=" + proposalPosition.getUnitBudgetMin(),
+                "proposalPosition.unitBudgetMax=" + proposalPosition.getUnitBudgetMax(),
+
+                "proposalPosition.skills=" + skillPart,
+
+                "recommendation.algorithm=" + algorithm.name(),
+                "recommendation.topK=" + topK
+        );
+
+        return sha256(raw);
+    }
+
+    private String toSkillToken(ProposalPositionSkill skill) {
+        return (skill.getSkill().getId() != null ? skill.getSkill().getId() : skill.getSkill().getName())
+                + ":" + skill.getImportance().name();
+    }
+
+    private String nullSafe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String enumName(Enum<?> value) {
+        return value == null ? "" : value.name();
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("request fingerprint 생성에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
@@ -41,7 +41,7 @@ public class RecommendationFingerprintGenerator {
                 "proposalPosition.positionId=" + proposalPosition.getPosition().getId(),
                 "proposalPosition.positionName=" + proposalPosition.getPosition().getName(),
                 "proposalPosition.headCount=" + proposalPosition.getHeadCount(),
-                "proposalPosition.status=" + proposalPosition.getStatus(),
+                "proposalPosition.status=" + proposalPosition.getStatus().name(),
                 "proposalPosition.unitBudgetMin=" + proposalPosition.getUnitBudgetMin(),
                 "proposalPosition.unitBudgetMax=" + proposalPosition.getUnitBudgetMax(),
 
@@ -78,7 +78,7 @@ public class RecommendationFingerprintGenerator {
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalArgumentException("request fingerprint 생성에 실패했습니다.", e);
+            throw new IllegalStateException("request fingerprint 생성에 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
@@ -1,0 +1,99 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecommendationRunService {
+
+    private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
+    private static final int DEFAULT_TOK_K = 3;
+
+    private final ProposalRepository proposalRepository;
+    private final MemberRepository memberRepository;
+    private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationFingerprintGenerator fingerprintGenerator;
+
+    public Long createOrReuse(Long proposalId, Long proposalPositionId, String email) {
+        Proposal proposal = loadProposalDetail(proposalId);
+
+        Member member = Optional.ofNullable(memberRepository.findByEmail_Value(email))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        validateOwnership(proposal, member);
+        validateProposalStatus(proposal);
+
+        ProposalPosition proposalPosition = proposal.getPositions().stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 제안서에 속한 모집 포지션이 아닙니다."));
+
+        validatePositionStatus(proposalPosition);
+
+        String fingerprint = fingerprintGenerator.generate(
+                proposal,
+                proposalPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOK_K
+        );
+
+        return recommendationRunRepository
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        proposalPositionId,
+                        fingerprint,
+                        DEFAULT_ALGORITHM
+                )
+                .map(RecommendationRun::getId)
+                .orElseGet(() -> createNewRun(proposalPosition, fingerprint).getId());
+    }
+
+    private RecommendationRun createNewRun(ProposalPosition proposalPosition, String fingerprint) {
+        RecommendationRun recommendationRun = RecommendationRun.create(
+                proposalPosition,
+                fingerprint,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOK_K
+        );
+        return recommendationRunRepository.save(recommendationRun);
+    }
+
+    private Proposal loadProposalDetail(Long proposalId) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 제안서입니다."));
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
+    }
+
+    private void validateOwnership(Proposal proposal, Member member) {
+        // member는 id 기반 equals & hashcode가 아님
+        if (!proposal.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인 제안서만 조회할 수 있습니다.");
+        }
+    }
+
+    private void validateProposalStatus(Proposal proposal) {
+        if (proposal.getStatus() != ProposalStatus.MATCHING) {
+            throw new IllegalStateException("MATCHING 상태의 제안서만 추천을 실행할 수 있습니다.");
+        }
+    }
+
+    private void validatePositionStatus(ProposalPosition proposalPosition) {
+        if (proposalPosition.getStatus() != ProposalPositionStatus.OPEN) {
+            throw new IllegalStateException("OPEN 상태의 모집 포지션만 추천을 실행할 수 있습니다.");
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecommendationRunService {
 
     private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
-    private static final int DEFAULT_TOK_K = 3;
+    private static final int DEFAULT_TOP_K = 3;
 
     private final ProposalRepository proposalRepository;
     private final MemberRepository memberRepository;
@@ -48,7 +48,7 @@ public class RecommendationRunService {
                 proposal,
                 proposalPosition,
                 DEFAULT_ALGORITHM,
-                DEFAULT_TOK_K
+                DEFAULT_TOP_K
         );
 
         return recommendationRunRepository
@@ -66,7 +66,7 @@ public class RecommendationRunService {
                 proposalPosition,
                 fingerprint,
                 DEFAULT_ALGORITHM,
-                DEFAULT_TOK_K
+                DEFAULT_TOP_K
         );
         return recommendationRunRepository.save(recommendationRun);
     }

--- a/src/main/resources/templates/recommendation/entry.html
+++ b/src/main/resources/templates/recommendation/entry.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+  <title>추천 진입</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
+    <div class="mx-auto flex w-full max-w-5xl flex-col gap-6">
+
+      <!-- 헤더 -->
+      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-slate-400">
+              Recommendation Entry
+            </p>
+            <h1 class="mt-2 text-3xl font-black tracking-tight text-slate-950"
+                th:text="${entry.proposalTitle}">
+              제안서 제목
+            </h1>
+            <p class="mt-3 text-sm text-slate-500">
+              현재 제안서 상태:
+              <span class="font-semibold text-slate-800"
+                    th:text="${entry.proposalStatus}">
+                                매칭 진행
+                            </span>
+            </p>
+          </div>
+
+          <span th:classappend="${entry.runnable}
+                            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                            : 'border-amber-200 bg-amber-50 text-amber-700'"
+                class="rounded-full border px-3 py-1 text-xs font-bold"
+                th:text="${entry.runnable} ? '추천 실행 가능' : '추천 실행 불가'">
+                        추천 실행 가능
+                    </span>
+        </div>
+
+        <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <p class="text-sm leading-6 text-slate-600"
+             th:text="${entry.helperMessage}">
+            안내 문구
+          </p>
+        </div>
+      </section>
+
+      <!-- 추천 요청 폼 -->
+      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+        <form th:action="@{/proposals/{proposalId}/recommendations(proposalId=${entry.proposalId})}"
+              th:object="${requestForm}"
+              method="post"
+              class="space-y-6">
+
+          <!-- 포지션 선택 -->
+          <div>
+            <label for="proposalPositionId"
+                   class="text-xs font-black uppercase tracking-widest text-slate-400">
+              추천 대상 포지션
+            </label>
+
+            <select id="proposalPositionId"
+                    th:field="*{proposalPositionId}"
+                    class="mt-3 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition focus:border-slate-400">
+              <option value="">포지션을 선택해주세요</option>
+              <option th:each="position : ${entry.positions}"
+                      th:value="${position.proposalPositionId}"
+                      th:text="${position.positionName}">
+                백엔드 개발자
+              </option>
+            </select>
+
+            <p th:if="${#fields.hasErrors('proposalPositionId')}"
+               th:errors="*{proposalPositionId}"
+               class="mt-2 text-sm font-semibold text-rose-600">
+              포지션을 선택해주세요.
+            </p>
+          </div>
+
+          <!-- 포지션 정보 카드 -->
+          <div class="space-y-4">
+            <div th:each="position : ${entry.positions}"
+                 th:classappend="${position.proposalPositionId == entry.selectedProposalPositionId}
+                                ? 'border-blue-200 bg-blue-50/40'
+                                : 'border-slate-200 bg-slate-50'"
+                 class="rounded-[24px] border p-5 transition">
+
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 class="text-xl font-black tracking-tight text-slate-950"
+                      th:text="${position.positionName}">
+                    백엔드 개발자
+                  </h2>
+
+                  <p class="mt-2 text-sm text-slate-500">
+                    모집 인원
+                    <span class="font-semibold text-slate-800"
+                          th:text="${position.headCount != null ? position.headCount + '명' : '미정'}">
+                                            2명
+                                        </span>
+                    <span class="mx-2 text-slate-300">•</span>
+                    예산
+                    <span class="font-semibold text-slate-800"
+                          th:text="${position.budgetText}">
+                                            5,000,000 ~ 9,000,000
+                                        </span>
+                  </p>
+                </div>
+
+                <span th:if="${position.proposalPositionId == entry.selectedProposalPositionId}"
+                      class="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700">
+                                    기본 선택 포지션
+                                </span>
+              </div>
+
+              <div class="mt-5">
+                <p class="text-xs font-black uppercase tracking-widest text-slate-400">
+                  요구 스킬
+                </p>
+
+                <div class="mt-3 flex flex-wrap gap-2"
+                     th:if="${!#lists.isEmpty(position.skills)}">
+                                    <span th:each="skill : ${position.skills}"
+                                          class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
+                                        <span th:text="${skill.skillName}">Java</span>
+                                        <span class="mx-1 text-slate-300">·</span>
+                                        <span class="text-slate-500"
+                                              th:text="${skill.importanceLabel}">
+                                            필수
+                                        </span>
+                                    </span>
+                </div>
+
+                <p th:if="${#lists.isEmpty(position.skills)}"
+                   class="mt-3 text-sm text-slate-500">
+                  등록된 스킬이 없습니다.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- 액션 -->
+          <div class="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-6">
+            <p class="text-sm text-slate-500">
+              추천 요청 후 실행 상태 페이지로 이동합니다.
+            </p>
+
+            <button type="submit"
+                    th:disabled="${!entry.runnable}"
+                    th:classappend="${entry.runnable}
+                                    ? 'bg-slate-950 text-white hover:bg-slate-800'
+                                    : 'cursor-not-allowed bg-slate-200 text-slate-400'"
+                    class="rounded-2xl px-5 py-3 text-sm font-semibold transition">
+              추천 시작
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
+++ b/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +41,7 @@ class RecommendationRunTest {
         void 생성_직후_상태는_PENDING() {
             RecommendationRun run = createPendingRun();
 
-            assertThat(run.getStatus()).isEqualTo(RecommendationAlgorithm.RecommendationRunStatus.PENDING);
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.PENDING);
         }
 
         @Test
@@ -104,7 +105,7 @@ class RecommendationRunTest {
 
             run.markRunning();
 
-            assertThat(run.getStatus()).isEqualTo(RecommendationAlgorithm.RecommendationRunStatus.RUNNING);
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.RUNNING);
         }
 
         @Test
@@ -115,7 +116,7 @@ class RecommendationRunTest {
 
             run.markCompleted(stat);
 
-            assertThat(run.getStatus()).isEqualTo(RecommendationAlgorithm.RecommendationRunStatus.COMPUTED);
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
         }
 
         @Test
@@ -126,7 +127,7 @@ class RecommendationRunTest {
 
             run.markFailed("AI 서버 연결 실패");
 
-            assertThat(run.getStatus()).isEqualTo(RecommendationAlgorithm.RecommendationRunStatus.FAILED);
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         }
     }
 

--- a/src/test/java/com/generic4/itda/repository/ProposalRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ProposalRepositoryTest.java
@@ -13,6 +13,7 @@ import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.skill.Skill;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -159,9 +160,126 @@ class ProposalRepositoryTest {
                 .hasMessage("같은 제안서에는 동일한 직무를 중복 등록할 수 없습니다.");
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // 두 단계 조회(findWithPositionsById -> findPositionsWithSkillsByProposalId) + 1차 캐시 합성 계약 검증
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @DisplayName("findWithPositionsById 단독 호출 시 ProposalPosition.skills는 LAZY 미초기화 상태다")
+    @Test
+    void findWithPositionsById_단독_호출_시_skills는_LAZY_미초기화_상태다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Skill java = persist(Skill.create("Java", "백엔드 언어"));
+
+        Proposal proposal = Proposal.create(
+                member, "AI 매칭 플랫폼", "원문", null,
+                null, null, ProposalWorkType.REMOTE, null, null);
+        proposal.addPosition(backend, 1L, 500_000L, 1_000_000L).addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        Proposal found = proposalRepository.findWithPositionsById(proposal.getId()).orElseThrow();
+        ProposalPosition pp = found.getPositions().get(0);
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(util.isLoaded(pp, "skills")).isFalse();
+    }
+
+    @DisplayName("두 단계 조회 호출 시 ProposalPosition.skills는 추가 쿼리 없이 초기화된 상태다")
+    @Test
+    void 두_단계_조회_호출_시_skills는_추가_쿼리_없이_초기화된_상태다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Skill java = persist(Skill.create("Java", "백엔드 언어"));
+        Skill spring = persist(Skill.create("Spring Boot", "웹 프레임워크"));
+
+        Proposal proposal = Proposal.create(
+                member, "AI 매칭 플랫폼", "원문", null,
+                null, null, ProposalWorkType.REMOTE, null, null);
+        ProposalPosition pp = proposal.addPosition(backend, 1L, 500_000L, 1_000_000L);
+        pp.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        pp.addSkill(spring, ProposalPositionSkillImportance.PREFERENCE);
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        Proposal found = loadProposalDetail(proposal.getId());
+        ProposalPosition foundPP = found.getPositions().get(0);
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(util.isLoaded(foundPP, "skills")).isTrue();
+        assertThat(foundPP.getSkills())
+                .extracting(pps -> pps.getSkill().getName())
+                .containsExactlyInAnyOrder("Java", "Spring Boot");
+    }
+
+    @DisplayName("두 단계 조회로 aggregate가 완성된다 — positions와 skills가 1차 캐시 합성으로 함께 반환된다")
+    @Test
+    void 두_단계_조회로_aggregate가_완성된다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Skill java = persist(Skill.create("Java", "백엔드 언어"));
+        Skill spring = persist(Skill.create("Spring Boot", "웹 프레임워크"));
+
+        Proposal proposal = Proposal.create(
+                member, "AI 매칭 플랫폼", "원문", null,
+                null, null, ProposalWorkType.REMOTE, null, null);
+        ProposalPosition pp = proposal.addPosition(backend, 1L, 500_000L, 1_000_000L);
+        pp.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        pp.addSkill(spring, ProposalPositionSkillImportance.PREFERENCE);
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        Proposal found = loadProposalDetail(proposal.getId());
+
+        assertThat(found.getPositions()).hasSize(1);
+        ProposalPosition foundPP = found.getPositions().get(0);
+        assertThat(foundPP.getPosition().getName()).isEqualTo("백엔드 개발자");
+        assertThat(foundPP.getSkills())
+                .extracting(pps -> pps.getSkill().getName())
+                .containsExactlyInAnyOrder("Java", "Spring Boot");
+    }
+
+    @DisplayName("두 단계 조회로 aggregate가 완성된다 — 복수 positions × skills 구조에서 positions 컬렉션에 중복이 없다 (DISTINCT 계약)")
+    @Test
+    void 두_단계_조회_복수_positions_x_skills_구조에서_positions_컬렉션에_중복이_없다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Position frontend = persist(Position.create("프론트엔드 개발자"));
+        Skill java = persist(Skill.create("Java", null));
+        Skill spring = persist(Skill.create("Spring Boot", null));
+        Skill react = persist(Skill.create("React", null));
+        Skill ts = persist(Skill.create("TypeScript", null));
+
+        Proposal proposal = Proposal.create(
+                member, "풀스택 프로젝트", "원문", null,
+                null, null, ProposalWorkType.HYBRID, null, null);
+        ProposalPosition pp1 = proposal.addPosition(backend, 1L, 500_000L, 1_000_000L);
+        pp1.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        pp1.addSkill(spring, ProposalPositionSkillImportance.PREFERENCE);
+        ProposalPosition pp2 = proposal.addPosition(frontend, 1L, 400_000L, 800_000L);
+        pp2.addSkill(react, ProposalPositionSkillImportance.ESSENTIAL);
+        pp2.addSkill(ts, ProposalPositionSkillImportance.PREFERENCE);
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        Proposal found = loadProposalDetail(proposal.getId());
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(found.getPositions()).hasSize(2);
+        found.getPositions().forEach(p ->
+                assertThat(util.isLoaded(p, "skills")).isTrue()
+        );
+    }
+
     private <T> T persist(T entity) {
         entityManager.persist(entity);
         return entity;
+    }
+
+    private Proposal loadProposalDetail(Long proposalId) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId).orElseThrow();
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
     }
 
     private long countRows(String entityName) {

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -14,8 +14,10 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,6 +36,7 @@ class RecommendationRunRepositoryTest {
     @Autowired
     private EntityManager em;
 
+    private Proposal proposal;
     private ProposalPosition proposalPosition;
 
     @BeforeEach
@@ -41,7 +44,7 @@ class RecommendationRunRepositoryTest {
         Member member = memberRepository.save(createMember());
         Position position = persistPosition("백엔드 개발자");
 
-        Proposal proposal = Proposal.create(
+        proposal = Proposal.create(
                 member, "AI 매칭 플랫폼 구축", "원문 내용", null,
                 null, null, ProposalWorkType.REMOTE, null, null);
         proposalPosition = proposal.addPosition(position, 2L, 500_000L, 1_000_000L);
@@ -87,6 +90,65 @@ class RecommendationRunRepositoryTest {
         RecommendationRun found = recommendationRunRepository.findById(run.getId()).orElseThrow();
         assertThat(found.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(found.getErrorMessage()).isEqualTo(errorMessage);
+    }
+
+    @Nested
+    @DisplayName("findByProposalPosition_IdAndRequestFingerprintAndAlgorithm")
+    class FindByCompositeKey {
+
+        private static final String FP = "fp-target";
+        private static final RecommendationAlgorithm ALG = RecommendationAlgorithm.HEURISTIC_V1;
+
+        @BeforeEach
+        void saveRun() {
+            recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, FP, ALG, 5));
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("세 필드가 모두 일치하면 해당 실행 이력이 조회된다")
+        void 세_필드가_모두_일치하면_조회된다() {
+            Optional<RecommendationRun> result =
+                    recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                            proposalPosition.getId(), FP, ALG);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("requestFingerprint가 다르면 조회되지 않는다")
+        void requestFingerprint가_다르면_조회되지_않는다() {
+            Optional<RecommendationRun> result =
+                    recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                            proposalPosition.getId(), "fp-other", ALG);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("algorithm이 다르면 조회되지 않는다")
+        void algorithm이_다르면_조회되지_않는다() {
+            Optional<RecommendationRun> result =
+                    recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                            proposalPosition.getId(), FP, RecommendationAlgorithm.VECTOR_ENGINE_V1);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("proposalPositionId가 다르면 조회되지 않는다")
+        void proposalPositionId가_다르면_조회되지_않는다() {
+            Position otherPosition = persistPosition("프론트엔드 개발자");
+            ProposalPosition otherPP = proposal.addPosition(otherPosition, 1L, 300_000L, 600_000L);
+            proposalRepository.saveAndFlush(proposal);
+
+            Optional<RecommendationRun> result =
+                    recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                            otherPP.getId(), FP, ALG);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     private Position persistPosition(String name) {

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -11,7 +11,7 @@ import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
-import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.recommend.RecommendationEntryPositionItem;
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class RecommendationEntryServiceIntegrationTest {
+
+    @Autowired
+    private RecommendationEntryService recommendationEntryService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProposalRepository proposalRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("저장된 recommendation aggregate를 조회해 entry ViewModel을 조립한다")
+    void getEntry_assemblesViewModelFromPersistedAggregate() {
+        Member owner = memberRepository.save(createMember("entry-owner@test.com", "pw", "제안자", "010-0000-1111"));
+        Position designer = persist(Position.create("디자이너"));
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Position frontend = persist(Position.create("프론트엔드 개발자"));
+        Skill figma = persist(Skill.create("Figma", null));
+        Skill java = persist(Skill.create("Java", null));
+        Skill react = persist(Skill.create("React", null));
+
+        Proposal proposal = Proposal.create(
+                owner,
+                "AI 매칭 플랫폼 구축",
+                "원본 입력",
+                "최종 제안서 설명",
+                10_000_000L,
+                20_000_000L,
+                ProposalWorkType.HYBRID,
+                "서울",
+                6L
+        );
+        ProposalPosition designerPosition = proposal.addPosition(designer, 1L, null, null);
+        designerPosition.addSkill(figma, ProposalPositionSkillImportance.PREFERENCE);
+        ProposalPosition backendPosition = proposal.addPosition(backend, 2L, 1_000_000L, 2_000_000L);
+        backendPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        ProposalPosition frontendPosition = proposal.addPosition(frontend, 1L, 800_000L, 1_200_000L);
+        frontendPosition.addSkill(react, ProposalPositionSkillImportance.PREFERENCE);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+
+        Long proposalId = proposal.getId();
+        Long designerPositionId = designerPosition.getId();
+        Long backendPositionId = backendPosition.getId();
+        Long frontendPositionId = frontendPosition.getId();
+
+        entityManager.clear();
+
+        RecommendationEntryViewModel result = recommendationEntryService.getEntry(
+                proposalId,
+                owner.getEmail().getValue()
+        );
+
+        assertThat(result.proposalId()).isEqualTo(proposalId);
+        assertThat(result.proposalTitle()).isEqualTo("AI 매칭 플랫폼 구축");
+        assertThat(result.proposalStatus()).isEqualTo("모집/추천 진행 중");
+        assertThat(result.runnable()).isTrue();
+        assertThat(result.helperMessage()).isEqualTo("선택한 포지션 기준으로 추천을 시작할 수 있습니다.");
+        assertThat(result.selectedProposalPositionId()).isEqualTo(designerPositionId);
+        assertThat(result.positions())
+                .extracting(RecommendationEntryPositionItem::proposalPositionId)
+                .containsExactly(designerPositionId, backendPositionId, frontendPositionId);
+
+        RecommendationEntryPositionItem first = result.positions().get(0);
+        assertThat(first.positionName()).isEqualTo("디자이너");
+        assertThat(first.budgetText()).isEqualTo("예산 미정");
+        assertThat(first.skills())
+                .singleElement()
+                .satisfies(skill -> {
+                    assertThat(skill.skillName()).isEqualTo("Figma");
+                    assertThat(skill.importanceLabel()).isEqualTo("우대");
+                });
+
+        RecommendationEntryPositionItem second = result.positions().get(1);
+        assertThat(second.positionName()).isEqualTo("백엔드 개발자");
+        assertThat(second.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
+        assertThat(second.skills())
+                .singleElement()
+                .satisfies(skill -> {
+                    assertThat(skill.skillName()).isEqualTo("Java");
+                    assertThat(skill.importanceLabel()).isEqualTo("필수");
+                });
+    }
+
+    @Test
+    @DisplayName("저장된 제안서에 모집 포지션이 없으면 빈 positions와 null 선택값을 반환한다")
+    void getEntry_returnsEmptyPositionsWhenProposalHasNoPositions() {
+        Member owner = memberRepository.save(createMember("entry-empty@test.com", "pw", "제안자", "010-0000-2222"));
+        Proposal proposal = Proposal.create(
+                owner,
+                "포지션 없는 제안서",
+                "원본 입력",
+                null,
+                null,
+                null,
+                ProposalWorkType.REMOTE,
+                null,
+                null
+        );
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        RecommendationEntryViewModel result = recommendationEntryService.getEntry(
+                proposal.getId(),
+                owner.getEmail().getValue()
+        );
+
+        assertThat(result.runnable()).isTrue();
+        assertThat(result.positions()).isEmpty();
+        assertThat(result.selectedProposalPositionId()).isNull();
+    }
+
+    @Test
+    @DisplayName("저장된 제안서의 소유자가 아니면 entry 조회를 거부한다")
+    void getEntry_rejectsNonOwner() {
+        Member owner = memberRepository.save(createMember("entry-real-owner@test.com", "pw", "소유자", "010-0000-3333"));
+        Member other = memberRepository.save(createMember("entry-other@test.com", "pw", "다른회원", "010-0000-4444"));
+        Position backend = persist(Position.create("통합 백엔드"));
+
+        Proposal proposal = Proposal.create(
+                owner,
+                "권한 체크용 제안서",
+                "원본 입력",
+                null,
+                null,
+                null,
+                ProposalWorkType.REMOTE,
+                null,
+                null
+        );
+        proposal.addPosition(backend, 1L, null, null);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        assertThatThrownBy(() -> recommendationEntryService.getEntry(proposal.getId(), other.getEmail().getValue()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("본인 제안서만 조회할 수 있습니다.");
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
@@ -1,0 +1,357 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.recommend.RecommendationEntryPositionItem;
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * RecommendationEntryService 단위 테스트:
+ * - service가 두 단계 조회(findWithPositionsById -> findPositionsWithSkillsByProposalId)를 명시적으로 수행하는지
+ * - repository가 준비해 준 aggregate를 바탕으로 ViewModel/권한/상태 로직을 올바르게 조립하는지
+ *
+ * 한계:
+ * - 이 테스트는 Mockito 기반 단위 테스트라서 실제 JPA fetch/lazy 계약을 검증하지 않는다.
+ * - 특히 skills preload는 "repository가 필요한 그래프를 준비해 준다"는 전제만 검증하며,
+ *   실제 1차 캐시 합성 및 lazy 초기화 여부는 ProposalRepositoryTest가 보장해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class RecommendationEntryServiceTest {
+
+    private static final Long PROPOSAL_ID = 10L;
+    private static final Long OWNER_ID = 1L;
+    private static final String OWNER_EMAIL = "owner@example.com";
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private RecommendationEntryService service;
+
+    @Test
+    @DisplayName("정상 조회 시 제안서 상세는 두 단계 조회로 조립되고 ViewModel도 올바르게 구성된다")
+    void getEntry_assemblesViewModelFromExplicitTwoStepRepositoryLoad() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+
+        ProposalPosition designer = addPosition(proposal, 30L, "디자이너", 1L, null, null);
+        addSkill(designer, 201L, "Figma", ProposalPositionSkillImportance.PREFERENCE);
+
+        ProposalPosition backend = addPosition(proposal, 10L, "백엔드 개발자", 3L, 1_000_000L, 2_000_000L);
+        addSkill(backend, 202L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
+
+        ProposalPosition frontend = addPosition(proposal, 20L, "프론트엔드 개발자", 2L, 700_000L, 900_000L);
+        addSkill(frontend, 203L, "React", ProposalPositionSkillImportance.PREFERENCE);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when
+        RecommendationEntryViewModel result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL);
+
+        // then
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        assertThat(result.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(result.proposalTitle()).isEqualTo("테스트 제안서");
+        assertThat(result.proposalStatus()).isEqualTo("모집/추천 진행 중");
+        assertThat(result.runnable()).isTrue();
+        assertThat(result.helperMessage()).isEqualTo("선택한 포지션 기준으로 추천을 시작할 수 있습니다.");
+        assertThat(result.selectedProposalPositionId()).isEqualTo(10L);
+
+        assertThat(result.positions())
+                .extracting(RecommendationEntryPositionItem::proposalPositionId)
+                .containsExactly(10L, 20L, 30L);
+
+        RecommendationEntryPositionItem firstPosition = result.positions().get(0);
+        assertThat(firstPosition.positionName()).isEqualTo("백엔드 개발자");
+        assertThat(firstPosition.headCount()).isEqualTo(3L);
+        assertThat(firstPosition.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
+        assertThat(firstPosition.skills())
+                .singleElement()
+                .satisfies(skill -> {
+                    assertThat(skill.skillName()).isEqualTo("Java");
+                    assertThat(skill.importanceLabel()).isEqualTo("필수");
+                });
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("positions가 비어 있으면 selectedProposalPositionId는 null이고 positions도 빈 리스트다")
+    void getEntry_returnsEmptyPositionsAndNullSelectionWhenProposalHasNoPositions() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when
+        RecommendationEntryViewModel result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL);
+
+        // then
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        assertThat(result.positions()).isEmpty();
+        assertThat(result.selectedProposalPositionId()).isNull();
+        assertThat(result.runnable()).isTrue();
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("MATCHING 상태이면 runnable=true다")
+    void getEntry_runnableIsTrueWhenStatusIsMatching() {
+        // given
+        Proposal proposal = ownedProposalWithSinglePosition(ProposalStatus.MATCHING, null, null);
+
+        // when
+        RecommendationEntryViewModel result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result.runnable()).isTrue();
+        assertThat(result.helperMessage()).isEqualTo("선택한 포지션 기준으로 추천을 시작할 수 있습니다.");
+        verifyExpectedInteractions();
+    }
+
+    @Test
+    @DisplayName("WRITING 상태이면 runnable=false다")
+    void getEntry_runnableIsFalseWhenStatusIsWriting() {
+        // given
+        ownedProposalWithSinglePosition(ProposalStatus.WRITING, null, null);
+
+        // when
+        RecommendationEntryViewModel result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result.runnable()).isFalse();
+        assertThat(result.helperMessage()).isEqualTo("제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.");
+        verifyExpectedInteractions();
+    }
+
+    @Test
+    @DisplayName("COMPLETE 상태이면 runnable=false다")
+    void getEntry_runnableIsFalseWhenStatusIsComplete() {
+        // given
+        ownedProposalWithSinglePosition(ProposalStatus.COMPLETE, null, null);
+
+        // when
+        RecommendationEntryViewModel result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result.runnable()).isFalse();
+        assertThat(result.helperMessage()).isEqualTo("제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.");
+        verifyExpectedInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 proposal이면 IllegalArgumentException이 발생한다")
+    void getEntry_throwsWhenProposalNotFound() {
+        // given
+        given(proposalRepository.findWithPositionsById(999L)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> service.getEntry(999L, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 제안서입니다.");
+
+        verify(proposalRepository).findWithPositionsById(999L);
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 member이면 IllegalArgumentException이 발생한다")
+    void getEntry_throwsWhenMemberNotFound() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(null);
+
+        // when / then
+        assertThatThrownBy(() -> service.getEntry(PROPOSAL_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 IllegalArgumentException이 발생한다")
+    void getEntry_throwsWhenMemberIsNotOwner() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Member other = createMemberWithId(2L, "other@example.com");
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value("other@example.com")).willReturn(other);
+
+        // when / then
+        assertThatThrownBy(() -> service.getEntry(PROPOSAL_ID, "other@example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("본인 제안서만 조회할 수 있습니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value("other@example.com");
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("budget min/max 모두 null이면 '예산 미정'을 반환한다")
+    void getEntry_budgetBothNull_returnsUndefined() {
+        assertThat(getBudgetText(null, null)).isEqualTo("예산 미정");
+    }
+
+    @Test
+    @DisplayName("budget min/max 모두 있으면 'min ~ max' 형식으로 반환한다")
+    void getEntry_budgetBothPresent_returnsRange() {
+        assertThat(getBudgetText(1_000_000L, 3_000_000L)).isEqualTo("1,000,000 ~ 3,000,000");
+    }
+
+    @Test
+    @DisplayName("budget min만 있으면 '이상' 포함 문자열을 반환한다")
+    void getEntry_budgetMinOnly_returnsAtLeast() {
+        assertThat(getBudgetText(1_000_000L, null)).isEqualTo("1,000,000 이상");
+    }
+
+    @Test
+    @DisplayName("budget max만 있으면 '이하' 포함 문자열을 반환한다")
+    void getEntry_budgetMaxOnly_returnsAtMost() {
+        assertThat(getBudgetText(null, 3_000_000L)).isEqualTo("3,000,000 이하");
+    }
+
+    private Proposal ownedProposalWithSinglePosition(ProposalStatus status, Long budgetMin, Long budgetMax) {
+        Member owner = createMemberWithId(OWNER_ID);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, status);
+        addPosition(proposal, 100L, "포지션", 1L, budgetMin, budgetMax);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+        return proposal;
+    }
+
+    /**
+     * mock 기반 테스트에서는 두 번째 조회의 반환값보다 "서비스가 preload 쿼리를 명시 호출한다"는 사실이 중요하다.
+     * 실제 1차 캐시 합성/fetch 계약은 ProposalRepositoryTest가 검증한다.
+     */
+    private void stubProposalDetailLoad(Proposal proposal) {
+        given(proposalRepository.findWithPositionsById(proposal.getId())).willReturn(Optional.of(proposal));
+        given(proposalRepository.findPositionsWithSkillsByProposalId(proposal.getId()))
+                .willReturn(List.copyOf(proposal.getPositions()));
+    }
+
+    private void verifyExpectedInteractions() {
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+    }
+
+    private String getBudgetText(Long min, Long max) {
+        ownedProposalWithSinglePosition(ProposalStatus.MATCHING, min, max);
+        return service.getEntry(PROPOSAL_ID, OWNER_EMAIL).positions().get(0).budgetText();
+    }
+
+    private Member createMemberWithId(Long id) {
+        return createMemberWithId(id, OWNER_EMAIL);
+    }
+
+    private Member createMemberWithId(Long id, String email) {
+        Member member = Member.create(email, "hashed-pw", "테스터", null, null, "010-1234-5678");
+        setId(member, id);
+        return member;
+    }
+
+    private Proposal createProposalWithStatus(Member owner, Long proposalId, ProposalStatus status) {
+        Proposal proposal = Proposal.create(
+                owner, "테스트 제안서", "원본 입력", "설명",
+                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+        );
+        setId(proposal, proposalId);
+
+        if (status == ProposalStatus.MATCHING || status == ProposalStatus.COMPLETE) {
+            proposal.startMatching();
+        }
+        if (status == ProposalStatus.COMPLETE) {
+            proposal.complete();
+        }
+        return proposal;
+    }
+
+    private ProposalPosition addPosition(
+            Proposal proposal,
+            Long proposalPositionId,
+            String positionName,
+            Long headCount,
+            Long budgetMin,
+            Long budgetMax
+    ) {
+        ProposalPosition position = proposal.addPosition(Position.create(positionName), headCount, budgetMin, budgetMax);
+        setId(position, proposalPositionId);
+        return position;
+    }
+
+    private void addSkill(
+            ProposalPosition proposalPosition,
+            Long skillId,
+            String skillName,
+            ProposalPositionSkillImportance importance
+    ) {
+        proposalPosition.addSkill(createSkillWithId(skillId, skillName), importance);
+    }
+
+    private Skill createSkillWithId(Long id, String name) {
+        Skill skill = Skill.create(name, null);
+        setId(skill, id);
+        return skill;
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
@@ -1,0 +1,323 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * FingerprintGenerator 계약 검증: 1. 결정성(determinism): 동일 입력 → 동일 fingerprint 2. 순서 불변성: skills 삽입 순서가 달라도 동일 fingerprint
+ * (정렬 로직) 3. 민감도(sensitivity): 입력 필드 하나가 바뀌면 fingerprint가 달라진다 4. null-safe: nullable 필드가 null이어도 예외 없이 생성된다 5. skill
+ * id fallback: skill.id=null이면 name으로 대체된다
+ * <p>
+ * ※ Spring 컨텍스트 없이 new RecommendationFingerprintGeneratorTest()로 직접 인스턴스화한다.
+ */
+class RecommendationFingerprintGeneratorTest {
+
+    private RecommendationFingerprintGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new RecommendationFingerprintGenerator();
+    }
+
+    // ============================================================
+    // 결정성
+    // ============================================================
+
+    @Test
+    @DisplayName("동일 입력으로 여러 번 호출해도 같은 fingerprint를 반환한다")
+    void generate_isDeterministic() {
+        // 이 값이 같아야 하는 이유:
+        // SHA-256은 순수 함수(pure function)다. 입력 바이트가 동일하면 출력 해시는 항상 동일하다.
+        // 난수·시간·외부 상태에 의존하지 않으므로 반복 호출에도 동일한 값이 나와야 한다.
+        Proposal proposal = createBaseProposal();
+        ProposalPosition position = createBasePosition(proposal);
+        addSkillWithId(position, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
+
+        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isEqualTo(fp2);
+    }
+
+    // ============================================================
+    // 순서 불변성
+    // ============================================================
+
+    @Test
+    @DisplayName("skills 추가 순서가 달라도 fingerprint가 동일하다")
+    void generate_isOrderInvariantForSkills() {
+        // 이 값이 같아야 하는 이유:
+        // generate() 내부에서 skills를 name → importance 기준으로 정렬(Comparator.comparing)한 뒤 "|"로 결합한다.
+        // 따라서 addSkill() 호출 순서(삽입 순서)가 달라도 skillPart 문자열이 동일하게 구성된다.
+        Proposal proposalA = createBaseProposal();
+        ProposalPosition posOrderA = createBasePosition(proposalA);
+        addSkillWithId(posOrderA, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);   // Java 먼저
+        addSkillWithId(posOrderA, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 나중
+
+        Proposal proposalB = createBaseProposal(); // id=1L (동일)
+        ProposalPosition posOrderB = createBasePosition(proposalB);
+        addSkillWithId(posOrderB, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 먼저 (역순)
+        addSkillWithId(posOrderB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);    // Java 나중 (역순)
+
+        String fp1 = generator.generate(proposalA, posOrderA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposalB, posOrderB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isEqualTo(fp2);
+    }
+
+    // ============================================================
+    // 민감도: proposal 필드 변경
+    // ============================================================
+
+    @Test
+    @DisplayName("proposal.title이 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenTitleChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // raw string에 "proposal.title=<value>"가 포함된다.
+        // title이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
+        Proposal proposalA = createProposalWithTitle("제목 A");
+        Proposal proposalB = createProposalWithTitle("제목 B"); // title만 다름, id=1L 동일
+        ProposalPosition posA = createBasePosition(proposalA);
+        ProposalPosition posB = createBasePosition(proposalB);
+
+        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    @Test
+    @DisplayName("proposal.description이 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenDescriptionChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // raw string에 "proposal.description=<value>"가 포함된다.
+        // description이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
+        Proposal proposalA = createProposalWithDescription("설명 A");
+        Proposal proposalB = createProposalWithDescription("설명 B"); // description만 다름, id=1L 동일
+        ProposalPosition posA = createBasePosition(proposalA);
+        ProposalPosition posB = createBasePosition(proposalB);
+
+        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    // ============================================================
+    // 민감도: position 필드 변경
+    // ============================================================
+
+    @Test
+    @DisplayName("proposalPosition.headCount가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenHeadCountChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // raw string에 "proposalPosition.headCount=<value>"가 포함된다.
+        // headCount가 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
+        Proposal proposalA = createBaseProposal();
+        Proposal proposalB = createBaseProposal(); // id=1L 동일
+
+        // 같은 proposal에 동일 position 이름을 두 번 추가할 수 없으므로 각각 별도 proposal에 추가
+        ProposalPosition posA = proposalA.addPosition(Position.create("포지션"), 3L, null, null);
+        setId(posA, 10L);
+
+        ProposalPosition posB = proposalB.addPosition(Position.create("포지션"), 5L, null, null); // headCount만 다름
+        setId(posB, 10L);
+
+        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    @Test
+    @DisplayName("skill importance가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenSkillImportanceChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // toSkillToken()이 "id:importance.name()"으로 토큰을 만든다.
+        // PREFERENCE → ESSENTIAL로 바뀌면 skillPart 문자열이 달라지고, fingerprint도 달라진다.
+        Proposal proposalA = createBaseProposal();
+        Proposal proposalB = createBaseProposal(); // id=1L 동일
+
+        ProposalPosition posA = createBasePosition(proposalA);
+        addSkillWithId(posA, 1L, "Java", ProposalPositionSkillImportance.PREFERENCE);
+
+        ProposalPosition posB = createBasePosition(proposalB);
+        addSkillWithId(posB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // importance만 다름
+
+        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    // ============================================================
+    // 민감도: 추천 파라미터 변경
+    // ============================================================
+
+    @Test
+    @DisplayName("algorithm이 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenAlgorithmChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // raw string에 "recommendation.algorithm=<value>"가 포함된다.
+        // HEURISTIC_V1 vs VECTOR_ENGINE_V1은 name()이 다르므로 raw string이 달라진다.
+        Proposal proposal = createBaseProposal();
+        ProposalPosition position = createBasePosition(proposal);
+
+        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.VECTOR_ENGINE_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    @Test
+    @DisplayName("topK가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenTopKChanges() {
+        // 이 값이 달라져야 하는 이유:
+        // raw string에 "recommendation.topK=<value>"가 포함된다.
+        // topK=5 vs topK=10은 숫자가 달라 raw string이 달라진다.
+        Proposal proposal = createBaseProposal();
+        ProposalPosition position = createBasePosition(proposal);
+
+        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 10);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    // ============================================================
+    // null-safe
+    // ============================================================
+
+    @Test
+    @DisplayName("proposal.description=null이어도 예외 없이 fingerprint가 생성된다")
+    void generate_nullSafe_whenDescriptionIsNull() {
+        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
+        Proposal proposal = Proposal.create(
+                MemberFixture.createMember(),
+                "제목", "원본 입력", null, // description = null
+                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+        );
+        setId(proposal, 1L);
+        ProposalPosition position = createBasePosition(proposal);
+
+        assertThatCode(() ->
+                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("proposal.workPlace=null이어도 예외 없이 fingerprint가 생성된다")
+    void generate_nullSafe_whenWorkPlaceIsNull() {
+        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
+        Proposal proposal = Proposal.create(
+                MemberFixture.createMember(),
+                "제목", "원본 입력", "설명",
+                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, null, // workPlace = null
+                3L
+        );
+        setId(proposal, 1L);
+        ProposalPosition position = createBasePosition(proposal);
+
+        assertThatCode(() ->
+                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
+        ).doesNotThrowAnyException();
+    }
+
+    // ============================================================
+    // skill id fallback
+    // ============================================================
+
+    @Test
+    @DisplayName("skill.id=null이면 name으로 fallback하여 결정적으로 fingerprint를 생성하며, id가 있는 경우와 다르다")
+    void generate_skillIdNullFallsBackToName() {
+        // 이 값이 달라져야 하는 이유:
+        // toSkillToken()이 id != null ? id : name 으로 토큰을 결정한다.
+        //   - skill.id=null  → 토큰: "Java:ESSENTIAL"
+        //   - skill.id=1L    → 토큰: "1:ESSENTIAL"
+        // 두 토큰이 다르므로 fingerprint도 달라야 한다.
+        //
+        // 각 경우는 결정적이어야 한다: 동일 입력으로 두 번 호출 시 같은 fingerprint가 나와야 한다.
+        Proposal proposalWithNullId = createBaseProposal();
+        ProposalPosition posNullId = createBasePosition(proposalWithNullId);
+        Skill skillNoId = Skill.create("Java", null); // id = null (JPA 미할당 상태)
+        posNullId.addSkill(skillNoId, ProposalPositionSkillImportance.ESSENTIAL);
+
+        Proposal proposalWithId = createBaseProposal(); // id=1L 동일
+        ProposalPosition posWithId = createBasePosition(proposalWithId);
+        addSkillWithId(posWithId, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // id=1L
+
+        String fpNullId1 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpNullId2 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpWithId = generator.generate(proposalWithId, posWithId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        // null id 경우도 결정적이어야 한다
+        assertThat(fpNullId1).isEqualTo(fpNullId2);
+
+        // id가 있을 때와 없을 때는 토큰이 달라 fingerprint가 달라야 한다
+        assertThat(fpNullId1).isNotEqualTo(fpWithId);
+    }
+
+    // ============================================================
+    // private helpers
+    // ============================================================
+
+    private Proposal createBaseProposal() {
+        Proposal proposal = Proposal.create(
+                MemberFixture.createMember(),
+                "기본 제안서 제목", "원본 입력 텍스트", "기본 설명",
+                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+        );
+        setId(proposal, 1L);
+        return proposal;
+    }
+
+    private Proposal createProposalWithTitle(String title) {
+        Proposal proposal = Proposal.create(
+                MemberFixture.createMember(),
+                title, "원본 입력 텍스트", "기본 설명",
+                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+        );
+        setId(proposal, 1L);
+        return proposal;
+    }
+
+    private Proposal createProposalWithDescription(String description) {
+        Proposal proposal = Proposal.create(
+                MemberFixture.createMember(),
+                "기본 제안서 제목", "원본 입력 텍스트", description,
+                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+        );
+        setId(proposal, 1L);
+        return proposal;
+    }
+
+    private ProposalPosition createBasePosition(Proposal proposal) {
+        ProposalPosition position = proposal.addPosition(Position.create("백엔드 개발자"), 2L, null, null);
+        setId(position, 10L);
+        return position;
+    }
+
+    private void addSkillWithId(ProposalPosition position, Long skillId, String name,
+            ProposalPositionSkillImportance importance) {
+        Skill skill = Skill.create(name, null);
+        setId(skill, skillId);
+        position.addSkill(skill, importance);
+    }
+
+    private void setId(Object target, Long id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Comparator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class RecommendationRunServiceIntegrationTest {
+
+    private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
+    private static final int DEFAULT_TOP_K = 3;
+
+    @Autowired
+    private RecommendationRunService recommendationRunService;
+
+    @Autowired
+    private RecommendationFingerprintGenerator fingerprintGenerator;
+
+    @Autowired
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProposalRepository proposalRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("같은 proposalPosition과 fingerprint 조합이면 recommendation run을 재사용한다")
+    void createOrReuse_reusesPersistedRunWhenRequestIsSame() {
+        Member owner = memberRepository.save(createMember("run-owner@test.com", "pw", "제안자", "010-0000-5555"));
+        Position backend = persist(Position.create("런 백엔드 개발자"));
+        Skill java = persist(Skill.create("Run Java", null));
+        Skill spring = persist(Skill.create("Run Spring", null));
+
+        Proposal proposal = Proposal.create(
+                owner,
+                "추천 실행 제안서",
+                "원본 입력",
+                "설명",
+                5_000_000L,
+                8_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                4L
+        );
+        ProposalPosition proposalPosition = proposal.addPosition(backend, 2L, 1_500_000L, 2_500_000L);
+        proposalPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposalPosition.addSkill(spring, ProposalPositionSkillImportance.PREFERENCE);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+
+        Long proposalId = proposal.getId();
+        Long proposalPositionId = proposalPosition.getId();
+        String ownerEmail = owner.getEmail().getValue();
+
+        entityManager.clear();
+
+        Long firstRunId = recommendationRunService.createOrReuse(proposalId, proposalPositionId, ownerEmail);
+        entityManager.flush();
+        entityManager.clear();
+
+        Long reusedRunId = recommendationRunService.createOrReuse(proposalId, proposalPositionId, ownerEmail);
+        entityManager.flush();
+        entityManager.clear();
+
+        RecommendationRun persistedRun = recommendationRunRepository.findById(firstRunId).orElseThrow();
+        Proposal persistedProposal = loadProposalDetail(proposalId);
+        ProposalPosition persistedPosition = findPosition(persistedProposal, proposalPositionId);
+        String expectedFingerprint = fingerprintGenerator.generate(
+                persistedProposal,
+                persistedPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K
+        );
+
+        assertThat(reusedRunId).isEqualTo(firstRunId);
+        assertThat(recommendationRunRepository.count()).isEqualTo(1);
+        assertThat(persistedRun.getProposalPosition().getId()).isEqualTo(proposalPositionId);
+        assertThat(persistedRun.getRequestFingerprint()).isEqualTo(expectedFingerprint);
+        assertThat(persistedRun.getAlgorithm()).isEqualTo(DEFAULT_ALGORITHM);
+        assertThat(persistedRun.getTopK()).isEqualTo(DEFAULT_TOP_K);
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("fingerprint 입력이 바뀌면 새 recommendation run을 생성한다")
+    void createOrReuse_createsNewRunWhenFingerprintInputChanges() {
+        Member owner = memberRepository.save(createMember("run-change@test.com", "pw", "제안자", "010-0000-6666"));
+        Position backend = persist(Position.create("런 변경 백엔드"));
+        Skill java = persist(Skill.create("Run Change Java", null));
+
+        Proposal proposal = Proposal.create(
+                owner,
+                "초기 제목",
+                "원본 입력",
+                "설명",
+                5_000_000L,
+                8_000_000L,
+                ProposalWorkType.HYBRID,
+                "서울",
+                5L
+        );
+        ProposalPosition proposalPosition = proposal.addPosition(backend, 1L, 1_000_000L, 2_000_000L);
+        proposalPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+
+        Long proposalId = proposal.getId();
+        Long proposalPositionId = proposalPosition.getId();
+        String ownerEmail = owner.getEmail().getValue();
+
+        entityManager.clear();
+
+        Long firstRunId = recommendationRunService.createOrReuse(proposalId, proposalPositionId, ownerEmail);
+        entityManager.flush();
+        entityManager.clear();
+
+        Proposal editableProposal = proposalRepository.findById(proposalId).orElseThrow();
+        editableProposal.update(
+                "수정된 제목",
+                editableProposal.getRawInputText(),
+                editableProposal.getDescription(),
+                editableProposal.getTotalBudgetMin(),
+                editableProposal.getTotalBudgetMax(),
+                editableProposal.getWorkType(),
+                editableProposal.getWorkPlace(),
+                editableProposal.getExpectedPeriod()
+        );
+        proposalRepository.saveAndFlush(editableProposal);
+        entityManager.clear();
+
+        Long secondRunId = recommendationRunService.createOrReuse(proposalId, proposalPositionId, ownerEmail);
+        entityManager.flush();
+        entityManager.clear();
+
+        RecommendationRun firstRun = recommendationRunRepository.findById(firstRunId).orElseThrow();
+        RecommendationRun secondRun = recommendationRunRepository.findById(secondRunId).orElseThrow();
+
+        assertThat(secondRunId).isNotEqualTo(firstRunId);
+        assertThat(recommendationRunRepository.count()).isEqualTo(2);
+        assertThat(firstRun.getRequestFingerprint()).isNotEqualTo(secondRun.getRequestFingerprint());
+    }
+
+    @Test
+    @DisplayName("저장된 모집 포지션이 OPEN 상태가 아니면 recommendation run 생성을 거부한다")
+    void createOrReuse_rejectsNonOpenPosition() {
+        Member owner = memberRepository.save(createMember("run-closed@test.com", "pw", "제안자", "010-0000-7777"));
+        Position backend = persist(Position.create("런 종료 백엔드"));
+
+        Proposal proposal = Proposal.create(
+                owner,
+                "닫힌 포지션 제안서",
+                "원본 입력",
+                null,
+                null,
+                null,
+                ProposalWorkType.REMOTE,
+                null,
+                null
+        );
+        ProposalPosition proposalPosition = proposal.addPosition(backend, 1L, null, null);
+        proposalPosition.changeStatus(ProposalPositionStatus.FULL);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+        entityManager.clear();
+
+        assertThatThrownBy(() -> recommendationRunService.createOrReuse(
+                proposal.getId(),
+                proposalPosition.getId(),
+                owner.getEmail().getValue()
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("OPEN 상태의 모집 포지션만 추천을 실행할 수 있습니다.");
+
+        assertThat(recommendationRunRepository.count()).isZero();
+    }
+
+    private Proposal loadProposalDetail(Long proposalId) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId).orElseThrow();
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
+    }
+
+    private ProposalPosition findPosition(Proposal proposal, Long proposalPositionId) {
+        return proposal.getPositions().stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .min(Comparator.comparing(ProposalPosition::getId))
+                .orElseThrow();
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
@@ -1,0 +1,370 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * RecommendationRunService 단위 테스트:
+ * - service가 제안서 상세를 두 단계 조회(findWithPositionsById -> findPositionsWithSkillsByProposalId)로 명시적으로 조합하는지
+ * - 권한/상태 검증 이후 fingerprint 기반 재사용 또는 신규 run 생성을 올바르게 오케스트레이션하는지
+ *
+ * 한계:
+ * - 이 테스트는 Mockito 기반 단위 테스트라 실제 JPA fetch/lazy, 1차 캐시 합성은 검증하지 않는다.
+ * - proposal/position 그래프 preload 계약은 ProposalRepositoryTest가, fingerprint 내용 자체의 계약은
+ *   RecommendationFingerprintGeneratorTest가 보장해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class RecommendationRunServiceTest {
+
+    private static final Long PROPOSAL_ID = 10L;
+    private static final Long OWNER_ID = 1L;
+    private static final String OWNER_EMAIL = "owner@example.com";
+    private static final Long SELECTED_POSITION_ID = 20L;
+    private static final String FINGERPRINT = "fp-abc123";
+    private static final Long EXISTING_RUN_ID = 301L;
+    private static final Long NEW_RUN_ID = 302L;
+    private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
+    private static final int DEFAULT_TOP_K = 3;
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @Mock
+    private RecommendationFingerprintGenerator fingerprintGenerator;
+
+    @InjectMocks
+    private RecommendationRunService service;
+
+    @Test
+    @DisplayName("동일한 fingerprint의 기존 run이 있으면 저장하지 않고 기존 id를 재사용한다")
+    void createOrReuse_returnsExistingRunIdWhenReusableRunExists() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+
+        RecommendationRun existingRun = RecommendationRun.create(
+                selectedPosition,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K
+        );
+        ReflectionTestUtils.setField(existingRun, "id", EXISTING_RUN_ID);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+                .willReturn(FINGERPRINT);
+        given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                SELECTED_POSITION_ID,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM
+        )).willReturn(Optional.of(existingRun));
+
+        // when
+        Long result = service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result).isEqualTo(EXISTING_RUN_ID);
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository, fingerprintGenerator, recommendationRunRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(recommendationRunRepository)
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        SELECTED_POSITION_ID,
+                        FINGERPRINT,
+                        DEFAULT_ALGORITHM
+                );
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository, fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("재사용 가능한 run이 없으면 PENDING 상태의 새 run을 생성해 저장한다")
+    void createOrReuse_createsNewPendingRunWhenReusableRunDoesNotExist() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+                .willReturn(FINGERPRINT);
+        given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                SELECTED_POSITION_ID,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM
+        )).willReturn(Optional.empty());
+        given(recommendationRunRepository.save(any(RecommendationRun.class))).willAnswer(invocation -> {
+            RecommendationRun run = invocation.getArgument(0);
+            ReflectionTestUtils.setField(run, "id", NEW_RUN_ID);
+            return run;
+        });
+
+        // when
+        Long result = service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result).isEqualTo(NEW_RUN_ID);
+
+        ArgumentCaptor<RecommendationRun> runCaptor = ArgumentCaptor.forClass(RecommendationRun.class);
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository, fingerprintGenerator, recommendationRunRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(recommendationRunRepository)
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        SELECTED_POSITION_ID,
+                        FINGERPRINT,
+                        DEFAULT_ALGORITHM
+                );
+        inOrder.verify(recommendationRunRepository).save(runCaptor.capture());
+
+        RecommendationRun savedRun = runCaptor.getValue();
+        assertThat(savedRun.getProposalPosition()).isSameAs(selectedPosition);
+        assertThat(savedRun.getRequestFingerprint()).isEqualTo(FINGERPRINT);
+        assertThat(savedRun.getAlgorithm()).isEqualTo(DEFAULT_ALGORITHM);
+        assertThat(savedRun.getTopK()).isEqualTo(DEFAULT_TOP_K);
+        assertThat(savedRun.getStatus()).isEqualTo(RecommendationRunStatus.PENDING);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository, fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 proposal이면 IllegalArgumentException이 발생한다")
+    void createOrReuse_throwsWhenProposalNotFound() {
+        // given
+        given(proposalRepository.findWithPositionsById(PROPOSAL_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 제안서입니다.");
+
+        verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        verifyNoMoreInteractions(proposalRepository);
+        verifyNoInteractions(memberRepository, fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 member이면 IllegalArgumentException이 발생한다")
+    void createOrReuse_throwsWhenMemberNotFound() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(null);
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 IllegalArgumentException이 발생한다")
+    void createOrReuse_throwsWhenMemberIsNotOwner() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Member other = createMemberWithId(2L, "other@example.com");
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value("other@example.com")).willReturn(other);
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, "other@example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("본인 제안서만 조회할 수 있습니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value("other@example.com");
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("MATCHING 상태가 아닌 proposal이면 IllegalStateException이 발생한다")
+    void createOrReuse_throwsWhenProposalStatusIsNotMatching() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.WRITING);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("MATCHING 상태의 제안서만 추천을 실행할 수 있습니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("선택한 proposalPositionId가 제안서에 없으면 IllegalArgumentException이 발생한다")
+    void createOrReuse_throwsWhenProposalPositionDoesNotBelongToProposal() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, 999L, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 제안서에 속한 모집 포지션이 아닙니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("OPEN 상태가 아닌 모집 포지션이면 IllegalStateException이 발생한다")
+    void createOrReuse_throwsWhenProposalPositionStatusIsNotOpen() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.FULL);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when / then
+        assertThatThrownBy(() -> service.createOrReuse(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("OPEN 상태의 모집 포지션만 추천을 실행할 수 있습니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(fingerprintGenerator, recommendationRunRepository);
+    }
+
+    private void stubProposalDetailLoad(Proposal proposal) {
+        // mock 기반 서비스 테스트에서는 repository가 필요한 aggregate를 준비해 준다는 전제만 고정한다.
+        // 실제 fetch join/lazy 초기화 계약은 ProposalRepositoryTest에서 검증되어야 한다.
+        given(proposalRepository.findWithPositionsById(proposal.getId())).willReturn(Optional.of(proposal));
+        given(proposalRepository.findPositionsWithSkillsByProposalId(proposal.getId())).willReturn(proposal.getPositions());
+    }
+
+    private Proposal createProposalWithStatus(Member member, Long proposalId, ProposalStatus status) {
+        Proposal proposal = Proposal.create(
+                member,
+                "테스트 제안서",
+                "raw-input",
+                "설명",
+                3_000_000L,
+                5_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                3L
+        );
+        ReflectionTestUtils.setField(proposal, "id", proposalId);
+        ReflectionTestUtils.setField(proposal, "status", status);
+        return proposal;
+    }
+
+    private ProposalPosition addPosition(
+            Proposal proposal,
+            Long proposalPositionId,
+            String positionName,
+            ProposalPositionStatus status
+    ) {
+        Position position = Position.create(positionName);
+        ReflectionTestUtils.setField(position, "id", proposalPositionId + 1000);
+
+        ProposalPosition proposalPosition = proposal.addPosition(position, 1L, 1_000_000L, 2_000_000L);
+        ReflectionTestUtils.setField(proposalPosition, "id", proposalPositionId);
+        proposalPosition.changeStatus(status);
+        return proposalPosition;
+    }
+
+    private Member createMemberWithId(Long memberId, String email) {
+        Member member = Member.create(
+                email,
+                "hashed-password",
+                "테스터",
+                null,
+                null,
+                "010-1234-5678"
+        );
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
+    }
+}


### PR DESCRIPTION
## 🔎 What

- RecommendationStatus의 위치가 잘못 잡혀있어서, 적절한 위치로 변경
- 추천 진입 페이지에 필요한 DTO들을 정의
- Repository에 필요 메서드 추가
- 추천 엔트리 조회 서비스 추가
- request fingerprint 생성기 추가
- 추천 실행 서비스 추가
- 서비스 레이어 통합 테스트 작성
- 추천 진입 페이지 노출

## 🔗 Issue

- Closes: #20 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

## 🔧 참고 (범위 관련)

이번 PR은 추천 진입 페이지 노출을 사용자 가치로 하지만,
다음 단계인 추천 실행 기능을 위해 일부 선행 서비스 코드가 포함되어 있습니다.