### PR TITLE
[Feat] 추천 후보 조회 파이프라인 구현

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
@@ -1,0 +1,11 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import java.util.List;
+
+public interface ResumeQueryRepository {
+
+    List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize);
+
+    List<Long> findRecommendableResumeIds(int candidatePoolSize);
+}

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.QResume;
+import com.generic4.itda.domain.resume.QResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QResume resume = QResume.resume;
+    private static final QResumeSkill resumeSkill = QResumeSkill.resumeSkill;
+
+    @Override
+    public List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize) {
+        NumberExpression<Integer> proficiencySquaredSum = new CaseBuilder()
+                .when(resumeSkill.proficiency.eq(Proficiency.BEGINNER)).then(1)
+                .when(resumeSkill.proficiency.eq(Proficiency.INTERMEDIATE)).then(4)
+                .when(resumeSkill.proficiency.eq(Proficiency.ADVANCED)).then(9)
+                .otherwise(0)
+                .sum();
+
+        NumberExpression<Long> matchedRequiredSkillCount = resumeSkill.skill.id.countDistinct();
+
+        return queryFactory
+                .select(Projections.constructor(
+                        CandidatePoolRow.class,
+                        resume.id,
+                        matchedRequiredSkillCount,
+                        proficiencySquaredSum,
+                        resume.careerYears
+                ))
+                .from(resume)
+                .join(resume.skills, resumeSkill)
+                .where(
+                        resume.status.eq(ResumeStatus.ACTIVE),
+                        resume.publiclyVisible.isTrue(),
+                        resume.aiMatchingEnabled.isTrue(),
+                        resumeSkill.skill.id.in(requiredSkillIds)
+                )
+                .groupBy(resume.id, resume.careerYears)
+                .orderBy(
+                        matchedRequiredSkillCount.desc(),
+                        proficiencySquaredSum.desc(),
+                        resume.careerYears.desc(),
+                        resume.id.asc()
+                )
+                .limit(candidatePoolSize)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findRecommendableResumeIds(int candidatePoolSize) {
+        return queryFactory
+                .select(resume.id)
+                .from(resume)
+                .where(
+                        resume.status.eq(ResumeStatus.ACTIVE),
+                        resume.publiclyVisible.isTrue(),
+                        resume.aiMatchingEnabled.isTrue()
+                )
+                .orderBy(
+                        resume.careerYears.desc(),
+                        resume.id.asc()
+                )
+                .limit(candidatePoolSize)
+                .fetch();
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.QResume;
 import com.generic4.itda.domain.resume.QResumeSkill;
 import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -47,6 +48,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                         resume.status.eq(ResumeStatus.ACTIVE),
                         resume.publiclyVisible.isTrue(),
                         resume.aiMatchingEnabled.isTrue(),
+                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -68,6 +70,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .where(
                         resume.status.eq(ResumeStatus.ACTIVE),
                         resume.publiclyVisible.isTrue(),
+                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
                         resume.aiMatchingEnabled.isTrue()
                 )
                 .orderBy(

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -1,13 +1,14 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.resume.Resume;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
     Optional<Resume> findByMemberId(Long memberId);
 
     boolean existsByMemberEmailValue(String email);
@@ -17,4 +18,13 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
             "left join fetch r.attachments " +
             "where r.member.email.value = :email")
     Optional<Resume> findByMemberEmailWithDetails(@Param("email") String email);
+
+    @Query("""
+            select distinct r
+            from Resume r
+            left join fetch r.skills rs
+            left join fetch rs.skill
+            where r.id in :resumeIds
+            """)
+    List<Resume> findAllWithSkillsByIds(List<Long> resumeIds);
 }

--- a/src/main/java/com/generic4/itda/service/recommend/CandidatePoolRow.java
+++ b/src/main/java/com/generic4/itda/service/recommend/CandidatePoolRow.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.service.recommend;
+
+public record CandidatePoolRow(
+        Long resumeId,
+        long matchedRequiredSkillCount,
+        int weightedProficiencySum,
+        byte careerYears
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidate.java
@@ -1,0 +1,52 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import java.util.List;
+import java.util.Objects;
+
+public record RecommendationCandidate(
+        Long resumeId,
+        ResumeStatus resumeStatus,
+        boolean publiclyVisible,
+        boolean aiMatchingEnabled,
+        byte careerYears,
+        List<CandidateSkill> skills
+) {
+
+    public RecommendationCandidate {
+        Objects.requireNonNull(resumeId);
+        Objects.requireNonNull(resumeStatus);
+        Objects.requireNonNull(skills);
+        skills = List.copyOf(skills); //방어적 복사
+    }
+
+    public boolean isActive() {
+        return resumeStatus == ResumeStatus.ACTIVE;
+    }
+
+    public record CandidateSkill(
+            Long skillId,
+            String skillName,
+            Proficiency proficiency
+    ) {
+
+        public CandidateSkill {
+            Objects.requireNonNull(skillId);
+            Objects.requireNonNull(skillName);
+            Objects.requireNonNull(proficiency);
+        }
+
+        public static CandidateSkill of(ResumeSkill resumeSkill) {
+            Objects.requireNonNull(resumeSkill);
+            Objects.requireNonNull(resumeSkill.getSkill());
+
+            return new CandidateSkill(
+                    resumeSkill.getSkill().getId(),
+                    resumeSkill.getSkill().getName(),
+                    resumeSkill.getProficiency()
+            );
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -1,0 +1,79 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeQueryRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendationCandidateFinder {
+
+    private static final int MINIMUM_CANDIDATE_POOL_SIZE = 100;
+
+    private final ResumeQueryRepository resumeQueryRepository;
+    private final ResumeRepository resumeRepository;
+
+    public List<RecommendationCandidate> findCandidates(RecommendationRun run) {
+        List<Long> requiredSkillIds = extractRequiredSkillIds(run);
+        int candidatePoolSize = resolveCandidatePoolSize(run.getTopK());
+
+        List<Long> candidateResumeIds;
+        if (requiredSkillIds.isEmpty()) {
+            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(candidatePoolSize);
+        } else {
+            candidateResumeIds = resumeQueryRepository.findCandidatePool(requiredSkillIds, candidatePoolSize).stream()
+                    .map(CandidatePoolRow::resumeId)
+                    .toList();
+        }
+
+        if (candidateResumeIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Resume> resumes = resumeRepository.findAllWithSkillsByIds(candidateResumeIds);
+        Map<Long, Resume> resumeMap = resumes.stream()
+                .collect(Collectors.toMap(Resume::getId, Function.identity()));
+
+        return candidateResumeIds.stream()
+                .map(resumeMap::get)
+                .filter(Objects::nonNull)
+                .map(this::toCandidate)
+                .toList();
+    }
+
+    private List<Long> extractRequiredSkillIds(RecommendationRun run) {
+        return run.getProposalPosition().getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                .map(pps -> pps.getSkill().getId())
+                .toList();
+    }
+
+    private int resolveCandidatePoolSize(int topK) {
+        return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
+    }
+
+    private RecommendationCandidate toCandidate(Resume resume) {
+        return new RecommendationCandidate(
+                resume.getId(),
+                resume.getStatus(),
+                resume.isPubliclyVisible(),
+                resume.isAiMatchingEnabled(),
+                resume.getCareerYears(),
+                resume.getSkills().stream()
+                        .map(RecommendationCandidate.CandidateSkill::of)
+                        .toList()
+        );
+    }
+
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -147,6 +147,45 @@ class ResumeQueryRepositoryTest {
         );
     }
 
+    @DisplayName("findCandidatePool은 작성중인 이력서를 후보 풀에서 제외한다")
+    @Test
+    void findCandidatePool_excludesWritingResumes() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-writing", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-writing", null));
+
+        Resume doneResume = saveResume(
+                "pool-done",
+                (byte) 8,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.DONE,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE)
+        );
+        saveResume(
+                "pool-writing",
+                (byte) 20,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.WRITING,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(doneResume.getId());
+    }
+
     @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
     @Test
     void findRecommendableResumeIds_appliesLimitAfterOrdering() {
@@ -167,12 +206,60 @@ class ResumeQueryRepositoryTest {
         );
     }
 
+    @DisplayName("findRecommendableResumeIds는 작성중인 이력서를 제외한다")
+    @Test
+    void findRecommendableResumeIds_excludesWritingResumes() {
+        // given
+        Resume doneResume = saveResume(
+                "recommend-done",
+                (byte) 7,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.DONE
+        );
+        saveResume(
+                "recommend-writing",
+                (byte) 30,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.WRITING
+        );
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+
+        // then
+        assertThat(result).containsExactly(doneResume.getId());
+    }
+
     private Resume saveResume(
             String suffix,
             byte careerYears,
             boolean publiclyVisible,
             boolean aiMatchingEnabled,
             boolean active,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                ResumeWritingStatus.DONE,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            ResumeWritingStatus writingStatus,
             SkillAssignment... skills
     ) {
         String phone = "010-1111-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
@@ -190,7 +277,7 @@ class ResumeQueryRepositoryTest {
                 careerYears,
                 new CareerPayload(),
                 WorkType.REMOTE,
-                ResumeWritingStatus.DONE,
+                writingStatus,
                 null
         );
 
@@ -215,5 +302,6 @@ class ResumeQueryRepositoryTest {
     }
 
     private record SkillAssignment(Skill skill, Proficiency proficiency) {
+
     }
 }

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -1,0 +1,165 @@
+package com.generic4.itda.repository;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.H2RepositoryTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@H2RepositoryTest
+@Import(ResumeQueryRepositoryImpl.class)
+class ResumeQueryRepositoryTest {
+
+    @Autowired
+    private ResumeQueryRepository resumeQueryRepository;
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SkillRepository skillRepository;
+
+    @DisplayName("findCandidatePool은 필터링 후 매칭 수, 숙련도 합, 경력, id 순으로 후보를 정렬한다")
+    @Test
+    void findCandidatePool_filtersAndOrdersCandidates() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool", null));
+        Skill aws = skillRepository.saveAndFlush(Skill.create("Aws-query-pool", null));
+
+        Resume strongest = saveResume("pool-1", (byte) 5, true, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreHighCareerLowId = saveResume("pool-2", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreLowCareer = saveResume("pool-3", (byte) 7, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreHighCareerHighId = saveResume("pool-4", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume partialMatch = saveResume("pool-5", (byte) 20, true, true, true,
+                skill(java, Proficiency.ADVANCED));
+
+        saveResume("pool-hidden", (byte) 30, false, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-ai-off", (byte) 30, true, false, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-inactive", (byte) 30, true, true, false,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-other-skill", (byte) 30, true, true, true,
+                skill(aws, Proficiency.ADVANCED));
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(
+                        strongest.getId(),
+                        sameScoreHighCareerLowId.getId(),
+                        sameScoreHighCareerHighId.getId(),
+                        sameScoreLowCareer.getId(),
+                        partialMatch.getId()
+                );
+        assertThat(result).extracting(CandidatePoolRow::matchedRequiredSkillCount)
+                .containsExactly(2L, 2L, 2L, 2L, 1L);
+        assertThat(result).extracting(CandidatePoolRow::weightedProficiencySum)
+                .containsExactly(13, 8, 8, 8, 9);
+    }
+
+    @DisplayName("findRecommendableResumeIds는 추천 가능 이력서만 경력과 id 순으로 조회한다")
+    @Test
+    void findRecommendableResumeIds_filtersAndOrdersResumes() {
+        // given
+        Resume highestCareer = saveResume("recommend-1", (byte) 9, true, true, true);
+        Resume mediumCareerLowId = saveResume("recommend-2", (byte) 5, true, true, true);
+        Resume mediumCareerHighId = saveResume("recommend-3", (byte) 5, true, true, true);
+
+        saveResume("recommend-hidden", (byte) 99, false, true, true);
+        saveResume("recommend-ai-off", (byte) 99, true, false, true);
+        saveResume("recommend-inactive", (byte) 99, true, true, false);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+
+        // then
+        assertThat(result).containsExactly(
+                highestCareer.getId(),
+                mediumCareerLowId.getId(),
+                mediumCareerHighId.getId()
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            SkillAssignment... skills
+    ) {
+        String phone = "010-1111-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
+        Member member = memberRepository.save(createMember(
+                "resume-query-" + suffix + "@example.com",
+                "hashed-password",
+                "name-" + suffix,
+                "nickname-" + suffix,
+                phone
+        ));
+
+        Resume resume = Resume.create(
+                member,
+                "소개-" + suffix,
+                careerYears,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+
+        if (!publiclyVisible) {
+            resume.togglePubliclyVisible();
+        }
+        if (!aiMatchingEnabled) {
+            resume.toggleAiMatchingEnabled();
+        }
+        if (!active) {
+            resume.delete();
+        }
+        for (SkillAssignment skill : skills) {
+            resume.addSkill(skill.skill(), skill.proficiency());
+        }
+
+        return resumeRepository.saveAndFlush(resume);
+    }
+
+    private static SkillAssignment skill(Skill skill, Proficiency proficiency) {
+        return new SkillAssignment(skill, proficiency);
+    }
+
+    private record SkillAssignment(Skill skill, Proficiency proficiency) {
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -90,6 +90,40 @@ class ResumeQueryRepositoryTest {
                 .containsExactly(13, 8, 8, 8, 9);
     }
 
+    @DisplayName("findCandidatePool은 정렬된 후보 중 limit 개수만 반환한다")
+    @Test
+    void findCandidatePool_appliesLimitAfterOrdering() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-limit", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-limit", null));
+
+        Resume strongest = saveResume("pool-limit-1", (byte) 5, true, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume higherCareer = saveResume("pool-limit-2", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        saveResume("pool-limit-3", (byte) 7, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        saveResume("pool-limit-4", (byte) 20, true, true, true,
+                skill(java, Proficiency.ADVANCED));
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                2
+        );
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(
+                        strongest.getId(),
+                        higherCareer.getId()
+                );
+    }
+
     @DisplayName("findRecommendableResumeIds는 추천 가능 이력서만 경력과 id 순으로 조회한다")
     @Test
     void findRecommendableResumeIds_filtersAndOrdersResumes() {
@@ -110,6 +144,26 @@ class ResumeQueryRepositoryTest {
                 highestCareer.getId(),
                 mediumCareerLowId.getId(),
                 mediumCareerHighId.getId()
+        );
+    }
+
+    @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
+    @Test
+    void findRecommendableResumeIds_appliesLimitAfterOrdering() {
+        // given
+        Resume highestCareer = saveResume("recommend-limit-1", (byte) 9, true, true, true);
+        Resume mediumCareerLowId = saveResume("recommend-limit-2", (byte) 5, true, true, true);
+        saveResume("recommend-limit-3", (byte) 5, true, true, true);
+        saveResume("recommend-limit-4", (byte) 1, true, true, true);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(2);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(
+                highestCareer.getId(),
+                mediumCareerLowId.getId()
         );
     }
 

--- a/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
@@ -7,13 +7,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.CareerEmploymentType;
 import com.generic4.itda.domain.resume.CareerItemPayload;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +35,9 @@ class ResumeRepositoryTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private SkillRepository skillRepository;
 
     @DisplayName("경력이 없는 CareerPayload도 JSON으로 정상 저장/조회된다")
     @Test
@@ -299,6 +305,57 @@ class ResumeRepositoryTest {
         assertThat(result).isEmpty();
     }
 
+    @DisplayName("findAllWithSkillsByIds는 skills와 skill 연관을 한 번에 조회하며 중복 없이 반환한다")
+    @Test
+    void findAllWithSkillsByIds_fetchesSkillsWithoutDuplicates() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-fetch-join", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-fetch-join", null));
+        Skill kotlin = skillRepository.saveAndFlush(Skill.create("Kotlin-fetch-join", null));
+
+        Resume first = createResume("fetch-1", (byte) 5);
+        first.addSkill(java, Proficiency.ADVANCED);
+        first.addSkill(spring, Proficiency.INTERMEDIATE);
+        Resume savedFirst = resumeRepository.saveAndFlush(first);
+
+        Resume second = createResume("fetch-2", (byte) 3);
+        second.addSkill(kotlin, Proficiency.BEGINNER);
+        Resume savedSecond = resumeRepository.saveAndFlush(second);
+
+        entityManager.clear();
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        Resume lazyLoaded = resumeRepository.findById(savedFirst.getId()).orElseThrow();
+        assertThat(util.isLoaded(lazyLoaded, "skills")).isFalse();
+
+        entityManager.clear();
+
+        // when
+        List<Resume> found = resumeRepository.findAllWithSkillsByIds(List.of(savedFirst.getId(), savedSecond.getId()));
+
+        // then
+        assertThat(found).hasSize(2);
+        assertThat(found).extracting(Resume::getId)
+                .containsExactlyInAnyOrder(savedFirst.getId(), savedSecond.getId());
+
+        Resume fetchedFirst = found.stream()
+                .filter(resume -> resume.getId().equals(savedFirst.getId()))
+                .findFirst()
+                .orElseThrow();
+        Resume fetchedSecond = found.stream()
+                .filter(resume -> resume.getId().equals(savedSecond.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(util.isLoaded(fetchedFirst, "skills")).isTrue();
+        assertThat(util.isLoaded(fetchedSecond, "skills")).isTrue();
+        assertThat(fetchedFirst.getSkills()).hasSize(2);
+        assertThat(fetchedSecond.getSkills()).hasSize(1);
+        assertThat(util.isLoaded(fetchedFirst.getSkills().first(), "skill")).isTrue();
+        assertThat(fetchedFirst.getSkills()).extracting(resumeSkill -> resumeSkill.getSkill().getName())
+                .containsExactly("Java-fetch-join", "Spring-fetch-join");
+    }
+
 
     private static CareerPayload createCareerPayload() {
         CareerItemPayload item = new CareerItemPayload();
@@ -314,5 +371,26 @@ class ResumeRepositoryTest {
         CareerPayload payload = new CareerPayload();
         payload.getItems().add(item);
         return payload;
+    }
+
+    private Resume createResume(String suffix, byte careerYears) {
+        String phone = "010-0000-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
+        Member member = memberRepository.save(createMember(
+                "resume-" + suffix + "@example.com",
+                "hashed-password",
+                "name-" + suffix,
+                "nickname-" + suffix,
+                phone
+        ));
+
+        return Resume.create(
+                member,
+                "자기소개-" + suffix,
+                careerYears,
+                createCareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -1,0 +1,189 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.ResumeQueryRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationCandidateFinderTest {
+
+    @Mock
+    private ResumeQueryRepository resumeQueryRepository;
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @InjectMocks
+    private RecommendationCandidateFinder finder;
+
+    @DisplayName("필수 스킬이 없으면 전체 추천 가능 이력서 풀을 조회하고 id 순서를 유지한다")
+    @Test
+    void findCandidates_usesRecommendablePoolWhenNoEssentialSkills() {
+        // given
+        RecommendationRun run = createRun(
+                3,
+                skillRequirement(201L, "Communication", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume second = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findRecommendableResumeIds(100)).willReturn(List.of(11L, 22L));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L, 22L);
+        assertThat(result.get(0).skills()).extracting(RecommendationCandidate.CandidateSkill::skillName)
+                .containsExactly("Java");
+
+        verify(resumeQueryRepository).findRecommendableResumeIds(100);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("필수 스킬이 있으면 필수 스킬 id만으로 후보 풀을 조회하고 topK에 따라 풀 크기를 늘린다")
+    @Test
+    void findCandidates_usesEssentialSkillsAndExpandedPoolSize() {
+        // given
+        RecommendationRun run = createRun(
+                6,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL),
+                skillRequirement(202L, "React", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume first = createResume(11L, (byte) 9, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume second = createResume(22L, (byte) 4, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findCandidatePool(List.of(101L), 120)).willReturn(List.of(
+                new CandidatePoolRow(22L, 1L, 4, (byte) 4),
+                new CandidatePoolRow(11L, 1L, 9, (byte) 9)
+        ));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(first, second));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(22L, 11L);
+
+        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 120);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("후보 풀 조회 결과가 비어 있으면 Resume 상세 조회 없이 빈 리스트를 반환한다")
+    @Test
+    void findCandidates_returnsEmptyWhenCandidatePoolIsEmpty() {
+        // given
+        RecommendationRun run = createRun(
+                5,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
+        );
+        given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 100);
+        verifyNoInteractions(resumeRepository);
+        verifyNoMoreInteractions(resumeQueryRepository);
+    }
+
+    private RecommendationRun createRun(int topK, SkillRequirement... requirements) {
+        Proposal proposal = Proposal.create(
+                createMember(),
+                "추천 요청",
+                "raw-input",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        ProposalPosition proposalPosition = proposal.addPosition(Position.create("백엔드"), 1L, null, null);
+
+        for (SkillRequirement requirement : requirements) {
+            Skill skill = Skill.create(requirement.name(), null);
+            ReflectionTestUtils.setField(skill, "id", requirement.skillId());
+            proposalPosition.addSkill(skill, requirement.importance());
+        }
+
+        return RecommendationRun.create(
+                proposalPosition,
+                "fingerprint",
+                RecommendationAlgorithm.HEURISTIC_V1,
+                topK
+        );
+    }
+
+    private Resume createResume(long resumeId, byte careerYears, SkillData... skills) {
+        Resume resume = Resume.create(
+                createMember(),
+                "소개-" + resumeId,
+                careerYears,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+        ReflectionTestUtils.setField(resume, "id", resumeId);
+
+        for (SkillData skillData : skills) {
+            Skill skill = Skill.create(skillData.name(), null);
+            ReflectionTestUtils.setField(skill, "id", skillData.skillId());
+            resume.addSkill(skill, skillData.proficiency());
+        }
+
+        return resume;
+    }
+
+    private static SkillRequirement skillRequirement(
+            long skillId,
+            String name,
+            ProposalPositionSkillImportance importance
+    ) {
+        return new SkillRequirement(skillId, name, importance);
+    }
+
+    private static SkillData skillData(long skillId, String name, Proficiency proficiency) {
+        return new SkillData(skillId, name, proficiency);
+    }
+
+    private record SkillRequirement(long skillId, String name, ProposalPositionSkillImportance importance) {
+    }
+
+    private record SkillData(long skillId, String name, Proficiency proficiency) {
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateTest.java
@@ -1,0 +1,99 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecommendationCandidateTest {
+
+    @DisplayName("skills 리스트는 방어적으로 복사되고 외부에서 수정할 수 없다")
+    @Test
+    void constructor_makesDefensiveCopyOfSkills() {
+        // given
+        List<RecommendationCandidate.CandidateSkill> original = new ArrayList<>();
+        original.add(new RecommendationCandidate.CandidateSkill(1L, "Java", Proficiency.ADVANCED));
+
+        RecommendationCandidate candidate = new RecommendationCandidate(
+                100L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 5,
+                original
+        );
+
+        // when
+        original.add(new RecommendationCandidate.CandidateSkill(2L, "Spring", Proficiency.INTERMEDIATE));
+
+        // then
+        assertThat(candidate.skills()).hasSize(1);
+        assertThatThrownBy(() -> candidate.skills()
+                .add(new RecommendationCandidate.CandidateSkill(3L, "Kotlin", Proficiency.BEGINNER)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @DisplayName("ACTIVE 상태일 때만 활성 후보로 판단한다")
+    @Test
+    void isActive_returnsTrueOnlyWhenStatusIsActive() {
+        RecommendationCandidate active = new RecommendationCandidate(
+                1L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of()
+        );
+        RecommendationCandidate inactive = new RecommendationCandidate(
+                2L,
+                ResumeStatus.INACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of()
+        );
+
+        assertThat(active.isActive()).isTrue();
+        assertThat(inactive.isActive()).isFalse();
+    }
+
+    @DisplayName("CandidateSkill.of는 ResumeSkill의 필드를 계산용 DTO로 복사한다")
+    @Test
+    void candidateSkillOf_mapsResumeSkillFields() {
+        // given
+        Skill java = Skill.create("Java", null);
+        ReflectionTestUtils.setField(java, "id", 10L);
+
+        Resume resume = Resume.create(
+                createMember(),
+                "백엔드 개발자입니다.",
+                (byte) 5,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, java, Proficiency.ADVANCED);
+
+        // when
+        RecommendationCandidate.CandidateSkill result = RecommendationCandidate.CandidateSkill.of(resumeSkill);
+
+        // then
+        assertThat(result.skillId()).isEqualTo(10L);
+        assertThat(result.skillName()).isEqualTo("Java");
+        assertThat(result.proficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+}


### PR DESCRIPTION
## 🔎 What

추천 실행 시 사용할 **후보 이력서 조회 파이프라인**을 구현했습니다.

- Querydsl 기반 candidate pool retrieval 구현
  - 필수 스킬 매칭 개수(`countDistinct`)
  - 숙련도 가중치 합(`priority^2`)
  - 정렬 기준 적용 (매칭 개수 → 숙련도 합 → 경력 → ID)
  - candidate pool size 제한

- 추천 가능 이력서 조건 반영
  - ACTIVE 상태
  - 공개 여부
  - AI 매칭 허용 여부

- `ResumeRepositoryCustom`을 통한 커스텀 조회 로직 분리

- ID 기반 상세 조회 후 fetch join으로 skill까지 로딩

- `RecommendationCandidateFinder` 구현
  - required skill 추출
  - candidate pool 조회 / fallback 분기 처리
  - Resume → RecommendationCandidate 매핑

- `RecommendationCandidate`, `CandidateSkill` 계산용 DTO 정의

- 테스트 코드 작성
  - Query repository: 집계/정렬/limit 검증
  - Repository: fetch join 조회 검증
  - Finder: 분기 처리 및 매핑 검증

> 본 PR은 추천 엔진의 입력 데이터 구성 단계이며, 이후 스코어링 로직과 분리되어 있습니다.

---

## 🔗 Issue

- Closes: #41 

---

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?