### PR TITLE
[Feat] 클라이언트 대시보드 화면 및 제안서 목록 필터 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ClientDashboardController.java
+++ b/src/main/java/com/generic4/itda/controller/ClientDashboardController.java
@@ -1,0 +1,35 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.dto.client.ClientDashboardFilter;
+import com.generic4.itda.dto.client.ClientDashboardViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.ClientDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class ClientDashboardController {
+
+    private final ClientDashboardService clientDashboardService;
+
+    @GetMapping("/client/dashboard")
+    public String dashboard(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @RequestParam(name = "filter", required = false) String filter,
+            Model model
+    ) {
+        ClientDashboardFilter selectedFilter = ClientDashboardFilter.from(filter);
+        ClientDashboardViewModel dashboard = clientDashboardService.getDashboard(principal.getEmail(), selectedFilter);
+
+        model.addAttribute("dashboard", dashboard);
+        model.addAttribute("memberName", principal.getName());
+        model.addAttribute("memberEmail", principal.getEmail());
+
+        return "client/dashboard";
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/client/ClientDashboardFilter.java
+++ b/src/main/java/com/generic4/itda/dto/client/ClientDashboardFilter.java
@@ -1,0 +1,47 @@
+package com.generic4.itda.dto.client;
+
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum ClientDashboardFilter {
+    ALL("all", "전체 프로젝트", "현재 관리 중인 모든 프로젝트 제안서 및 매칭 현황"),
+    WAITING("waiting", "매칭 대기 중", "아직 매칭을 시작하지 않은 프로젝트"),
+    MATCHING("matching", "진행 중 매칭", "프리랜서에게 요청을 보내고 응답을 기다리거나 매칭이 진행 중인 프로젝트"),
+    COMPLETE("complete", "종료된 참여", "계약이 종료되었거나 성공적으로 완료된 프로젝트");
+
+    private final String key;
+    private final String title;
+    private final String description;
+
+    ClientDashboardFilter(String key, String title, String description) {
+        this.key = key;
+        this.title = title;
+        this.description = description;
+    }
+
+    public ProposalStatus toProposalStatus() {
+        return switch (this) {
+            case WAITING -> ProposalStatus.WRITING;
+            case MATCHING -> ProposalStatus.MATCHING;
+            case COMPLETE -> ProposalStatus.COMPLETE;
+            case ALL -> null;
+        };
+    }
+
+    public boolean isAll() {
+        return this == ALL;
+    }
+
+    public static ClientDashboardFilter from(String value) {
+        if (value == null || value.isBlank()) {
+            return ALL;
+        }
+
+        return Arrays.stream(values())
+                .filter(filter -> filter.key.equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(ALL);
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/client/ClientDashboardProjectItem.java
+++ b/src/main/java/com/generic4/itda/dto/client/ClientDashboardProjectItem.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.dto.client;
+
+public record ClientDashboardProjectItem(
+        Long proposalId,
+        String title,
+        String statusKey,
+        String statusLabel,
+        int positionCount,
+        String totalBudgetText,
+        String modifiedDate,
+        String matchingOverview
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/client/ClientDashboardSummaryItem.java
+++ b/src/main/java/com/generic4/itda/dto/client/ClientDashboardSummaryItem.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.dto.client;
+
+public record ClientDashboardSummaryItem(
+        String filterKey,
+        String title,
+        long count,
+        String description,
+        boolean selected
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/client/ClientDashboardViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/client/ClientDashboardViewModel.java
@@ -1,0 +1,11 @@
+package com.generic4.itda.dto.client;
+
+import java.util.List;
+
+public record ClientDashboardViewModel(
+        String selectedFilterKey,
+        String selectedFilterTitle,
+        List<ClientDashboardSummaryItem> summaries,
+        List<ClientDashboardProjectItem> projects
+) {
+}

--- a/src/main/java/com/generic4/itda/repository/ProposalRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ProposalRepository.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,14 @@ import org.springframework.data.jpa.repository.Query;
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
     Optional<Proposal> findByMemberIdAndTitle(Long memberId, String title);
+
+    List<Proposal> findAllByMember_Email_ValueOrderByModifiedAtDesc(String email);
+
+    List<Proposal> findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(String email, ProposalStatus status);
+
+    long countByMember_Email_Value(String email);
+
+    long countByMember_Email_ValueAndStatus(String email, ProposalStatus status);
 
     @Query("""
             select distinct p

--- a/src/main/java/com/generic4/itda/service/ClientDashboardService.java
+++ b/src/main/java/com/generic4/itda/service/ClientDashboardService.java
@@ -1,0 +1,120 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.dto.client.ClientDashboardFilter;
+import com.generic4.itda.dto.client.ClientDashboardProjectItem;
+import com.generic4.itda.dto.client.ClientDashboardSummaryItem;
+import com.generic4.itda.dto.client.ClientDashboardViewModel;
+import com.generic4.itda.repository.ProposalRepository;
+import java.text.NumberFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClientDashboardService {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+    private static final NumberFormat NUMBER_FORMATTER = NumberFormat.getNumberInstance(Locale.KOREA);
+
+    private final ProposalRepository proposalRepository;
+
+    public ClientDashboardViewModel getDashboard(String memberEmail, ClientDashboardFilter filter) {
+        Assert.hasText(memberEmail, "회원 이메일은 필수값입니다.");
+
+        ClientDashboardFilter selectedFilter = filter == null ? ClientDashboardFilter.ALL : filter;
+        List<Proposal> proposals = loadProjects(memberEmail, selectedFilter);
+
+        return new ClientDashboardViewModel(
+                selectedFilter.getKey(),
+                selectedFilter.getTitle(),
+                buildSummaries(memberEmail, selectedFilter),
+                proposals.stream()
+                        .map(this::toProjectItem)
+                        .toList()
+        );
+    }
+
+    private List<Proposal> loadProjects(String memberEmail, ClientDashboardFilter filter) {
+        if (filter.isAll()) {
+            return proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(memberEmail);
+        }
+
+        return proposalRepository.findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(
+                memberEmail,
+                filter.toProposalStatus()
+        );
+    }
+
+    private List<ClientDashboardSummaryItem> buildSummaries(String memberEmail, ClientDashboardFilter selectedFilter) {
+        long totalCount = proposalRepository.countByMember_Email_Value(memberEmail);
+        long waitingCount = proposalRepository.countByMember_Email_ValueAndStatus(memberEmail, ProposalStatus.WRITING);
+        long matchingCount = proposalRepository.countByMember_Email_ValueAndStatus(memberEmail, ProposalStatus.MATCHING);
+        long completeCount = proposalRepository.countByMember_Email_ValueAndStatus(memberEmail, ProposalStatus.COMPLETE);
+
+        return List.of(
+                toSummaryItem(ClientDashboardFilter.ALL, totalCount, selectedFilter),
+                toSummaryItem(ClientDashboardFilter.WAITING, waitingCount, selectedFilter),
+                toSummaryItem(ClientDashboardFilter.MATCHING, matchingCount, selectedFilter),
+                toSummaryItem(ClientDashboardFilter.COMPLETE, completeCount, selectedFilter)
+        );
+    }
+
+    private ClientDashboardSummaryItem toSummaryItem(
+            ClientDashboardFilter filter,
+            long count,
+            ClientDashboardFilter selectedFilter
+    ) {
+        return new ClientDashboardSummaryItem(
+                filter.getKey(),
+                filter.getTitle(),
+                count,
+                filter.getDescription(),
+                filter == selectedFilter
+        );
+    }
+
+    private ClientDashboardProjectItem toProjectItem(Proposal proposal) {
+        return new ClientDashboardProjectItem(
+                proposal.getId(),
+                proposal.getTitle(),
+                proposal.getStatus().name(),
+                proposal.getStatus().getDescription(),
+                proposal.getPositions().size(),
+                formatBudget(proposal.getTotalBudgetMin(), proposal.getTotalBudgetMax()),
+                proposal.getModifiedAt().format(DATE_FORMATTER),
+                buildMatchingOverview(proposal.getStatus())
+        );
+    }
+
+    private String formatBudget(Long min, Long max) {
+        if (min == null && max == null) {
+            return "예산 미정";
+        }
+        if (min != null && max != null && min.equals(max)) {
+            return NUMBER_FORMATTER.format(min) + "원";
+        }
+        if (min != null && max != null) {
+            return NUMBER_FORMATTER.format(min) + " ~ " + NUMBER_FORMATTER.format(max) + "원";
+        }
+        if (min != null) {
+            return NUMBER_FORMATTER.format(min) + "원 이상";
+        }
+        return NUMBER_FORMATTER.format(max) + "원 이하";
+    }
+
+    private String buildMatchingOverview(ProposalStatus status) {
+        return switch (status) {
+            case WRITING -> "매칭 시작 전";
+            case MATCHING -> "추천/매칭 진행 중";
+            case COMPLETE -> "프로젝트 종료";
+        };
+    }
+}

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -10,7 +10,9 @@
     <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
         <div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
 
-            <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+            <section class="fade-up rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70"
+                     x-show="loaded"
+                     x-transition.enter>
                 <div class="flex flex-wrap items-start justify-between gap-6">
                     <div>
                         <p class="text-xs font-black uppercase tracking-widest text-slate-400">
@@ -35,7 +37,10 @@
                 </div>
             </section>
 
-            <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <section class="fade-up grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+                     x-show="loaded"
+                     x-transition.enter
+                     style="transition-delay: 80ms;">
                 <a th:each="summary : ${dashboard.summaries}"
                    th:href="@{/client/dashboard(filter=${summary.filterKey})}"
                    th:classappend="${summary.selected}
@@ -61,17 +66,25 @@
                 </a>
             </section>
 
-            <section class="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70">
+            <section class="fade-up overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70"
+                     x-show="loaded"
+                     x-transition.enter
+                     style="transition-delay: 140ms;">
                 <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 px-8 py-7">
-                    <div class="flex items-center gap-3">
-                        <h2 class="text-2xl font-black tracking-tight text-slate-950"
-                            th:text="${dashboard.selectedFilterTitle} + ' 프로젝트'">
-                            전체 프로젝트
-                        </h2>
-                        <span class="inline-flex min-w-10 items-center justify-center rounded-full bg-slate-100 px-3 py-1 text-sm font-bold text-slate-500"
-                              th:text="${#lists.size(dashboard.projects)}">
-                            0
-                        </span>
+                    <div>
+                        <div class="flex items-center gap-3">
+                            <h2 class="text-2xl font-black tracking-tight text-slate-950"
+                                th:text="${dashboard.selectedFilterTitle} + ' 프로젝트'">
+                                전체 프로젝트
+                            </h2>
+                            <span class="inline-flex min-w-10 items-center justify-center rounded-full bg-slate-100 px-3 py-1 text-sm font-bold text-slate-500"
+                                  th:text="${#lists.size(dashboard.projects)}">
+                                0
+                            </span>
+                        </div>
+                        <p class="mt-2 text-sm text-slate-500">
+                            선택한 카드 기준으로 프로젝트 목록을 빠르게 확인할 수 있습니다.
+                        </p>
                     </div>
 
                     <a href="#"
@@ -112,6 +125,10 @@
                                 <div class="max-w-[320px]">
                                     <p class="text-xl font-black tracking-tight text-slate-900" th:text="${project.title}">
                                         AI 프리랜서 추천 플랫폼 고도화
+                                    </p>
+                                    <p class="mt-2 text-xs font-semibold uppercase tracking-widest text-slate-400"
+                                       th:text="'Proposal #' + ${project.proposalId}">
+                                        Proposal #1
                                     </p>
                                 </div>
                             </td>

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>클라이언트 대시보드</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
+        <div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+
+            <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+                <div class="flex flex-wrap items-start justify-between gap-6">
+                    <div>
+                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">
+                            Client Dashboard
+                        </p>
+                        <h1 class="mt-2 text-3xl font-black tracking-tight text-slate-950">
+                            안녕하세요, <span th:text="${memberName}">클라이언트</span>님
+                        </h1>
+                        <p class="mt-3 max-w-2xl text-sm leading-7 text-slate-500">
+                            작성한 제안서와 현재 매칭 진행 상황을 한 곳에서 확인할 수 있습니다.
+                            상태 카드를 눌러 원하는 프로젝트만 빠르게 골라보세요.
+                        </p>
+                    </div>
+
+                    <div class="rounded-3xl border border-blue-100 bg-blue-50 px-5 py-4 text-right">
+                        <p class="text-xs font-black uppercase tracking-widest text-blue-400">
+                            Client Account
+                        </p>
+                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${memberName}">시드 클라이언트</p>
+                        <p class="mt-1 text-xs font-medium text-slate-500" th:text="${memberEmail}">seed.client@itda.local</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <a th:each="summary : ${dashboard.summaries}"
+                   th:href="@{/client/dashboard(filter=${summary.filterKey})}"
+                   th:classappend="${summary.selected}
+                                   ? 'border-blue-200 bg-blue-50/50 shadow-lg shadow-blue-100/60'
+                                   : 'border-slate-200 bg-white hover:-translate-y-0.5 hover:border-slate-300'"
+                   class="rounded-[28px] border p-6 transition-all">
+                    <div class="flex h-14 w-14 items-center justify-center rounded-3xl"
+                         th:classappend="${summary.selected} ? 'bg-blue-600 text-white' : 'bg-slate-100 text-slate-400'">
+                        <i th:attr="data-lucide=${
+                                summary.filterKey == 'all' ? 'layout-grid' :
+                                (summary.filterKey == 'waiting' ? 'file-text' :
+                                (summary.filterKey == 'matching' ? 'users' : 'badge-check'))
+                            }"
+                           class="h-6 w-6"></i>
+                    </div>
+                    <p class="mt-6 text-sm font-bold tracking-wide text-slate-400" th:text="${summary.title}">
+                        전체 프로젝트
+                    </p>
+                    <p class="mt-3 text-5xl font-black tracking-tight text-slate-950" th:text="${summary.count}">0</p>
+                    <p class="mt-4 text-sm leading-7 text-slate-500" th:text="${summary.description}">
+                        현재 관리 중인 모든 프로젝트 제안서 및 매칭 현황
+                    </p>
+                </a>
+            </section>
+
+            <section class="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70">
+                <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 px-8 py-7">
+                    <div class="flex items-center gap-3">
+                        <h2 class="text-2xl font-black tracking-tight text-slate-950"
+                            th:text="${dashboard.selectedFilterTitle} + ' 프로젝트'">
+                            전체 프로젝트
+                        </h2>
+                        <span class="inline-flex min-w-10 items-center justify-center rounded-full bg-slate-100 px-3 py-1 text-sm font-bold text-slate-500"
+                              th:text="${#lists.size(dashboard.projects)}">
+                            0
+                        </span>
+                    </div>
+
+                    <a href="#"
+                       class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                        <i data-lucide="plus" class="h-4 w-4"></i>
+                        새 프로젝트 만들기
+                    </a>
+                </div>
+
+                <div th:if="${#lists.isEmpty(dashboard.projects)}" class="px-8 py-14">
+                    <div class="rounded-[28px] border border-dashed border-slate-200 bg-slate-50 px-8 py-12 text-center">
+                        <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-white text-slate-400 shadow-sm shadow-slate-200/70">
+                            <i data-lucide="folder-open" class="h-7 w-7"></i>
+                        </div>
+                        <h3 class="mt-6 text-2xl font-black text-slate-900">표시할 프로젝트가 없습니다</h3>
+                        <p class="mt-3 text-sm leading-7 text-slate-500">
+                            선택한 상태에 해당하는 제안서가 아직 없습니다.
+                        </p>
+                    </div>
+                </div>
+
+                <div th:if="${!#lists.isEmpty(dashboard.projects)}" class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200">
+                        <thead class="bg-slate-50/90">
+                        <tr class="text-left text-xs font-black uppercase tracking-widest text-slate-400">
+                            <th class="px-8 py-5">프로젝트 제목</th>
+                            <th class="px-6 py-5">상태</th>
+                            <th class="px-6 py-5">포지션</th>
+                            <th class="px-6 py-5">총 예산</th>
+                            <th class="px-6 py-5">최종 수정일</th>
+                            <th class="px-6 py-5">매칭 현황</th>
+                            <th class="px-6 py-5 text-right">관리</th>
+                        </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-200 bg-white">
+                        <tr th:each="project : ${dashboard.projects}" class="transition hover:bg-slate-50/70">
+                            <td class="px-8 py-7">
+                                <div class="max-w-[320px]">
+                                    <p class="text-xl font-black tracking-tight text-slate-900" th:text="${project.title}">
+                                        AI 프리랜서 추천 플랫폼 고도화
+                                    </p>
+                                </div>
+                            </td>
+                            <td class="px-6 py-7">
+                                <span th:classappend="${
+                                        project.statusKey == 'WRITING' ? 'border-slate-200 bg-slate-100 text-slate-600' :
+                                        (project.statusKey == 'MATCHING' ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                        'border-emerald-200 bg-emerald-50 text-emerald-600')
+                                      }"
+                                      class="inline-flex rounded-full border px-4 py-2 text-xs font-bold"
+                                      th:text="${project.statusLabel}">
+                                    작성 중
+                                </span>
+                            </td>
+                            <td class="px-6 py-7 text-sm font-bold text-slate-600" th:text="${project.positionCount} + '개'">2개</td>
+                            <td class="px-6 py-7 text-sm font-black text-slate-700" th:text="${project.totalBudgetText}">12,000,000원</td>
+                            <td class="px-6 py-7 text-sm font-medium text-slate-400" th:text="${project.modifiedDate}">2026.04.17</td>
+                            <td class="px-6 py-7">
+                                <span class="text-sm font-semibold text-slate-500" th:text="${project.matchingOverview}">
+                                    매칭 시작 전
+                                </span>
+                            </td>
+                            <td class="px-6 py-7 text-right">
+                                <button type="button"
+                                        class="inline-flex h-10 w-10 items-center justify-center rounded-full text-slate-300 transition hover:bg-slate-100 hover:text-slate-500">
+                                    <i data-lucide="ellipsis" class="h-4 w-4"></i>
+                                </button>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/com/generic4/itda/controller/ClientDashboardControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ClientDashboardControllerTest.java
@@ -1,0 +1,94 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.dto.client.ClientDashboardProjectItem;
+import com.generic4.itda.dto.client.ClientDashboardSummaryItem;
+import com.generic4.itda.dto.client.ClientDashboardViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.ClientDashboardService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(ClientDashboardController.class)
+class ClientDashboardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClientDashboardService clientDashboardService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("인증된 사용자가 클라이언트 대시보드를 조회하면 화면과 모델을 반환한다")
+    void renderClientDashboard() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+        ClientDashboardViewModel dashboard = new ClientDashboardViewModel(
+                "matching",
+                "진행 중 매칭",
+                List.of(
+                        new ClientDashboardSummaryItem("all", "전체 프로젝트", 6L, "전체", false),
+                        new ClientDashboardSummaryItem("matching", "진행 중 매칭", 3L, "진행 중", true)
+                ),
+                List.of(
+                        new ClientDashboardProjectItem(
+                                1L,
+                                "핀테크 앱 고도화 프로젝트",
+                                "MATCHING",
+                                "모집/추천 진행 중",
+                                3,
+                                "4,500,000원",
+                                "2024.03.15",
+                                "추천/매칭 진행 중"
+                        )
+                )
+        );
+        given(clientDashboardService.getDashboard("client@example.com", com.generic4.itda.dto.client.ClientDashboardFilter.MATCHING))
+                .willReturn(dashboard);
+
+        mockMvc.perform(get("/client/dashboard")
+                        .param("filter", "matching")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/dashboard"))
+                .andExpect(model().attribute("dashboard", dashboard))
+                .andExpect(model().attribute("memberName", "클라이언트"))
+                .andExpect(model().attribute("memberEmail", "client@example.com"));
+
+        then(clientDashboardService).should()
+                .getDashboard("client@example.com", com.generic4.itda.dto.client.ClientDashboardFilter.MATCHING);
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 로그인 페이지로 리다이렉트된다")
+    void redirectToLoginWhenUnauthenticated() throws Exception {
+        mockMvc.perform(get("/client/dashboard"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ClientDashboardServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ClientDashboardServiceTest.java
@@ -1,0 +1,195 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.client.ClientDashboardFilter;
+import com.generic4.itda.dto.client.ClientDashboardProjectItem;
+import com.generic4.itda.dto.client.ClientDashboardSummaryItem;
+import com.generic4.itda.dto.client.ClientDashboardViewModel;
+import com.generic4.itda.repository.ProposalRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ClientDashboardServiceTest {
+
+    private static final String OWNER_EMAIL = "owner@example.com";
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @InjectMocks
+    private ClientDashboardService clientDashboardService;
+
+    @Test
+    @DisplayName("전체 필터 조회 시 상태별 카드 개수와 최근 제안서 목록을 함께 반환한다")
+    void getDashboard_returnsSummariesAndProjectsForAllFilter() {
+        Proposal matchingProposal = createProposal(
+                1L,
+                "핀테크 앱 고도화 프로젝트",
+                ProposalStatus.MATCHING,
+                4_500_000L,
+                4_500_000L,
+                LocalDateTime.of(2024, 3, 15, 10, 0),
+                3
+        );
+        Proposal waitingProposal = createProposal(
+                2L,
+                "AI 기반 데이터 분석 툴 구축",
+                ProposalStatus.WRITING,
+                3_000_000L,
+                3_000_000L,
+                LocalDateTime.of(2024, 3, 20, 10, 0),
+                2
+        );
+
+        given(proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL))
+                .willReturn(List.of(waitingProposal, matchingProposal));
+        stubCounts(6L, 2L, 3L, 1L);
+
+        ClientDashboardViewModel result = clientDashboardService.getDashboard(OWNER_EMAIL, ClientDashboardFilter.ALL);
+
+        InOrder inOrder = inOrder(proposalRepository);
+        inOrder.verify(proposalRepository).findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL);
+        verifyCountQueries(inOrder);
+
+        assertThat(result.selectedFilterKey()).isEqualTo("all");
+        assertThat(result.selectedFilterTitle()).isEqualTo("전체 프로젝트");
+        assertThat(result.summaries())
+                .extracting(ClientDashboardSummaryItem::filterKey, ClientDashboardSummaryItem::count,
+                        ClientDashboardSummaryItem::selected)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("all", 6L, true),
+                        org.assertj.core.groups.Tuple.tuple("waiting", 2L, false),
+                        org.assertj.core.groups.Tuple.tuple("matching", 3L, false),
+                        org.assertj.core.groups.Tuple.tuple("complete", 1L, false)
+                );
+
+        assertThat(result.projects()).hasSize(2);
+        ClientDashboardProjectItem firstProject = result.projects().get(0);
+        assertThat(firstProject.proposalId()).isEqualTo(2L);
+        assertThat(firstProject.title()).isEqualTo("AI 기반 데이터 분석 툴 구축");
+        assertThat(firstProject.statusKey()).isEqualTo("WRITING");
+        assertThat(firstProject.statusLabel()).isEqualTo("작성 중");
+        assertThat(firstProject.positionCount()).isEqualTo(2);
+        assertThat(firstProject.totalBudgetText()).isEqualTo("3,000,000원");
+        assertThat(firstProject.modifiedDate()).isEqualTo("2024.03.20");
+        assertThat(firstProject.matchingOverview()).isEqualTo("매칭 시작 전");
+
+        verifyNoMoreInteractions(proposalRepository);
+    }
+
+    @Test
+    @DisplayName("매칭 대기 필터 조회 시 WRITING 상태 제안서만 반환한다")
+    void getDashboard_filtersProjectsByWaitingStatus() {
+        Proposal waitingProposal = createProposal(
+                2L,
+                "AI 기반 데이터 분석 툴 구축",
+                ProposalStatus.WRITING,
+                3_000_000L,
+                3_000_000L,
+                LocalDateTime.of(2024, 3, 20, 10, 0),
+                2
+        );
+
+        given(proposalRepository.findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(
+                OWNER_EMAIL,
+                ProposalStatus.WRITING
+        )).willReturn(List.of(waitingProposal));
+        stubCounts(6L, 2L, 3L, 1L);
+
+        ClientDashboardViewModel result = clientDashboardService.getDashboard(OWNER_EMAIL, ClientDashboardFilter.WAITING);
+
+        InOrder inOrder = inOrder(proposalRepository);
+        inOrder.verify(proposalRepository)
+                .findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(OWNER_EMAIL, ProposalStatus.WRITING);
+        verifyCountQueries(inOrder);
+
+        assertThat(result.selectedFilterKey()).isEqualTo("waiting");
+        assertThat(result.selectedFilterTitle()).isEqualTo("매칭 대기 중");
+        assertThat(result.projects()).singleElement()
+                .satisfies(project -> {
+                    assertThat(project.statusKey()).isEqualTo("WRITING");
+                    assertThat(project.matchingOverview()).isEqualTo("매칭 시작 전");
+                });
+
+        verifyNoMoreInteractions(proposalRepository);
+    }
+
+    @Test
+    @DisplayName("필터가 null이면 전체 필터로 조회한다")
+    void getDashboard_defaultsToAllFilterWhenFilterIsNull() {
+        given(proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL))
+                .willReturn(List.of());
+        stubCounts(0L, 0L, 0L, 0L);
+
+        ClientDashboardViewModel result = clientDashboardService.getDashboard(OWNER_EMAIL, null);
+
+        InOrder inOrder = inOrder(proposalRepository);
+        inOrder.verify(proposalRepository).findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL);
+        verifyCountQueries(inOrder);
+
+        assertThat(result.selectedFilterKey()).isEqualTo("all");
+        assertThat(result.projects()).isEmpty();
+
+        verifyNoMoreInteractions(proposalRepository);
+    }
+
+    private void stubCounts(long total, long waiting, long matching, long complete) {
+        given(proposalRepository.countByMember_Email_Value(OWNER_EMAIL)).willReturn(total);
+        given(proposalRepository.countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.WRITING))
+                .willReturn(waiting);
+        given(proposalRepository.countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.MATCHING))
+                .willReturn(matching);
+        given(proposalRepository.countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.COMPLETE))
+                .willReturn(complete);
+    }
+
+    private void verifyCountQueries(InOrder inOrder) {
+        inOrder.verify(proposalRepository).countByMember_Email_Value(OWNER_EMAIL);
+        inOrder.verify(proposalRepository).countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.WRITING);
+        inOrder.verify(proposalRepository).countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.MATCHING);
+        inOrder.verify(proposalRepository).countByMember_Email_ValueAndStatus(OWNER_EMAIL, ProposalStatus.COMPLETE);
+    }
+
+    private Proposal createProposal(Long id, String title, ProposalStatus status, Long budgetMin, Long budgetMax,
+            LocalDateTime modifiedAt, int positionCount) {
+        Proposal proposal = Proposal.create(
+                createMember(OWNER_EMAIL, "hashed-password", "소유자", "010-1234-5678"),
+                title,
+                "원본 입력",
+                "설명",
+                budgetMin,
+                budgetMax,
+                ProposalWorkType.HYBRID,
+                "판교",
+                12L
+        );
+
+        ReflectionTestUtils.setField(proposal, "id", id);
+        ReflectionTestUtils.setField(proposal, "status", status);
+        ReflectionTestUtils.setField(proposal, "modifiedAt", modifiedAt);
+
+        for (int index = 0; index < positionCount; index++) {
+            proposal.addPosition(Position.create("포지션" + index), 1L, null, null);
+        }
+
+        return proposal;
+    }
+}


### PR DESCRIPTION
## 🔎 What

- `/client/dashboard` 진입 컨트롤러 추가
- 클라이언트 대시보드 ViewModel / item DTO 정의
- 로그인한 사용자의 제안서 목록 조회 서비스 구현
- `Proposal.status` 기반 상태별 개수 집계 구현
- 대시보드 상단 요약 카드 4개 구현
- 카드 선택에 따른 제안서 목록 필터링 구현
- 클라이언트 대시보드 Thymeleaf 화면 추가
- 제안서 목록 테이블 UI 구현
- 상태 배지(`WRITING`, `MATCHING`, `COMPLETE`) 표시 규칙 반영
- 포지션 수 / 총 예산 / 최종 수정일 표시
- `매칭 현황` 컬럼은 현재 도메인 범위에 맞는 임시 문구로 우선 처리
- `새 프로젝트 만들기` 버튼은 화면에만 두고 실제 이동 연결은 보류
- 컨트롤러 테스트 및 서비스 테스트 작성

## 🔗 Issue

- Closes: #30 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?