### PR TITLE
[Refactor] ProposalPosition 중심 구조 전환을 위한 필드 추가 (Additive 단계)

### DIFF
--- a/src/main/java/com/generic4/itda/domain/proposal/Proposal.java
+++ b/src/main/java/com/generic4/itda/domain/proposal/Proposal.java
@@ -133,8 +133,34 @@ public class Proposal extends BaseEntity {
     }
 
     public ProposalPosition addPosition(Position position, Long headCount, Long unitBudgetMin, Long unitBudgetMax) {
-        ProposalPosition proposalPosition = ProposalPosition.create(this, position, headCount, unitBudgetMin,
-                unitBudgetMax);
+        return addPosition(position, null, null, headCount, unitBudgetMin, unitBudgetMax, null, null, null, null);
+    }
+
+    public ProposalPosition addPosition(
+            Position position,
+            String title,
+            ProposalWorkType workType,
+            Long headCount,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Long expectedPeriod,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
+        ProposalPosition proposalPosition = ProposalPosition.create(
+                this,
+                position,
+                title,
+                workType,
+                headCount,
+                unitBudgetMin,
+                unitBudgetMax,
+                expectedPeriod,
+                careerMinYears,
+                careerMaxYears,
+                workPlace
+        );
         validatePositionChange(proposalPosition, proposalPosition.getPosition());
         this.positions.add(proposalPosition);
         return proposalPosition;

--- a/src/main/java/com/generic4/itda/domain/proposal/ProposalPosition.java
+++ b/src/main/java/com/generic4/itda/domain/proposal/ProposalPosition.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Table(
@@ -53,6 +54,12 @@ public class ProposalPosition extends BaseEntity {
     @JoinColumn(name = "position_id", nullable = false)
     private Position position;
 
+    @Column(length = 200)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private ProposalWorkType workType;
+
     private Long headCount;
 
     @Enumerated(EnumType.STRING)
@@ -63,49 +70,127 @@ public class ProposalPosition extends BaseEntity {
 
     private Long unitBudgetMax;
 
+    private Long expectedPeriod;
+
+    private Integer careerMinYears;
+
+    private Integer careerMaxYears;
+
+    @Column(length = 255)
+    private String workPlace;
+
     @OneToMany(mappedBy = "proposalPosition", fetch = FetchType.LAZY, cascade = CascadeType.ALL,
             orphanRemoval = true)
     @OrderBy("id ASC")
     private final List<ProposalPositionSkill> skills = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    private ProposalPosition(Proposal proposal, Position position, Long headCount, ProposalPositionStatus status,
-            Long unitBudgetMin, Long unitBudgetMax) {
+    private ProposalPosition(
+            Proposal proposal,
+            Position position,
+            String title,
+            ProposalWorkType workType,
+            Long headCount,
+            ProposalPositionStatus status,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Long expectedPeriod,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
         Assert.notNull(proposal, "상위 제안서는 필수값입니다.");
         Assert.notNull(position, "직무는 필수값입니다.");
         validateHeadCount(headCount);
         validateBudgetRange(unitBudgetMin, unitBudgetMax);
+        validateExpectedPeriod(expectedPeriod);
+        validateCareerRange(careerMinYears, careerMaxYears);
+        validateWorkPlace(workType, workPlace);
 
         this.proposal = proposal;
         this.position = position;
+        this.title = normalizeOptionalShortText(title);
+        this.workType = workType;
         this.headCount = headCount;
         this.status = status == null ? ProposalPositionStatus.OPEN : status;
         this.unitBudgetMin = unitBudgetMin;
         this.unitBudgetMax = unitBudgetMax;
+        this.expectedPeriod = expectedPeriod;
+        this.careerMinYears = careerMinYears;
+        this.careerMaxYears = careerMaxYears;
+        this.workPlace = normalizeOptionalShortText(workPlace);
     }
 
     public static ProposalPosition create(Proposal proposal, Position position, Long headCount,
             Long unitBudgetMin, Long unitBudgetMax) {
+        return create(proposal, position, null, null, headCount, unitBudgetMin, unitBudgetMax, null, null, null,
+                null);
+    }
+
+    public static ProposalPosition create(
+            Proposal proposal,
+            Position position,
+            String title,
+            ProposalWorkType workType,
+            Long headCount,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Long expectedPeriod,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
         return ProposalPosition.builder()
                 .proposal(proposal)
                 .position(position)
+                .title(title)
+                .workType(workType)
                 .headCount(headCount)
                 .status(ProposalPositionStatus.OPEN)
                 .unitBudgetMin(unitBudgetMin)
                 .unitBudgetMax(unitBudgetMax)
+                .expectedPeriod(expectedPeriod)
+                .careerMinYears(careerMinYears)
+                .careerMaxYears(careerMaxYears)
+                .workPlace(workPlace)
                 .build();
     }
 
     public void update(Position position, Long headCount, Long unitBudgetMin, Long unitBudgetMax) {
+        update(position, this.title, this.workType, headCount, unitBudgetMin, unitBudgetMax, this.expectedPeriod,
+                this.careerMinYears, this.careerMaxYears, this.workPlace);
+    }
+
+    public void update(
+            Position position,
+            String title,
+            ProposalWorkType workType,
+            Long headCount,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Long expectedPeriod,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
         Assert.notNull(position, "직무는 필수값입니다.");
         validateHeadCount(headCount);
         validateBudgetRange(unitBudgetMin, unitBudgetMax);
+        validateExpectedPeriod(expectedPeriod);
+        validateCareerRange(careerMinYears, careerMaxYears);
+        validateWorkPlace(workType, workPlace);
         this.proposal.validatePositionChange(this, position);
 
         this.position = position;
+        this.title = normalizeOptionalShortText(title);
+        this.workType = workType;
         this.headCount = headCount;
         this.unitBudgetMin = unitBudgetMin;
         this.unitBudgetMax = unitBudgetMax;
+        this.expectedPeriod = expectedPeriod;
+        this.careerMinYears = careerMinYears;
+        this.careerMaxYears = careerMaxYears;
+        this.workPlace = normalizeOptionalShortText(workPlace);
     }
 
     public void changeStatus(ProposalPositionStatus status) {
@@ -173,5 +258,33 @@ public class ProposalPosition extends BaseEntity {
         if (budgetMin != null && budgetMax != null) {
             Assert.isTrue(budgetMin <= budgetMax, "1인 기준 최소 예산은 최대 예산보다 클 수 없습니다.");
         }
+    }
+
+    private static void validateExpectedPeriod(Long expectedPeriod) {
+        if (expectedPeriod != null) {
+            Assert.isTrue(expectedPeriod > 0, "포지션 예상 기간은 양수여야 합니다.");
+        }
+    }
+
+    private static void validateCareerRange(Integer careerMinYears, Integer careerMaxYears) {
+        if (careerMinYears != null) {
+            Assert.isTrue(careerMinYears >= 0, "최소 경력 연차는 음수일 수 없습니다.");
+        }
+        if (careerMaxYears != null) {
+            Assert.isTrue(careerMaxYears >= 0, "최대 경력 연차는 음수일 수 없습니다.");
+        }
+        if (careerMinYears != null && careerMaxYears != null) {
+            Assert.isTrue(careerMinYears <= careerMaxYears, "최소 경력 연차는 최대 경력 연차보다 클 수 없습니다.");
+        }
+    }
+
+    private static void validateWorkPlace(ProposalWorkType workType, String workPlace) {
+        if (workType == ProposalWorkType.REMOTE) {
+            Assert.isTrue(!StringUtils.hasText(workPlace), "원격 근무이면 근무지는 비워야 합니다.");
+        }
+    }
+
+    private static String normalizeOptionalShortText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
     }
 }

--- a/src/test/java/com/generic4/itda/domain/proposal/ProposalPositionTest.java
+++ b/src/test/java/com/generic4/itda/domain/proposal/ProposalPositionTest.java
@@ -27,8 +27,42 @@ class ProposalPositionTest {
         assertThat(proposalPosition.getHeadCount()).isEqualTo(2L);
         assertThat(proposalPosition.getUnitBudgetMin()).isEqualTo(3_000_000L);
         assertThat(proposalPosition.getUnitBudgetMax()).isEqualTo(5_000_000L);
+        assertThat(proposalPosition.getTitle()).isNull();
+        assertThat(proposalPosition.getWorkType()).isNull();
+        assertThat(proposalPosition.getExpectedPeriod()).isNull();
+        assertThat(proposalPosition.getCareerMinYears()).isNull();
+        assertThat(proposalPosition.getCareerMaxYears()).isNull();
+        assertThat(proposalPosition.getWorkPlace()).isNull();
         assertThat(proposalPosition.getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
         assertThat(proposal.getPositions()).isEmpty();
+    }
+
+    @DisplayName("상세 필드가 주어지면 모집 단위에 함께 저장한다")
+    @Test
+    void createWithDetailFields() {
+        Proposal proposal = createProposal();
+        Position position = Position.create("백엔드 개발자");
+
+        ProposalPosition proposalPosition = ProposalPosition.create(
+                proposal,
+                position,
+                "  Node.js 백엔드 개발자  ",
+                ProposalWorkType.HYBRID,
+                2L,
+                3_000_000L,
+                5_000_000L,
+                12L,
+                3,
+                7,
+                "  판교  "
+        );
+
+        assertThat(proposalPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(proposalPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposalPosition.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(proposalPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(proposalPosition.getCareerMaxYears()).isEqualTo(7);
+        assertThat(proposalPosition.getWorkPlace()).isEqualTo("판교");
     }
 
     @DisplayName("상위 제안서가 없으면 생성에 실패한다")
@@ -88,6 +122,87 @@ class ProposalPositionTest {
                 .hasMessage("1인 기준 최소 예산은 최대 예산보다 클 수 없습니다.");
     }
 
+    @DisplayName("포지션 예상 기간이 0 이하이면 생성에 실패한다")
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L})
+    void failWhenExpectedPeriodIsNotPositive(long expectedPeriod) {
+        assertThatThrownBy(() -> ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                ProposalWorkType.HYBRID,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                expectedPeriod,
+                1,
+                3,
+                "판교"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("포지션 예상 기간은 양수여야 합니다.");
+    }
+
+    @DisplayName("경력 연차는 음수일 수 없다")
+    @Test
+    void failWhenCareerYearsIsNegative() {
+        assertThatThrownBy(() -> ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                ProposalWorkType.HYBRID,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                12L,
+                -1,
+                3,
+                "판교"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 경력 연차는 음수일 수 없습니다.");
+    }
+
+    @DisplayName("최소 경력 연차는 최대 경력 연차보다 클 수 없다")
+    @Test
+    void failWhenCareerRangeIsInvalid() {
+        assertThatThrownBy(() -> ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                ProposalWorkType.HYBRID,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                12L,
+                5,
+                3,
+                "판교"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 경력 연차는 최대 경력 연차보다 클 수 없습니다.");
+    }
+
+    @DisplayName("원격 근무이면 근무지는 비워야 한다")
+    @Test
+    void failWhenRemoteHasWorkPlace() {
+        assertThatThrownBy(() -> ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                12L,
+                1,
+                3,
+                "판교"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("원격 근무이면 근무지는 비워야 합니다.");
+    }
+
     @DisplayName("유효한 입력이면 모집 단위를 수정한다")
     @Test
     void updateProposalPosition() {
@@ -107,6 +222,76 @@ class ProposalPositionTest {
         assertThat(proposalPosition.getUnitBudgetMin()).isEqualTo(4_000_000L);
         assertThat(proposalPosition.getUnitBudgetMax()).isEqualTo(6_000_000L);
         assertThat(proposalPosition.getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
+    }
+
+    @DisplayName("상세 필드와 함께 모집 단위를 수정할 수 있다")
+    @Test
+    void updateProposalPositionWithDetailFields() {
+        ProposalPosition proposalPosition = ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                ProposalWorkType.SITE,
+                1L,
+                2_000_000L,
+                3_000_000L,
+                8L,
+                2,
+                5,
+                "강남"
+        );
+        Position updatedPosition = Position.create("프론트엔드 개발자");
+
+        proposalPosition.update(
+                updatedPosition,
+                "React 프론트엔드 개발자",
+                ProposalWorkType.REMOTE,
+                3L,
+                4_000_000L,
+                6_000_000L,
+                16L,
+                4,
+                8,
+                null
+        );
+
+        assertThat(proposalPosition.getPosition()).isEqualTo(updatedPosition);
+        assertThat(proposalPosition.getTitle()).isEqualTo("React 프론트엔드 개발자");
+        assertThat(proposalPosition.getWorkType()).isEqualTo(ProposalWorkType.REMOTE);
+        assertThat(proposalPosition.getHeadCount()).isEqualTo(3L);
+        assertThat(proposalPosition.getUnitBudgetMin()).isEqualTo(4_000_000L);
+        assertThat(proposalPosition.getUnitBudgetMax()).isEqualTo(6_000_000L);
+        assertThat(proposalPosition.getExpectedPeriod()).isEqualTo(16L);
+        assertThat(proposalPosition.getCareerMinYears()).isEqualTo(4);
+        assertThat(proposalPosition.getCareerMaxYears()).isEqualTo(8);
+        assertThat(proposalPosition.getWorkPlace()).isNull();
+    }
+
+    @DisplayName("기존 update 시그니처를 써도 새 상세 필드는 유지된다")
+    @Test
+    void updateWithLegacySignaturePreservesDetailFields() {
+        ProposalPosition proposalPosition = ProposalPosition.create(
+                createProposal(),
+                Position.create("백엔드 개발자"),
+                "Node.js 백엔드 개발자",
+                ProposalWorkType.HYBRID,
+                1L,
+                2_000_000L,
+                3_000_000L,
+                10L,
+                3,
+                6,
+                "판교"
+        );
+
+        proposalPosition.update(Position.create("서버 개발자"), 2L, 4_000_000L, 5_000_000L);
+
+        assertThat(proposalPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(proposalPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposalPosition.getExpectedPeriod()).isEqualTo(10L);
+        assertThat(proposalPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(proposalPosition.getCareerMaxYears()).isEqualTo(6);
+        assertThat(proposalPosition.getWorkPlace()).isEqualTo("판교");
     }
 
     @DisplayName("같은 제안서 안에 이미 존재하는 직무로 모집 단위를 수정할 수 없다")

--- a/src/test/java/com/generic4/itda/domain/proposal/ProposalTest.java
+++ b/src/test/java/com/generic4/itda/domain/proposal/ProposalTest.java
@@ -235,6 +235,33 @@ class ProposalTest {
         assertThat(proposalPosition.getProposal()).isNull();
     }
 
+    @DisplayName("제안서에 상세 필드를 포함한 모집 단위를 추가할 수 있다")
+    @Test
+    void addPositionWithDetailFields() {
+        Proposal proposal = createProposal("원본 입력");
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                Position.create("백엔드 개발자"),
+                "Node.js 백엔드 개발자",
+                ProposalWorkType.HYBRID,
+                2L,
+                3_000_000L,
+                5_000_000L,
+                12L,
+                3,
+                7,
+                "판교"
+        );
+
+        assertThat(proposal.getPositions()).containsExactly(proposalPosition);
+        assertThat(proposalPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(proposalPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposalPosition.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(proposalPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(proposalPosition.getCareerMaxYears()).isEqualTo(7);
+        assertThat(proposalPosition.getWorkPlace()).isEqualTo("판교");
+    }
+
     @DisplayName("같은 직무 마스터를 같은 제안서 안에 중복 등록할 수 없다")
     @Test
     void failWhenPositionMasterIsDuplicatedWithinProposal() {


### PR DESCRIPTION
## 🔎 What

- 도메인 정책 변경을 반영하기 위해, 기존 로직들이 깨지지 않는 선에서 변경을 반영해보았습니다.
- 현 단계에서는 ProposalPosition에 필드 추가 및 메서드 시그니처 유지가 주 목표였습니다.
- 다음 단계에서는 write path를 전환할 계획입니다.

## 🔗 Issue

- Closes: #49 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?