### PR TITLE
[Feat] RecommendationRun 점유 및 RUNNING 전이 처리

### DIFF
--- a/src/main/java/com/generic4/itda/ItDaApplication.java
+++ b/src/main/java/com/generic4/itda/ItDaApplication.java
@@ -3,7 +3,9 @@ package com.generic4.itda;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ItDaApplication {

--- a/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
@@ -2,8 +2,11 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface RecommendationRunRepository extends JpaRepository<RecommendationRun, Long> {
@@ -23,4 +26,22 @@ public interface RecommendationRunRepository extends JpaRepository<Recommendatio
             where rr.id = :runId
             """)
     Optional<RecommendationRun> findDetailById(Long runId);
+
+    @Query("""
+            select rr.id
+            from RecommendationRun rr
+            where rr.status = com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.PENDING
+            order by rr.id asc
+            """)
+    List<Long> findPendingRunIds(Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update RecommendationRun rr
+            set rr.status = com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.RUNNING,
+                rr.errorMessage = null
+            where rr.id = :runId
+            and rr.status = com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.PENDING
+            """)
+    int claimAsRunning(Long runId);
 }

--- a/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -39,9 +40,14 @@ public interface RecommendationRunRepository extends JpaRepository<Recommendatio
     @Query("""
             update RecommendationRun rr
             set rr.status = com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.RUNNING,
-                rr.errorMessage = null
+                rr.errorMessage = null,
+                rr.modifiedAt = :startedAt
             where rr.id = :runId
             and rr.status = com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.PENDING
             """)
