### PR TITLE
[Refactor] 추천 진입 화면을 ProposalPosition 기반으로 정리

### DIFF
--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 public record RecommendationEntryPositionItem(
         Long proposalPositionId,
-        String positionName,
+        String positionTitle,
+        String positionCategoryName,
         Long headCount,
         String budgetText,
+        Long expectedPeriod,
         List<RecommendationEntrySkillItem> skills
 ) {
 

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -69,15 +69,24 @@ public class RecommendationEntryService {
     private RecommendationEntryPositionItem toPositionItem(ProposalPosition position) {
         return new RecommendationEntryPositionItem(
                 position.getId(),
+                resolvePositionTitle(position),
                 position.getPosition().getName(),
                 position.getHeadCount(),
                 formatBudget(position.getUnitBudgetMin(), position.getUnitBudgetMax()),
+                position.getExpectedPeriod(),
                 position.getSkills().stream()
                         .map(skill -> new RecommendationEntrySkillItem(
                                 skill.getSkill().getName(),
                                 skill.getImportance().getDescription()
                         )).toList()
         );
+    }
+
+    private String resolvePositionTitle(ProposalPosition position) {
+        if (position.getTitle() != null && !position.getTitle().isBlank()) {
+            return position.getTitle();
+        }
+        return position.getPosition().getName();
     }
 
     private String formatBudget(Long min, Long max) {

--- a/src/main/resources/templates/recommendation/entry.html
+++ b/src/main/resources/templates/recommendation/entry.html
@@ -76,7 +76,7 @@
               <option value="">포지션을 선택해주세요</option>
               <option th:each="position : ${entry.positions}"
                       th:value="${position.proposalPositionId}"
-                      th:text="${position.positionName}">
+                      th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
                 백엔드 개발자
               </option>
             </select>
@@ -99,9 +99,15 @@
               <div class="flex flex-wrap items-start justify-between gap-4">
                 <div>
                   <h2 class="text-xl font-black tracking-tight text-slate-950"
-                      th:text="${position.positionName}">
+                      th:text="${position.positionTitle}">
                     백엔드 개발자
                   </h2>
+
+                  <p th:if="${position.positionCategoryName != null and position.positionCategoryName != position.positionTitle}"
+                     class="mt-2 inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-500"
+                     th:text="${position.positionCategoryName}">
+                    백엔드
+                  </p>
 
                   <p class="mt-2 text-sm text-slate-500">
                     모집 인원
@@ -114,6 +120,12 @@
                     <span class="font-semibold text-slate-800"
                           th:text="${position.budgetText}">
                                             5,000,000 ~ 9,000,000
+                                        </span>
+                    <span class="mx-2 text-slate-300">•</span>
+                    기간
+                    <span class="font-semibold text-slate-800"
+                          th:text="${position.expectedPeriod != null ? position.expectedPeriod + '주' : '미정'}">
+                                            8주
                                         </span>
                   </p>
                 </div>

--- a/src/main/resources/templates/recommendation/entry.html
+++ b/src/main/resources/templates/recommendation/entry.html
@@ -70,16 +70,23 @@
               추천 대상 포지션
             </label>
 
-            <select id="proposalPositionId"
-                    th:field="*{proposalPositionId}"
-                    class="mt-3 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition focus:border-slate-400">
-              <option value="">포지션을 선택해주세요</option>
-              <option th:each="position : ${entry.positions}"
-                      th:value="${position.proposalPositionId}"
-                      th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
-                백엔드 개발자
-              </option>
-            </select>
+            <div class="relative mt-3">
+              <select id="proposalPositionId"
+                      th:field="*{proposalPositionId}"
+                      class="w-full appearance-none rounded-2xl border border-slate-200 bg-slate-50 py-3 pl-4 pr-10 text-sm font-semibold text-slate-900 outline-none transition focus:border-slate-400">
+                <option value="">포지션을 선택해주세요</option>
+                <option th:each="position : ${entry.positions}"
+                        th:value="${position.proposalPositionId}"
+                        th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
+                  백엔드 개발자
+                </option>
+              </select>
+              <div class="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+                <svg class="h-4 w-4 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                </svg>
+              </div>
+            </div>
 
             <p th:if="${#fields.hasErrors('proposalPositionId')}"
                th:errors="*{proposalPositionId}"

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
@@ -42,9 +42,9 @@ class RecommendationEntryServiceIntegrationTest {
     @DisplayName("저장된 recommendation aggregate를 조회해 entry ViewModel을 조립한다")
     void getEntry_assemblesViewModelFromPersistedAggregate() {
         Member owner = memberRepository.save(createMember("entry-owner@test.com", "pw", "제안자", "010-0000-1111"));
-        Position designer = persist(Position.create("디자이너"));
-        Position backend = persist(Position.create("백엔드 개발자"));
-        Position frontend = persist(Position.create("프론트엔드 개발자"));
+        Position designer = persist(Position.create("디자인"));
+        Position backend = persist(Position.create("백엔드"));
+        Position frontend = persist(Position.create("프론트엔드"));
         Skill figma = persist(Skill.create("Figma", null));
         Skill java = persist(Skill.create("Java", null));
         Skill react = persist(Skill.create("React", null));
@@ -60,11 +60,11 @@ class RecommendationEntryServiceIntegrationTest {
                 "서울",
                 6L
         );
-        ProposalPosition designerPosition = proposal.addPosition(designer, 1L, null, null);
+        ProposalPosition designerPosition = proposal.addPosition(designer, "프로덕트 디자이너", null, 1L, null, null, null, null, null, null);
         designerPosition.addSkill(figma, ProposalPositionSkillImportance.PREFERENCE);
-        ProposalPosition backendPosition = proposal.addPosition(backend, 2L, 1_000_000L, 2_000_000L);
+        ProposalPosition backendPosition = proposal.addPosition(backend, "Node.js 백엔드 개발자", null, 2L, 1_000_000L, 2_000_000L, 5L, null, null, null);
         backendPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
-        ProposalPosition frontendPosition = proposal.addPosition(frontend, 1L, 800_000L, 1_200_000L);
+        ProposalPosition frontendPosition = proposal.addPosition(frontend, "프론트엔드 개발자", null, 1L, 800_000L, 1_200_000L, 4L, null, null, null);
         frontendPosition.addSkill(react, ProposalPositionSkillImportance.PREFERENCE);
         proposal.startMatching();
         proposalRepository.saveAndFlush(proposal);
@@ -92,7 +92,8 @@ class RecommendationEntryServiceIntegrationTest {
                 .containsExactly(designerPositionId, backendPositionId, frontendPositionId);
 
         RecommendationEntryPositionItem first = result.positions().get(0);
-        assertThat(first.positionName()).isEqualTo("디자이너");
+        assertThat(first.positionTitle()).isEqualTo("프로덕트 디자이너");
+        assertThat(first.positionCategoryName()).isEqualTo("디자인");
         assertThat(first.budgetText()).isEqualTo("예산 미정");
         assertThat(first.skills())
                 .singleElement()
@@ -102,8 +103,10 @@ class RecommendationEntryServiceIntegrationTest {
                 });
 
         RecommendationEntryPositionItem second = result.positions().get(1);
-        assertThat(second.positionName()).isEqualTo("백엔드 개발자");
+        assertThat(second.positionTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(second.positionCategoryName()).isEqualTo("백엔드");
         assertThat(second.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
+        assertThat(second.expectedPeriod()).isEqualTo(5L);
         assertThat(second.skills())
                 .singleElement()
                 .satisfies(skill -> {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
@@ -63,13 +63,13 @@ class RecommendationEntryServiceTest {
         Member owner = createMemberWithId(OWNER_ID);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
 
-        ProposalPosition designer = addPosition(proposal, 30L, "디자이너", 1L, null, null);
+        ProposalPosition designer = addPosition(proposal, 30L, "디자인", "프로덕트 디자이너", 1L, null, null, null);
         addSkill(designer, 201L, "Figma", ProposalPositionSkillImportance.PREFERENCE);
 
-        ProposalPosition backend = addPosition(proposal, 10L, "백엔드 개발자", 3L, 1_000_000L, 2_000_000L);
+        ProposalPosition backend = addPosition(proposal, 10L, "백엔드", "Node.js 백엔드 개발자", 3L, 1_000_000L, 2_000_000L, 3L);
         addSkill(backend, 202L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        ProposalPosition frontend = addPosition(proposal, 20L, "프론트엔드 개발자", 2L, 700_000L, 900_000L);
+        ProposalPosition frontend = addPosition(proposal, 20L, "프론트엔드", "프론트엔드 개발자", 2L, 700_000L, 900_000L, 2L);
         addSkill(frontend, 203L, "React", ProposalPositionSkillImportance.PREFERENCE);
 
         stubProposalDetailLoad(proposal);
@@ -96,9 +96,11 @@ class RecommendationEntryServiceTest {
                 .containsExactly(10L, 20L, 30L);
 
         RecommendationEntryPositionItem firstPosition = result.positions().get(0);
-        assertThat(firstPosition.positionName()).isEqualTo("백엔드 개발자");
+        assertThat(firstPosition.positionTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(firstPosition.positionCategoryName()).isEqualTo("백엔드");
         assertThat(firstPosition.headCount()).isEqualTo(3L);
         assertThat(firstPosition.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
+        assertThat(firstPosition.expectedPeriod()).isEqualTo(3L);
         assertThat(firstPosition.skills())
                 .singleElement()
                 .satisfies(skill -> {
@@ -162,6 +164,27 @@ class RecommendationEntryServiceTest {
         // then
         assertThat(result.runnable()).isFalse();
         assertThat(result.helperMessage()).isEqualTo("제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.");
+        verifyExpectedInteractions();
+    }
+
+    @Test
+    @DisplayName("포지션 title이 비어 있으면 category 이름을 fallback으로 사용한다")
+    void getEntry_usesCategoryNameWhenPositionTitleIsBlank() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        ProposalPosition position = addPosition(proposal, 100L, "백엔드", "백엔드 개발자", 1L, null, null, null);
+        ReflectionTestUtils.setField(position, "title", "   ");
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when
+        RecommendationEntryPositionItem result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL).positions().get(0);
+
+        // then
+        assertThat(result.positionTitle()).isEqualTo("백엔드");
+        assertThat(result.positionCategoryName()).isEqualTo("백엔드");
         verifyExpectedInteractions();
     }
 
@@ -267,7 +290,7 @@ class RecommendationEntryServiceTest {
     private Proposal ownedProposalWithSinglePosition(ProposalStatus status, Long budgetMin, Long budgetMax) {
         Member owner = createMemberWithId(OWNER_ID);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, status);
-        addPosition(proposal, 100L, "포지션", 1L, budgetMin, budgetMax);
+        addPosition(proposal, 100L, "포지션", "포지션", 1L, budgetMin, budgetMax, null);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
@@ -326,12 +349,25 @@ class RecommendationEntryServiceTest {
     private ProposalPosition addPosition(
             Proposal proposal,
             Long proposalPositionId,
-            String positionName,
+            String positionCategoryName,
+            String positionTitle,
             Long headCount,
             Long budgetMin,
-            Long budgetMax
+            Long budgetMax,
+            Long expectedPeriod
     ) {
-        ProposalPosition position = proposal.addPosition(Position.create(positionName), headCount, budgetMin, budgetMax);
+        ProposalPosition position = proposal.addPosition(
+                Position.create(positionCategoryName),
+                positionTitle,
+                null,
+                headCount,
+                budgetMin,
+                budgetMax,
+                expectedPeriod,
+                null,
+                null,
+                null
+        );
         setId(position, proposalPositionId);
         return position;
     }


### PR DESCRIPTION
## 🔎 What

- 도메인 정책 변경을 추천 진입 페이지에 반영했습니다.
- proposal_position 기준으로 데이터를 가져오며, position은 직무 마스터(카테고리)로 기능합니다.
- 또한, 작업 기간을 화면에 렌더링하도록 변경했습니다.

<img width="1920" height="1086" alt="image" src="https://github.com/user-attachments/assets/4e973fb0-2386-4c70-8e72-1f239d3dbb26" />

## 🔗 Issue

- Closes: #54 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?