### PR TITLE
[Feat] 추천 실행 상태 조회(run) 엔드포인트 및 상태 페이지 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -64,7 +64,7 @@ public class RecommendationController {
 
             redirectAttributes.addAttribute("runId", runId);
             redirectAttributes.addAttribute("proposalId", proposalId);
-            return "redirect:/proposals/{proposalId}/recommendations/runs/{runId}";
+            return "redirect:/proposals/{proposalId}/runs/{runId}";
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, form.proposalPositionId(), principal.getEmail(), e);

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -2,8 +2,10 @@ package com.generic4.itda.controller;
 
 import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
+import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.recommend.RecommendationEntryService;
+import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class RecommendationController {
 
     private final RecommendationEntryService recommendationEntryService;
     private final RecommendationRunService recommendationRunService;
+    private final RecommendationRunQueryService recommendationRunQueryService;
 
     @GetMapping("/proposals/{proposalId}/recommendations")
     public String entry(
@@ -72,6 +75,20 @@ public class RecommendationController {
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
             return "redirect:/proposals/{proposalId}/recommendations";
         }
+    }
+
+    @GetMapping("/proposals/{proposalId}/runs/{runId}")
+    public String runStatus(
+            @PathVariable Long proposalId,
+            @PathVariable Long runId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model
+    ) {
+        RecommendationRunStatusViewModel view = recommendationRunQueryService
+                .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
+
+        model.addAttribute("view", view);
+        return "recommendation/status";
     }
 
     private static String toUserMessage(RuntimeException e) {

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -84,11 +84,22 @@ public class RecommendationController {
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
-        RecommendationRunStatusViewModel view = recommendationRunQueryService
-                .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
+        try {
+            RecommendationRunStatusViewModel view = recommendationRunQueryService
+                    .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
 
-        model.addAttribute("view", view);
-        return "recommendation/status";
+            model.addAttribute("view", view);
+            return "recommendation/status";
+        } catch (IllegalArgumentException e) {
+            log.warn("추천 실행 상태 조회 실패. proposalId={}, runId={}, email={}",
+                    proposalId, runId, principal.getEmail(), e);
+
+            model.addAttribute("title", "추천 실행 정보를 확인할 수 없습니다.");
+            model.addAttribute("message", toRunStatusUserMessage(e));
+            model.addAttribute("backUrl", "/proposals/" + proposalId + "/recommendations");
+
+            return "recommendation/error";
+        }
     }
 
     private static String toUserMessage(RuntimeException e) {
@@ -99,5 +110,14 @@ public class RecommendationController {
             return "현재 상태에는 추천을 실행할 수 없습니다.";
         }
         return "추천 요청 처리 중 문제가 발생했습니다. 다시 시도해주세요.";
+    }
+
+    private static String toRunStatusUserMessage(IllegalArgumentException e) {
+        return switch (e.getMessage()) {
+            case "추천 실행 정보를 찾을 수 없습니다." -> "존재하지 않거나 만료된 추천 실행입니다.";
+            case "잘못된 추천 실행 접근입니다." -> "요청한 추천 실행 정보가 올바르지 않습니다.";
+            case "접근 권한이 없습니다." -> "해당 추천 실행 정보에 접근할 수 없습니다.";
+            default -> "추천 실행 정보를 불러오는 중 문제가 발생했습니다.";
+        };
     }
 }

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunStatusViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunStatusViewModel.java
@@ -1,0 +1,50 @@
+package com.generic4.itda.dto.recommend;
+
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+
+/**
+ * 추천 실행(run) 상태를 기반으로 결과 페이지에서 사용자에게 노출할 데이터를 담는 ViewModel.
+ *
+ * <p>이 ViewModel은 RecommendationRun 도메인 객체를 그대로 노출하지 않고,
+ * 화면에서 필요한 정보(문구, 상태, 다음 액션)를 가공하여 전달하기 위한 역할을 가진다.</p>
+ *
+ * <p>특히 비동기 추천 실행 흐름에서 결과가 아직 생성되지 않은 경우에도
+ * 상태(PENDING / RUNNING / COMPUTED / FAILED)에 따라 사용자에게 적절한 안내 메시지와 후속 액션을 제공하기 위해 사용된다.</p>
+ *
+ * <h3>설계 의도</h3>
+ * <ul>
+ *     <li>도메인 상태를 UI 친화적인 형태로 변환한다.</li>
+ *     <li>템플릿에서 상태 분기 로직을 최소화한다.</li>
+ *     <li>추천 결과 페이지의 "상태 셸(shell)" 역할을 지원한다.</li>
+ * </ul>
+ *
+ * <h3>상태별 동작 예시</h3>
+ * <ul>
+ *     <li>PENDING / RUNNING: 진행 중 안내 및 새로고침 유도</li>
+ *     <li>COMPUTED: 결과 목록 페이지로 이동 가능</li>
+ *     <li>FAILED: 실패 안내 및 재시도 유도</li>
+ * </ul>
+ *
+ * @param proposalId      제안서 식별자 (URL 및 링크 생성에 사용)
+ * @param runId           추천 실행 식별자 (URL 및 상태 조회에 사용)
+ * @param proposalTitle   제안서 제목 (사용자 컨텍스트 표시용)
+ * @param status          추천 실행 상태 (도메인 상태)
+ * @param title           상태에 따른 주요 안내 제목
+ * @param message         상태에 따른 상세 안내 메시지
+ * @param nextActionLabel 사용자에게 제공할 다음 액션 버튼 라벨
+ * @param nextActionUrl   다음 액션으로 이동할 URL (없을 경우 null 가능)
+ * @param autoRefresh     자동 새로고침 여부 (진행 중 상태에서 true)
+ */
+public record RecommendationRunStatusViewModel(
+        Long proposalId,
+        Long runId,
+        String proposalTitle,
+        RecommendationRunStatus status,
+        String title,
+        String message,
+        String nextActionLabel,
+        String nextActionUrl,
+        boolean autoRefresh
+) {
+
+}

--- a/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
@@ -4,6 +4,7 @@ import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecommendationRunRepository extends JpaRepository<RecommendationRun, Long> {
 
@@ -12,4 +13,14 @@ public interface RecommendationRunRepository extends JpaRepository<Recommendatio
             String requestFingerprint,
             RecommendationAlgorithm algorithm
     );
+
+    @Query("""
+            select rr
+            from RecommendationRun rr
+            join fetch rr.proposalPosition pp
+            join fetch pp.proposal p
+            join fetch p.member m
+            where rr.id = :runId
+            """)
+    Optional<RecommendationRun> findDetailById(Long runId);
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -1,0 +1,95 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendationRunQueryService {
+
+    private final RecommendationRunRepository recommendationRunRepository;
+
+    public RecommendationRunStatusViewModel getRecommendationRunStatus(Long proposalId, Long runId, String email) {
+        RecommendationRun run = recommendationRunRepository.findDetailById(runId)
+                .orElseThrow(() -> new IllegalArgumentException("추천 실행 정보를 찾을 수 없습니다."));
+
+        ProposalPosition proposalPosition = run.getProposalPosition();
+        Proposal proposal = proposalPosition.getProposal();
+
+        validateProposalMatches(proposal, proposalId);
+        validateOwnership(proposal, email);
+
+        return toViewModel(proposal, run);
+    }
+
+    private void validateProposalMatches(Proposal proposal, Long proposalId) {
+        if (!proposal.getId().equals(proposalId)) {
+            throw new IllegalArgumentException("잘못된 추천 실행 접근입니다.");
+        }
+    }
+
+    private void validateOwnership(Proposal proposal, String email) {
+        if (!proposal.getMember().getEmail().getValue().equals(email)) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+    }
+
+    private RecommendationRunStatusViewModel toViewModel(
+            Proposal proposal,
+            RecommendationRun run
+    ) {
+        return switch (run.getStatus()) {
+            case PENDING -> new RecommendationRunStatusViewModel(
+                    proposal.getId(),
+                    run.getId(),
+                    proposal.getTitle(),
+                    run.getStatus(),
+                    "추천 요청이 접수되었습니다.",
+                    "선택한 포지션의 추천 결과를 준비하고 있습니다.",
+                    "새로고침",
+                    "/proposals/%d/runs/%d".formatted(proposal.getId(), run.getId()),
+                    true
+            );
+            case RUNNING -> new RecommendationRunStatusViewModel(
+                    proposal.getId(),
+                    run.getId(),
+                    proposal.getTitle(),
+                    run.getStatus(),
+                    "추천을 계산하고 있습니다.",
+                    "잠시 후 추천 결과를 확인할 수 있습니다.",
+                    "새로고침",
+                    "/proposals/%d/runs/%d".formatted(proposal.getId(), run.getId()),
+                    true
+            );
+            case COMPUTED -> new RecommendationRunStatusViewModel(
+                    proposal.getId(),
+                    run.getId(),
+                    proposal.getTitle(),
+                    run.getStatus(),
+                    "추천 결과가 준비되었습니다.",
+                    "추천 결과 목록으로 이동할 수 있습니다.",
+                    "결과 보기",
+                    "/proposals/%d/recommendations/results?runId=%d".formatted(proposal.getId(), run.getId()),
+                    false
+            );
+            case FAILED -> new RecommendationRunStatusViewModel(
+                    proposal.getId(),
+                    run.getId(),
+                    proposal.getTitle(),
+                    run.getStatus(),
+                    "추천 생성에 실패했습니다.",
+                    "잠시 후 다시 시도해 주세요.",
+                    "추천 다시 실행",
+                    "/proposals/%d/recommendations".formatted(proposal.getId()),
+                    false
+            );
+        };
+    }
+}

--- a/src/main/resources/templates/recommendation/error.html
+++ b/src/main/resources/templates/recommendation/error.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+  <title>추천 실행 오류</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6">
+
+      <!-- 헤더 -->
+      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-black uppercase tracking-widest text-slate-400">
+              Recommendation Error
+            </p>
+            <h1 class="mt-2 text-3xl font-black tracking-tight text-slate-950"
+                th:text="${title}">
+              추천 실행 정보를 확인할 수 없습니다.
+            </h1>
+            <p class="mt-3 text-sm text-slate-500">
+              요청한 추천 실행을 불러오는 중 문제가 발생했습니다.
+            </p>
+          </div>
+
+          <span class="rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-bold text-rose-700">
+            접근 불가
+          </span>
+        </div>
+
+        <div class="mt-5 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4">
+          <p class="text-sm font-semibold text-rose-700"
+             th:text="${message}">
+            요청한 추천 실행에 접근할 수 없습니다.
+          </p>
+        </div>
+
+        <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <p class="text-sm leading-6 text-slate-600">
+            잘못된 실행 정보이거나 접근 권한이 없을 수 있습니다. 이전 페이지로 돌아가 다시 확인해 주세요.
+          </p>
+        </div>
+      </section>
+
+      <!-- 액션 -->
+      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <p class="text-sm text-slate-500">
+            추천 진입 페이지로 돌아가 다시 시도할 수 있습니다.
+          </p>
+
+          <div class="flex flex-wrap gap-3">
+            <a th:href="${backUrl}"
+               class="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800">
+              이전 페이지로 돌아가기
+            </a>
+
+            <a th:href="@{/proposals}"
+               class="rounded-2xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+              제안서 목록으로 이동
+            </a>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/recommendation/status.html
+++ b/src/main/resources/templates/recommendation/status.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>추천 결과</title>
+  <meta http-equiv="refresh" content="5" th:if="${view.autoRefresh}">
+</head>
+<body>
+<main>
+  <h1 th:text="${view.title}">추천 상태 제목</h1>
+  <p th:text="${view.proposalTitle}">제안서 제목</p>
+  <p th:text="${view.message}">상태 메시지</p>
+
+  <a th:if="${view.nextActionUrl != null}"
+     th:href="${view.nextActionUrl}"
+     th:text="${view.nextActionLabel}">
+    다음 액션
+  </a>
+</main>
+</body>
+</html>

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -14,6 +14,7 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -147,6 +148,66 @@ class RecommendationRunRepositoryTest {
                     recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                             otherPP.getId(), FP, ALG);
 
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findDetailById")
+    class FindDetailById {
+
+        private RecommendationRun run;
+
+        @BeforeEach
+        void saveRun() {
+            run = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-detail", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            em.clear();
+        }
+
+        @Test
+        @DisplayName("run, proposalPosition, proposal, member를 한 번에 조회한다")
+        void run과_연결된_상위_그래프를_함께_조회한다() {
+            // when
+            Optional<RecommendationRun> result = recommendationRunRepository.findDetailById(run.getId());
+
+            // then
+            assertThat(result).isPresent();
+
+            RecommendationRun found = result.orElseThrow();
+            PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+
+            assertThat(util.isLoaded(found, "proposalPosition")).isTrue();
+            assertThat(found.getProposalPosition().getId()).isEqualTo(proposalPosition.getId());
+
+            assertThat(util.isLoaded(found.getProposalPosition(), "proposal")).isTrue();
+            assertThat(found.getProposalPosition().getProposal().getId()).isEqualTo(proposal.getId());
+
+            assertThat(util.isLoaded(found.getProposalPosition().getProposal(), "member")).isTrue();
+            assertThat(found.getProposalPosition().getProposal().getMember().getId())
+                    .isEqualTo(proposal.getMember().getId());
+        }
+
+        @Test
+        @DisplayName("쿼리에 포함되지 않은 연관은 LAZY 상태로 남는다")
+        void 쿼리에_포함되지_않은_연관은_LAZY_상태로_남는다() {
+            // when
+            RecommendationRun found = recommendationRunRepository.findDetailById(run.getId()).orElseThrow();
+
+            // then
+            PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+
+            assertThat(util.isLoaded(found.getProposalPosition(), "position")).isFalse();
+            assertThat(util.isLoaded(found.getProposalPosition().getProposal(), "positions")).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id면 빈 Optional을 반환한다")
+        void 존재하지_않는_id면_빈_Optional을_반환한다() {
+            // when
+            Optional<RecommendationRun> result = recommendationRunRepository.findDetailById(Long.MAX_VALUE);
+
+            // then
             assertThat(result).isEmpty();
         }
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -1,0 +1,291 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * RecommendationRunQueryService 단위 테스트:
+ * - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을 수행하는지 확인한다.
+ *
+ * 한계:
+ * - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다.
+ * - proposal/member/proposalPosition 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class RecommendationRunQueryServiceTest {
+
+    private static final Long PROPOSAL_ID = 10L;
+    private static final Long RUN_ID = 301L;
+    private static final Long OWNER_ID = 1L;
+    private static final String OWNER_EMAIL = "owner@example.com";
+
+    @Mock
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @InjectMocks
+    private RecommendationRunQueryService service;
+
+    @Test
+    @DisplayName("PENDING 상태면 새로고침 가능한 상태 ViewModel을 반환한다")
+    void getRecommendationRunStatus_returnsPendingViewModel() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when
+        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertViewModel(
+                result,
+                RecommendationRunStatus.PENDING,
+                "추천 요청이 접수되었습니다.",
+                "선택한 포지션의 추천 결과를 준비하고 있습니다.",
+                "새로고침",
+                "/proposals/10/runs/301",
+                true
+        );
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("RUNNING 상태면 새로고침 가능한 진행중 ViewModel을 반환한다")
+    void getRecommendationRunStatus_returnsRunningViewModel() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when
+        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertViewModel(
+                result,
+                RecommendationRunStatus.RUNNING,
+                "추천을 계산하고 있습니다.",
+                "잠시 후 추천 결과를 확인할 수 있습니다.",
+                "새로고침",
+                "/proposals/10/runs/301",
+                true
+        );
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태면 결과 페이지로 이동하는 ViewModel을 반환한다")
+    void getRecommendationRunStatus_returnsComputedViewModel() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when
+        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertViewModel(
+                result,
+                RecommendationRunStatus.COMPUTED,
+                "추천 결과가 준비되었습니다.",
+                "추천 결과 목록으로 이동할 수 있습니다.",
+                "결과 보기",
+                "/proposals/10/recommendations/results?runId=301",
+                false
+        );
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("FAILED 상태면 재실행 안내 ViewModel을 반환한다")
+    void getRecommendationRunStatus_returnsFailedViewModel() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.FAILED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when
+        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertViewModel(
+                result,
+                RecommendationRunStatus.FAILED,
+                "추천 생성에 실패했습니다.",
+                "잠시 후 다시 시도해 주세요.",
+                "추천 다시 실행",
+                "/proposals/10/recommendations",
+                false
+        );
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 run이면 IllegalArgumentException이 발생한다")
+    void getRecommendationRunStatus_throwsWhenRunNotFound() {
+        // given
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("추천 실행 정보를 찾을 수 없습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("run이 다른 proposal에 속하면 IllegalArgumentException이 발생한다")
+    void getRecommendationRunStatus_throwsWhenProposalDoesNotMatch() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(999L, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 추천 실행 접근입니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("제안서 소유자 이메일과 다르면 IllegalArgumentException이 발생한다")
+    void getRecommendationRunStatus_throwsWhenEmailDoesNotMatchOwner() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, "other@example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("접근 권한이 없습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    private void assertViewModel(
+            RecommendationRunStatusViewModel viewModel,
+            RecommendationRunStatus status,
+            String title,
+            String message,
+            String nextActionLabel,
+            String nextActionUrl,
+            boolean autoRefresh
+    ) {
+        assertThat(viewModel.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(viewModel.runId()).isEqualTo(RUN_ID);
+        assertThat(viewModel.proposalTitle()).isEqualTo("추천 테스트 제안서");
+        assertThat(viewModel.status()).isEqualTo(status);
+        assertThat(viewModel.title()).isEqualTo(title);
+        assertThat(viewModel.message()).isEqualTo(message);
+        assertThat(viewModel.nextActionLabel()).isEqualTo(nextActionLabel);
+        assertThat(viewModel.nextActionUrl()).isEqualTo(nextActionUrl);
+        assertThat(viewModel.autoRefresh()).isEqualTo(autoRefresh);
+    }
+
+    private RecommendationRun createOwnedRunWithStatus(RecommendationRunStatus status) {
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposal(owner, PROPOSAL_ID);
+        ProposalPosition proposalPosition = addPosition(proposal, 21L, "백엔드 개발자");
+
+        RecommendationRun run = RecommendationRun.create(
+                proposalPosition,
+                "fp-abc123",
+                RecommendationAlgorithm.HEURISTIC_V1,
+                3
+        );
+        ReflectionTestUtils.setField(run, "id", RUN_ID);
+
+        applyStatus(run, status);
+        return run;
+    }
+
+    private void applyStatus(RecommendationRun run, RecommendationRunStatus status) {
+        switch (status) {
+            case PENDING -> {
+                return;
+            }
+            case RUNNING -> run.markRunning();
+            case COMPUTED -> {
+                run.markRunning();
+                run.markCompleted(new HardFilterStat(12, 8, 5, 3));
+            }
+            case FAILED -> {
+                run.markRunning();
+                run.markFailed("추천 생성 실패");
+            }
+        }
+    }
+
+    private Proposal createProposal(Member member, Long proposalId) {
+        Proposal proposal = Proposal.create(
+                member,
+                "추천 테스트 제안서",
+                "raw-input",
+                "description",
+                3_000_000L,
+                5_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                3L
+        );
+        ReflectionTestUtils.setField(proposal, "id", proposalId);
+        ReflectionTestUtils.setField(proposal, "status", ProposalStatus.MATCHING);
+        return proposal;
+    }
+
+    private ProposalPosition addPosition(Proposal proposal, Long proposalPositionId, String positionName) {
+        Position position = Position.create(positionName);
+        ReflectionTestUtils.setField(position, "id", proposalPositionId + 1000);
+
+        ProposalPosition proposalPosition = proposal.addPosition(position, 1L, 1_000_000L, 2_000_000L);
+        ReflectionTestUtils.setField(proposalPosition, "id", proposalPositionId);
+        return proposalPosition;
+    }
+
+    private Member createMemberWithId(Long memberId, String email) {
+        Member member = Member.create(
+                email,
+                "hashed-password",
+                "테스터",
+                null,
+                null,
+                "010-1234-5678"
+        );
+        ReflectionTestUtils.setField(member, "id", memberId);
+        return member;
+    }
+}


### PR DESCRIPTION
## 🔎 What

- 사용자가 요청한 추천의 상태와 추천 결과를 API로 노출하고자 했습니
- 이를 위해, 추천 실행을 조회하는 로직을 개발하고 뷰를 노출했습니다.
- 다만, 추천을 실제로 처리해주는 비동기 워커는 구현되어 있지 않습니다.
- 따라서, 해당 뷰에서 추천 결과를 보여주는 기능은 제외되었습니다.
- 또한, 아직 플로우 자체가 마무리되지 않았기 때문에 과도한 UI 디자인은 불필요한 변경 포인트를 늘릴 수 있다 판단해, 스켈레톤 정도만 삽입하여 UX 공백을 메꿨습니다.

## 🔗 Issue

- Closes: #29 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?