-    int claimAsRunning(Long runId);
+    int claimAsRunning(Long runId, LocalDateTime startedAt);
+
+    default int claimAsRunning(Long runId) {
+        return claimAsRunning(runId, LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunExecutor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunExecutor.java
@@ -1,0 +1,34 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecommendationRunExecutor {
+
+    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 1);
+    private final RecommendationRunRepository recommendationRunRepository;
+
+    public Optional<Long> claimNextPendingRun() {
+        List<Long> pendingRunIds = recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN);
+        if (pendingRunIds.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Long runId = pendingRunIds.get(0);
+        int updated = recommendationRunRepository.claimAsRunning(runId);
+
+        if (updated == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(runId);
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunPollingScheduler.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunPollingScheduler.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.service.recommend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationRunPollingScheduler {
+
+    private final RecommendationRunExecutor recommendationRunExecutor;
+    private final RecommendationRunProcessor recommendationRunProcessor;
+
+    @Scheduled(fixedDelay = 3000)
+    public void poll() {
+        recommendationRunExecutor.claimNextPendingRun()
+                .ifPresent(recommendationRunProcessor::process);
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
@@ -1,0 +1,42 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecommendationRunProcessor {
+
+    private final RecommendationRunRepository recommendationRunRepository;
+
+    public void process(Long runId) {
+        RecommendationRun run = recommendationRunRepository.findById(runId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 추천 실행입니다."));
+
+        if (!run.isRunning()) {
+            throw new IllegalStateException("RUNNING 상태의 추천 실행만 처리할 수 있습니다.");
+        }
+
+        try {
+            doProcess(run);
+        } catch (Exception e) {
+            run.markFailed(resolveErrorMessage(e));
+        }
+    }
+
+    void doProcess(RecommendationRun run) {
+        // TODO 실제 추천 계산 / 결과 저장 / 완료 처리
+    }
+
+    private String resolveErrorMessage(Exception e) {
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            return "추천 실행 중 오류가 발생했습니다.";
+        }
+        return message;
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -15,12 +15,14 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 @RepositoryTest
 class RecommendationRunRepositoryTest {
@@ -212,9 +214,144 @@ class RecommendationRunRepositoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("findPendingRunIds")
+    class FindPendingRunIds {
+
+        @Test
+        @DisplayName("PENDING 상태인 run id만 반환된다")
+        void PENDING_상태인_run_id만_반환된다() {
+            RecommendationRun pending = saveRunWithStatus(RecommendationRunStatus.PENDING);
+            saveRunWithStatus(RecommendationRunStatus.RUNNING);
+            saveRunWithStatus(RecommendationRunStatus.COMPUTED);
+            saveRunWithStatus(RecommendationRunStatus.FAILED);
+            em.clear();
+
+            List<Long> ids = recommendationRunRepository.findPendingRunIds(PageRequest.of(0, 100));
+
+            assertThat(ids).containsExactly(pending.getId());
+        }
+
+        @Test
+        @DisplayName("id asc 순으로 정렬되어 반환된다")
+        void id_asc_순으로_정렬되어_반환된다() {
+            RecommendationRun first = saveRunWithStatus(RecommendationRunStatus.PENDING);
+            RecommendationRun second = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-second", RecommendationAlgorithm.VECTOR_ENGINE_V1,
+                            5));
+            em.clear();
+
+            List<Long> ids = recommendationRunRepository.findPendingRunIds(PageRequest.of(0, 100));
+
+            assertThat(ids).containsExactly(first.getId(), second.getId());
+        }
+
+        @Test
+        @DisplayName("PageRequest size 1 적용 시 1건만 반환된다")
+        void PageRequest_size_1_적용_시_1건만_반환된다() {
+            saveRunWithStatus(RecommendationRunStatus.PENDING);
+            recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-second", RecommendationAlgorithm.VECTOR_ENGINE_V1,
+                            5));
+            em.clear();
+
+            List<Long> ids = recommendationRunRepository.findPendingRunIds(PageRequest.of(0, 1));
+
+            assertThat(ids).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("PENDING run이 없으면 빈 리스트를 반환한다")
+        void PENDING_run이_없으면_빈_리스트를_반환한다() {
+            saveRunWithStatus(RecommendationRunStatus.RUNNING);
+            em.clear();
+
+            List<Long> ids = recommendationRunRepository.findPendingRunIds(PageRequest.of(0, 100));
+
+            assertThat(ids).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("claimAsRunning")
+    class ClaimAsRunning {
+
+        @Test
+        @DisplayName("PENDING 상태 run 점유 시 update count가 1이다")
+        void PENDING_상태_run_점유_시_update_count가_1이다() {
+            RecommendationRun run = saveRunWithStatus(RecommendationRunStatus.PENDING);
+
+            int count = recommendationRunRepository.claimAsRunning(run.getId());
+
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("claimAsRunning 후 DB에서 다시 조회하면 RUNNING 상태이고 errorMessage가 null이다")
+        void claimAsRunning_후_상태가_RUNNING이고_errorMessage가_null이다() {
+            RecommendationRun run = saveRunWithStatus(RecommendationRunStatus.PENDING);
+
+            recommendationRunRepository.claimAsRunning(run.getId());
+            em.clear();
+
+            RecommendationRun found = recommendationRunRepository.findById(run.getId()).orElseThrow();
+            assertThat(found.getStatus()).isEqualTo(RecommendationRunStatus.RUNNING);
+            assertThat(found.getErrorMessage()).isNull();
+        }
+
+        @Test
+        @DisplayName("같은 run을 두 번 호출하면 첫 번째만 1, 두 번째는 0이다")
+        void 같은_run을_두_번_호출하면_첫_번째만_성공한다() {
+            RecommendationRun run = saveRunWithStatus(RecommendationRunStatus.PENDING);
+
+            int first = recommendationRunRepository.claimAsRunning(run.getId());
+            int second = recommendationRunRepository.claimAsRunning(run.getId());
+
+            assertThat(first).isEqualTo(1);
+            assertThat(second).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("RUNNING 상태 run은 점유되지 않는다")
+        void RUNNING_상태_run은_점유되지_않는다() {
+            RecommendationRun run = saveRunWithStatus(RecommendationRunStatus.RUNNING);
+
+            int count = recommendationRunRepository.claimAsRunning(run.getId());
+
+            assertThat(count).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("COMPUTED 또는 FAILED 상태 run은 점유되지 않는다")
+        void COMPUTED_또는_FAILED_상태_run은_점유되지_않는다() {
+            RecommendationRun computed = saveRunWithStatus(RecommendationRunStatus.COMPUTED);
+            RecommendationRun failed = saveRunWithStatus(RecommendationRunStatus.FAILED);
+
+            assertThat(recommendationRunRepository.claimAsRunning(computed.getId())).isEqualTo(0);
+            assertThat(recommendationRunRepository.claimAsRunning(failed.getId())).isEqualTo(0);
+        }
+    }
+
     private Position persistPosition(String name) {
         Position position = Position.create(name);
         em.persist(position);
         return position;
+    }
+
+    private RecommendationRun saveRunWithStatus(RecommendationRunStatus targetStatus) {
+        RecommendationRun run = recommendationRunRepository.saveAndFlush(
+                RecommendationRun.create(proposalPosition, "fp-" + targetStatus.name().toLowerCase(),
+                        RecommendationAlgorithm.HEURISTIC_V1, 5));
+        if (targetStatus == RecommendationRunStatus.RUNNING
+                || targetStatus == RecommendationRunStatus.COMPUTED
+                || targetStatus == RecommendationRunStatus.FAILED) {
+            run.markRunning();
+        }
+        if (targetStatus == RecommendationRunStatus.COMPUTED) {
+            run.markCompleted(new HardFilterStat(10, 8, 6, 3));
+        } else if (targetStatus == RecommendationRunStatus.FAILED) {
+            run.markFailed("의도된 실패");
+        }
+        return recommendationRunRepository.saveAndFlush(run);
     }
 }

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -15,6 +15,7 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -329,6 +330,22 @@ class RecommendationRunRepositoryTest {
 
             assertThat(recommendationRunRepository.claimAsRunning(computed.getId())).isEqualTo(0);
             assertThat(recommendationRunRepository.claimAsRunning(failed.getId())).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("claimAsRunning 시 modifiedAt이 전달한 시각으로 갱신된다")
+        void claimAsRunning_시_modifiedAt이_전달한_시각으로_갱신된다() {
+            RecommendationRun run = saveRunWithStatus(RecommendationRunStatus.PENDING);
+            LocalDateTime startedAt = LocalDateTime.of(2026, 4, 17, 15, 30, 0);
+
+            recommendationRunRepository.claimAsRunning(run.getId(), startedAt);
+            em.flush();
+            em.clear();
+
+            RecommendationRun found = recommendationRunRepository.findById(run.getId()).orElseThrow();
+
+            assertThat(found.getStatus()).isEqualTo(RecommendationRunStatus.RUNNING);
+            assertThat(found.getModifiedAt()).isEqualTo(startedAt);
         }
     }
 

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendRunPollingSchedulerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendRunPollingSchedulerTest.java
@@ -1,0 +1,55 @@
+package com.generic4.itda.service.recommend;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationRunPollingSchedulerTest {
+
+    @Mock
+    private RecommendationRunExecutor recommendationRunExecutor;
+
+    @Mock
+    private RecommendationRunProcessor recommendationRunProcessor;
+
+    @InjectMocks
+    private RecommendationRunPollingScheduler recommendationRunPollingScheduler;
+
+    @Nested
+    @DisplayName("poll")
+    class Poll {
+
+        @Test
+        @DisplayName("점유 가능한 run이 없으면 processor를 호출하지 않는다")
+        void 점유_가능한_run이_없으면_processor를_호출하지_않는다() {
+            given(recommendationRunExecutor.claimNextPendingRun())
+                    .willReturn(Optional.empty());
+
+            recommendationRunPollingScheduler.poll();
+
+            then(recommendationRunExecutor).should().claimNextPendingRun();
+            then(recommendationRunProcessor).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("점유한 run이 있으면 processor를 호출한다")
+        void 점유한_run이_있으면_processor를_호출한다() {
+            given(recommendationRunExecutor.claimNextPendingRun())
+                    .willReturn(Optional.of(1L));
+
+            recommendationRunPollingScheduler.poll();
+
+            then(recommendationRunExecutor).should().claimNextPendingRun();
+            then(recommendationRunProcessor).should().process(1L);
+        }
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunExecutorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunExecutorTest.java
@@ -1,0 +1,81 @@
+package com.generic4.itda.service.recommend;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationRunExecutorTest {
+
+    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 1);
+
+    @Mock
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @InjectMocks
+    private RecommendationRunExecutor recommendationRunExecutor;
+
+    @Test
+    @DisplayName("대기 중인 run이 없으면 빈 값을 반환한다")
+    void 대기_중인_run이_없으면_빈_값을_반환한다() {
+        given(recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN))
+                .willReturn(List.of());
+
+        Optional<Long> result = recommendationRunExecutor.claimNextPendingRun();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("대기 중인 run 점유에 성공하면 runId를 반환한다")
+    void 대기_중인_run_점유에_성공하면_runId를_반환한다() {
+        given(recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN))
+                .willReturn(List.of(1L));
+        given(recommendationRunRepository.claimAsRunning(1L))
+                .willReturn(1);
+
+        Optional<Long> result = recommendationRunExecutor.claimNextPendingRun();
+
+        assertThat(result).contains(1L);
+    }
+
+    @Test
+    @DisplayName("대기 중인 run이 있어도 이미 다른 실행기가 점유했으면 빈 값을 반환한다")
+    void claim_실패하면_빈_값을_반환한다() {
+        given(recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN))
+                .willReturn(List.of(1L));
+        given(recommendationRunRepository.claimAsRunning(1L))
+                .willReturn(0);
+
+        Optional<Long> result = recommendationRunExecutor.claimNextPendingRun();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 대기 run이 있어도 가장 앞의 run 하나만 점유 시도한다")
+    void 여러_대기_run이_있어도_가장_앞의_run_하나만_점유_시도한다() {
+        given(recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN))
+                .willReturn(List.of(1L));
+
+        given(recommendationRunRepository.claimAsRunning(1L))
+                .willReturn(1);
+
+        Optional<Long> result = recommendationRunExecutor.claimNextPendingRun();
+
+        assertThat(result).contains(1L);
+        then(recommendationRunRepository).should().claimAsRunning(1L);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -1,0 +1,154 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.spy;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationRunProcessorTest {
+
+    @Mock
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @InjectMocks
+    private RecommendationRunProcessor recommendationRunProcessor;
+
+    @Nested
+    @DisplayName("process")
+    class Process {
+
+        @Test
+        @DisplayName("존재하지 않는 run이면 예외가 발생한다")
+        void 존재하지_않는_run이면_예외가_발생한다() {
+            given(recommendationRunRepository.findById(1L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recommendationRunProcessor.process(1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("존재하지 않는 추천 실행입니다.");
+        }
+
+        @Test
+        @DisplayName("RUNNING 상태가 아니면 예외가 발생한다")
+        void RUNNING_상태가_아니면_예외가_발생한다() {
+            RecommendationRun run = createRun(false);
+
+            given(recommendationRunRepository.findById(1L))
+                    .willReturn(Optional.of(run));
+
+            assertThatThrownBy(() -> recommendationRunProcessor.process(1L))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("RUNNING 상태의 추천 실행만 처리할 수 있습니다.");
+        }
+
+        @Test
+        @DisplayName("RUNNING 상태의 run이면 예외없이 처리한다")
+        void RUNNING_상태의_run이면_예외_없이_처리한다() {
+            RecommendationRun run = createRun(true);
+
+            given(recommendationRunRepository.findById(1L))
+                    .willReturn(Optional.of(run));
+
+            assertThatCode(() -> recommendationRunProcessor.process(1L))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    @DisplayName("처리 중 예외가 발생하면 FAILED 상태로 전이하고 예외 메시지를 저장한다")
+    void 처리_중_예외가_발생하면_FAILED_상태로_전이하고_예외_메시지를_저장한다() {
+        RecommendationRun run = createRun(true);
+        RecommendationRunProcessor spyProcessor = spy(
+                new RecommendationRunProcessor(recommendationRunRepository)
+        );
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        willThrow(new RuntimeException("하드 필터 계산 실패"))
+                .given(spyProcessor).doProcess(run);
+
+        assertThatCode(() -> spyProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("하드 필터 계산 실패");
+    }
+
+    @Test
+    @DisplayName("예외 메시지가 없으면 기본 실패 메시지로 FAILED 처리한다")
+    void 예외_메시지가_없으면_기본_실패_메시지로_FAILED_처리한다() {
+        RecommendationRun run = createRun(true);
+        RecommendationRunProcessor spyProcessor = org.mockito.Mockito.spy(
+                new RecommendationRunProcessor(recommendationRunRepository)
+        );
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        org.mockito.BDDMockito.willThrow(new RuntimeException())
+                .given(spyProcessor).doProcess(run);
+
+        assertThatCode(() -> spyProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(
+                com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
+    }
+
+    private RecommendationRun createRun(boolean running) {
+        RecommendationRun run = RecommendationRun.create(
+                createProposalPosition(),
+                running ? "fp-running" : "fp-pending",
+                RecommendationAlgorithm.HEURISTIC_V1,
+                5
+        );
+
+        if (running) {
+            run.markRunning();
+        }
+
+        return run;
+    }
+
+    private ProposalPosition createProposalPosition() {
+        Member member = createMember();
+
+        Position position = Position.create("백엔드 개발자");
+
+        Proposal proposal = Proposal.create(
+                member,
+                "AI 매칭 플랫폼 구축",
+                "원문 내용",
+                null,
+                null,
+                null,
+                ProposalWorkType.REMOTE,
+                null,
+                null
+        );
+
+        return proposal.addPosition(position, 2L, 500_000L, 1_000_000L);
+    }
+}


### PR DESCRIPTION
## 🔎 What

- `RecommendationRun` 실행 흐름의 기본 구조를 구성했습니다.
- `PENDING` 상태의 run을 안전하게 점유하여 `RUNNING`으로 전이하는 Executor를 구현했습니다.
- `RUNNING`상태의 run을 처리하는 Processor 뼈대를 추가하고, 상태 가드 및 최소 실패 처리 로직을 적용했습니다.
- Executor와 Processor를 연결하는 polling기반 Scheduler를 추가했습니다.
- Repository / Executor / Processor / Scheduler 각각에 대한 테스트 코드를 작성했습니다.
> 이번 PR에서는 실제 추천 계산 및 결과 생성은 포함하지 않고,
> **run 실행 계약과 워크플로우 뼈대 구성에 집중했습니다.**

## 🔗 Issue

- Closes: #35 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?