### PR TITLE
[Feat] 이력서 - 경력 사항 카드 및 추가/삭제/수정 화면 추가

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -19,6 +19,9 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Controller
 @RequestMapping("/resumes")
 @RequiredArgsConstructor
@@ -149,7 +152,7 @@ public class ResumeController {
     @PostMapping("/career/add")
     public String addCareer(
             @AuthenticationPrincipal ItDaPrincipal principal,
-            @ModelAttribute CareerItemForm form,
+            @Valid @ModelAttribute CareerItemForm form,
             Model model
     ) {
         resumeService.addCareer(principal.getEmail(), form.toPayload());
@@ -159,11 +162,23 @@ public class ResumeController {
     @PostMapping("/career/update")
     public String updateCareer(
             @AuthenticationPrincipal ItDaPrincipal principal,
-            @ModelAttribute CareerItemForm form,
+            @Valid @ModelAttribute CareerItemForm form,
             Model model
     ) {
         resumeService.updateCareer(principal.getEmail(), form.getIndex(), form.toPayload());
         return prepareCareerSection(principal, model);
+    }
+
+    @ExceptionHandler(org.springframework.validation.BindException.class)
+    @ResponseBody
+    public ResponseEntity<Map<String, String>> handleCareerValidation(org.springframework.validation.BindException ex) {
+        Map<String, String> errors = ex.getFieldErrors().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getField(),
+                        e -> e.getDefaultMessage(),
+                        (a, b) -> a
+                ));
+        return ResponseEntity.badRequest().body(errors);
     }
 
     @PostMapping("/career/remove")

--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -1,9 +1,11 @@
 package com.generic4.itda.controller;
 
+import com.generic4.itda.domain.resume.CareerEmploymentType;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.dto.resume.CareerItemForm;
 import com.generic4.itda.dto.resume.ResumeForm;
 import com.generic4.itda.dto.resume.ResumeSkillForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
@@ -144,6 +146,44 @@ public class ResumeController {
         return "redirect:/resumes/me";
     }
 
+    @PostMapping("/career/add")
+    public String addCareer(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @ModelAttribute CareerItemForm form,
+            Model model
+    ) {
+        resumeService.addCareer(principal.getEmail(), form.toPayload());
+        return prepareCareerSection(principal, model);
+    }
+
+    @PostMapping("/career/update")
+    public String updateCareer(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @ModelAttribute CareerItemForm form,
+            Model model
+    ) {
+        resumeService.updateCareer(principal.getEmail(), form.getIndex(), form.toPayload());
+        return prepareCareerSection(principal, model);
+    }
+
+    @PostMapping("/career/remove")
+    public String removeCareer(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @RequestParam int index,
+            Model model
+    ) {
+        resumeService.removeCareer(principal.getEmail(), index);
+        return prepareCareerSection(principal, model);
+    }
+
+    private String prepareCareerSection(ItDaPrincipal principal, Model model) {
+        Resume resume = resumeService.findByEmail(principal.getEmail());
+        addCommonAttributes(model);
+        model.addAttribute("resume", resume);
+        model.addAttribute("isEditing", true);
+        return "freelancer/resumeForm :: #careerSection";
+    }
+
     @PostMapping("/skill/add")
     public String addSkill(
             @AuthenticationPrincipal ItDaPrincipal principal,
@@ -216,6 +256,7 @@ public class ResumeController {
         model.addAttribute("workTypes", WorkType.values());
         model.addAttribute("proficiencies", Proficiency.values());
         model.addAttribute("writingStatuses", ResumeWritingStatus.values());
+        model.addAttribute("employmentTypes", CareerEmploymentType.values());
     }
 
     private void addMemberAttributes(Model model, ItDaPrincipal principal) {

--- a/src/main/java/com/generic4/itda/domain/resume/CareerItemPayload.java
+++ b/src/main/java/com/generic4/itda/domain/resume/CareerItemPayload.java
@@ -51,6 +51,11 @@ public class CareerItemPayload {
             String> techStack = new ArrayList<>();
 
     @JsonIgnore
+    public String getTechStackJoined() {
+        return techStack == null ? "" : String.join(", ", techStack);
+    }
+
+    @JsonIgnore
     @AssertTrue(message = "재직중인 경력은 종료 연월을 비워야 합니다.")
     public boolean isEndYearMonthEmptyWhenCurrentlyWorking() {
         if (currentlyWorking == null || !currentlyWorking) {

--- a/src/main/java/com/generic4/itda/domain/resume/Resume.java
+++ b/src/main/java/com/generic4/itda/domain/resume/Resume.java
@@ -194,6 +194,39 @@ public class Resume extends BaseEntity {
         this.skills.removeIf(resumeSkill -> resumeSkill.getSkill().equals(skill));
     }
 
+    public void addCareerItem(CareerItemPayload item) {
+        Assert.notNull(item, "경력 항목은 필수값입니다.");
+        CareerPayload updated = new CareerPayload();
+        updated.setVersion(this.career.getVersion());
+        List<CareerItemPayload> newItems = new ArrayList<>(this.career.getItems());
+        newItems.add(item);
+        updated.setItems(newItems);
+        this.career = updated;
+    }
+
+    public void updateCareerItem(int index, CareerItemPayload item) {
+        Assert.notNull(item, "경력 항목은 필수값입니다.");
+        List<CareerItemPayload> items = this.career.getItems();
+        Assert.isTrue(index >= 0 && index < items.size(), "유효하지 않은 경력 인덱스입니다.");
+        CareerPayload updated = new CareerPayload();
+        updated.setVersion(this.career.getVersion());
+        List<CareerItemPayload> newItems = new ArrayList<>(items);
+        newItems.set(index, item);
+        updated.setItems(newItems);
+        this.career = updated;
+    }
+
+    public void removeCareerItem(int index) {
+        List<CareerItemPayload> items = this.career.getItems();
+        Assert.isTrue(index >= 0 && index < items.size(), "유효하지 않은 경력 인덱스입니다.");
+        CareerPayload updated = new CareerPayload();
+        updated.setVersion(this.career.getVersion());
+        List<CareerItemPayload> newItems = new ArrayList<>(items);
+        newItems.remove(index);
+        updated.setItems(newItems);
+        this.career = updated;
+    }
+
     public void updateSkill(Skill skill, Proficiency proficiency) {
         Assert.notNull(skill, "스킬은 필수 입력값입니다.");
         Assert.notNull(proficiency, "숙련도는 필수 입력값입니다.");

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.dto.proposal;
 
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,30 +10,51 @@ import org.springframework.util.Assert;
 @Getter
 public class AiBriefPositionResult {
 
-    private final String positionName;
+    private final String positionCategoryName;
+    private final String title;
+    private final ProposalWorkType workType;
     private final Long headCount;
     private final Long unitBudgetMin;
     private final Long unitBudgetMax;
+    private final Long expectedPeriod;
+    private final Integer careerMinYears;
+    private final Integer careerMaxYears;
+    private final String workPlace;
     private final List<AiBriefSkillResult> skills;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private AiBriefPositionResult(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
-            List<AiBriefSkillResult> skills) {
-        Assert.hasText(positionName, "AI 브리프 직무명은 필수값입니다.");
-        this.positionName = positionName.trim();
+    private AiBriefPositionResult(String positionCategoryName, String title, ProposalWorkType workType, Long headCount,
+            Long unitBudgetMin, Long unitBudgetMax, Long expectedPeriod, Integer careerMinYears,
+            Integer careerMaxYears, String workPlace, List<AiBriefSkillResult> skills) {
+        Assert.hasText(positionCategoryName, "AI 브리프 포지션 카테고리는 필수값입니다.");
+        Assert.hasText(title, "AI 브리프 포지션 제목은 필수값입니다.");
+        this.positionCategoryName = positionCategoryName.trim();
+        this.title = title.trim();
+        this.workType = workType;
         this.headCount = headCount;
         this.unitBudgetMin = unitBudgetMin;
         this.unitBudgetMax = unitBudgetMax;
+        this.expectedPeriod = expectedPeriod;
+        this.careerMinYears = careerMinYears;
+        this.careerMaxYears = careerMaxYears;
+        this.workPlace = workPlace;
         this.skills = skills == null ? List.of() : List.copyOf(skills);
     }
 
-    public static AiBriefPositionResult of(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
-            List<AiBriefSkillResult> skills) {
+    public static AiBriefPositionResult of(String positionCategoryName, String title, ProposalWorkType workType,
+            Long headCount, Long unitBudgetMin, Long unitBudgetMax, Long expectedPeriod, Integer careerMinYears,
+            Integer careerMaxYears, String workPlace, List<AiBriefSkillResult> skills) {
         return AiBriefPositionResult.builder()
-                .positionName(positionName)
+                .positionCategoryName(positionCategoryName)
+                .title(title)
+                .workType(workType)
                 .headCount(headCount)
                 .unitBudgetMin(unitBudgetMin)
                 .unitBudgetMax(unitBudgetMax)
+                .expectedPeriod(expectedPeriod)
+                .careerMinYears(careerMinYears)
+                .careerMaxYears(careerMaxYears)
+                .workPlace(workPlace)
                 .skills(skills)
                 .build();
     }

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.dto.proposal;
 
-import com.generic4.itda.domain.proposal.ProposalWorkType;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,35 +12,27 @@ public class AiBriefResult {
     private final String description;
     private final Long totalBudgetMin;
     private final Long totalBudgetMax;
-    private final ProposalWorkType workType;
-    private final String workPlace;
     private final Long expectedPeriod;
     private final List<AiBriefPositionResult> positions;
 
     @Builder(access = AccessLevel.PRIVATE)
     private AiBriefResult(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
-            ProposalWorkType workType, String workPlace, Long expectedPeriod,
-            List<AiBriefPositionResult> positions) {
+            Long expectedPeriod, List<AiBriefPositionResult> positions) {
         this.title = title;
         this.description = description;
         this.totalBudgetMin = totalBudgetMin;
         this.totalBudgetMax = totalBudgetMax;
-        this.workType = workType;
-        this.workPlace = workPlace;
         this.expectedPeriod = expectedPeriod;
         this.positions = positions == null ? List.of() : List.copyOf(positions);
     }
 
     public static AiBriefResult of(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
-            ProposalWorkType workType, String workPlace, Long expectedPeriod,
-            List<AiBriefPositionResult> positions) {
+            Long expectedPeriod, List<AiBriefPositionResult> positions) {
         return AiBriefResult.builder()
                 .title(title)
                 .description(description)
                 .totalBudgetMin(totalBudgetMin)
                 .totalBudgetMax(totalBudgetMax)
-                .workType(workType)
-                .workPlace(workPlace)
                 .expectedPeriod(expectedPeriod)
                 .positions(positions)
                 .build();

--- a/src/main/java/com/generic4/itda/dto/resume/CareerItemForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/CareerItemForm.java
@@ -2,6 +2,11 @@ package com.generic4.itda.dto.resume;
 
 import com.generic4.itda.domain.resume.CareerEmploymentType;
 import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.dto.resume.validation.ValidCareerPeriod;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,17 +19,37 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @NoArgsConstructor
+@ValidCareerPeriod
 public class CareerItemForm {
+
+    private static final String YEAR_MONTH_REGEX = "^\\d{4}-(0[1-9]|1[0-2])$";
 
     private Integer index; // 수정/삭제 시 사용
 
+    @NotBlank(message = "회사명은 필수값입니다.")
+    @Size(max = 100, message = "회사명은 100자를 초과할 수 없습니다.")
     private String companyName;
+
+    @NotBlank(message = "직책은 필수값입니다.")
+    @Size(max = 100, message = "직책은 100자를 초과할 수 없습니다.")
     private String position;
+
+    @NotNull(message = "고용 형태는 필수값입니다.")
     private CareerEmploymentType employmentType;
+
+    @NotBlank(message = "시작 연월은 필수값입니다.")
+    @Pattern(regexp = YEAR_MONTH_REGEX, message = "시작 연월은 yyyy-MM 형식이어야 합니다.")
     private String startYearMonth;
+
+    @Pattern(regexp = YEAR_MONTH_REGEX, message = "종료 연월은 yyyy-MM 형식이어야 합니다.")
     private String endYearMonth;
+
+    @NotNull(message = "재직 여부는 필수값입니다.")
     private Boolean currentlyWorking;
+
+    @Size(max = 1000, message = "요약은 1000자를 초과할 수 없습니다.")
     private String summary;
+
     private String techStackRaw; // 쉼표 구분 문자열
 
     public CareerItemPayload toPayload() {

--- a/src/main/java/com/generic4/itda/dto/resume/CareerItemForm.java
+++ b/src/main/java/com/generic4/itda/dto/resume/CareerItemForm.java
@@ -1,0 +1,52 @@
+package com.generic4.itda.dto.resume;
+
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CareerItemForm {
+
+    private Integer index; // 수정/삭제 시 사용
+
+    private String companyName;
+    private String position;
+    private CareerEmploymentType employmentType;
+    private String startYearMonth;
+    private String endYearMonth;
+    private Boolean currentlyWorking;
+    private String summary;
+    private String techStackRaw; // 쉼표 구분 문자열
+
+    public CareerItemPayload toPayload() {
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName(companyName);
+        item.setPosition(position);
+        item.setEmploymentType(employmentType);
+        item.setStartYearMonth(startYearMonth);
+        item.setCurrentlyWorking(Boolean.TRUE.equals(currentlyWorking));
+        item.setEndYearMonth(Boolean.TRUE.equals(currentlyWorking) ? null : endYearMonth);
+        item.setSummary(summary);
+
+        if (techStackRaw != null && !techStackRaw.isBlank()) {
+            List<String> stack = Arrays.stream(techStackRaw.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+            item.setTechStack(stack);
+        } else {
+            item.setTechStack(Collections.emptyList());
+        }
+
+        return item;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/resume/validation/CareerItemFormPeriodValidator.java
+++ b/src/main/java/com/generic4/itda/dto/resume/validation/CareerItemFormPeriodValidator.java
@@ -1,0 +1,70 @@
+package com.generic4.itda.dto.resume.validation;
+
+import com.generic4.itda.dto.resume.CareerItemForm;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.YearMonth;
+
+public class CareerItemFormPeriodValidator implements ConstraintValidator<ValidCareerPeriod, CareerItemForm> {
+
+    @Override
+    public boolean isValid(CareerItemForm form, ConstraintValidatorContext context) {
+        if (form == null) {
+            return true;
+        }
+
+        Boolean currentlyWorking = form.getCurrentlyWorking();
+        String endYearMonth = form.getEndYearMonth();
+
+        // If currentlyWorking is missing, let @NotNull handle it.
+        if (currentlyWorking == null) {
+            return true;
+        }
+
+        if (currentlyWorking) {
+            // When currently working, endYearMonth must be empty.
+            if (endYearMonth != null && !endYearMonth.isBlank()) {
+                return violationOnEndYearMonth(context, "재직중인 경력은 종료 연월을 비워야 합니다.");
+            }
+            return true;
+        }
+
+        // Not currently working: endYearMonth is required.
+        if (endYearMonth == null || endYearMonth.isBlank()) {
+            return violationOnEndYearMonth(context, "재직중이 아닌 경력은 종료 연월이 필요합니다.");
+        }
+
+        // Validate ordering only when both are parseable.
+        YearMonth start = parseYearMonth(form.getStartYearMonth());
+        YearMonth end = parseYearMonth(endYearMonth);
+        if (start == null || end == null) {
+            return true;
+        }
+
+        if (end.isBefore(start)) {
+            return violationOnEndYearMonth(context, "종료 연월은 시작 연월보다 빠를 수 없습니다.");
+        }
+
+        return true;
+    }
+
+    private boolean violationOnEndYearMonth(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode("endYearMonth")
+                .addConstraintViolation();
+        return false;
+    }
+
+    private YearMonth parseYearMonth(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return YearMonth.parse(value);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/com/generic4/itda/dto/resume/validation/ValidCareerPeriod.java
+++ b/src/main/java/com/generic4/itda/dto/resume/validation/ValidCareerPeriod.java
@@ -1,0 +1,23 @@
+package com.generic4.itda.dto.resume.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CareerItemFormPeriodValidator.class)
+@Documented
+public @interface ValidCareerPeriod {
+
+    String message() default "Invalid career period";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.resume.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,8 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
             "left join fetch r.attachments " +
             "where r.member.email.value = :email")
     Optional<Resume> findByMemberEmailWithDetails(@Param("email") String email);
+
+    @Modifying
+    @Query(value = "UPDATE resume SET career = :career WHERE id = :id", nativeQuery = true)
+    void updateCareerJson(@Param("id") Long id, @Param("career") String career);
 }

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -50,18 +50,18 @@ public class AiBriefProposalMapper {
         }
 
         for (AiBriefPositionResult positionResult : positions) {
-            Position position = findOrCreatePosition(positionResult.getPositionName());
+            Position position = findOrCreatePosition(positionResult.getPositionCategoryName());
             ProposalPosition proposalPosition = proposal.addPosition(
                     position,
-                    positionResult.getPositionName(),
-                    null,
+                    positionResult.getTitle(),
+                    positionResult.getWorkType(),
                     positionResult.getHeadCount(),
                     positionResult.getUnitBudgetMin(),
                     positionResult.getUnitBudgetMax(),
-                    null,
-                    null,
-                    null,
-                    null
+                    positionResult.getExpectedPeriod(),
+                    positionResult.getCareerMinYears(),
+                    positionResult.getCareerMaxYears(),
+                    positionResult.getWorkPlace()
             );
             addSkills(proposalPosition, positionResult.getSkills());
         }
@@ -74,9 +74,9 @@ public class AiBriefProposalMapper {
         }
     }
 
-    private Position findOrCreatePosition(String positionName) {
-        return positionRepository.findByName(positionName)
-                .orElseGet(() -> positionRepository.save(Position.create(positionName)));
+    private Position findOrCreatePosition(String positionCategoryName) {
+        return positionRepository.findByName(positionCategoryName)
+                .orElseGet(() -> positionRepository.save(Position.create(positionCategoryName)));
     }
 
     private Skill findOrCreateSkill(String skillName) {

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -36,13 +36,17 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - 반드시 JSON만 반환한다.
             - title, description은 한국어로 자연스럽게 작성한다.
             - 근거가 부족한 값은 추측하지 말고 null로 반환한다.
-            - workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
             - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
             - expectedPeriod는 주 단위 기준 정수로 반환한다.
-            - positions는 직무명별로 나누고 같은 직무를 중복 생성하지 않는다.
+            - positions는 실제 모집 단위 배열이다.
+            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 프론트엔드 개발자, 앱 개발자
+            - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Node.js 백엔드 개발자, React Native 앱 개발자
+            - position별 workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
+            - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
+            - 동일한 title을 불필요하게 중복 생성하지 않는다.
             - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
             - importance를 확신할 수 없으면 PREFERENCE를 사용한다.
-            - skillName, positionName은 짧고 일반적인 명칭으로 정리한다.
+            - skillName은 짧고 일반적인 명칭으로 정리한다.
             """;
 
     private final RestClient restClient;
@@ -115,8 +119,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 "description",
                 "totalBudgetMin",
                 "totalBudgetMax",
-                "workType",
-                "workPlace",
                 "expectedPeriod",
                 "positions"
         ));
@@ -125,8 +127,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 "description", nullableStringSchema(),
                 "totalBudgetMin", nullableIntegerSchema(),
                 "totalBudgetMax", nullableIntegerSchema(),
-                "workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"),
-                "workPlace", nullableStringSchema(),
                 "expectedPeriod", nullableIntegerSchema(),
                 "positions", Map.of(
                         "type", "array",
@@ -139,17 +139,35 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
 
     private Map<String, Object> buildPositionSchema() {
         Map<String, Object> schema = objectSchema();
-        schema.put("required", List.of("positionName", "headCount", "unitBudgetMin", "unitBudgetMax", "skills"));
-        schema.put("properties", Map.of(
-                "positionName", Map.of("type", "string"),
-                "headCount", nullableIntegerSchema(),
-                "unitBudgetMin", nullableIntegerSchema(),
-                "unitBudgetMax", nullableIntegerSchema(),
-                "skills", Map.of(
-                        "type", "array",
-                        "items", buildSkillSchema()
-                )
+        schema.put("required", List.of(
+                "positionCategoryName",
+                "title",
+                "workType",
+                "headCount",
+                "unitBudgetMin",
+                "unitBudgetMax",
+                "expectedPeriod",
+                "careerMinYears",
+                "careerMaxYears",
+                "workPlace",
+                "skills"
         ));
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("positionCategoryName", Map.of("type", "string"));
+        properties.put("title", Map.of("type", "string"));
+        properties.put("workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"));
+        properties.put("headCount", nullableIntegerSchema());
+        properties.put("unitBudgetMin", nullableIntegerSchema());
+        properties.put("unitBudgetMax", nullableIntegerSchema());
+        properties.put("expectedPeriod", nullableIntegerSchema());
+        properties.put("careerMinYears", nullableIntegerSchema());
+        properties.put("careerMaxYears", nullableIntegerSchema());
+        properties.put("workPlace", nullableStringSchema());
+        properties.put("skills", Map.of(
+                "type", "array",
+                "items", buildSkillSchema()
+        ));
+        schema.put("properties", properties);
         return schema;
     }
 
@@ -246,8 +264,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 normalizeText(root.get("description")),
                 asLong(root.get("totalBudgetMin")),
                 asLong(root.get("totalBudgetMax")),
-                parseWorkType(root.get("workType")),
-                normalizeText(root.get("workPlace")),
                 asLong(root.get("expectedPeriod")),
                 parsePositions(root.get("positions"))
         );
@@ -261,10 +277,16 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
         List<AiBriefPositionResult> positions = new ArrayList<>();
         for (JsonNode positionNode : positionsNode) {
             positions.add(AiBriefPositionResult.of(
-                    normalizeRequiredText(positionNode.get("positionName"), "AI 브리프 직무명은 필수값입니다."),
+                    normalizeRequiredText(positionNode.get("positionCategoryName"), "AI 브리프 포지션 카테고리는 필수값입니다."),
+                    normalizeRequiredText(positionNode.get("title"), "AI 브리프 포지션 제목은 필수값입니다."),
+                    parseWorkType(positionNode.get("workType")),
                     asLong(positionNode.get("headCount")),
                     asLong(positionNode.get("unitBudgetMin")),
                     asLong(positionNode.get("unitBudgetMax")),
+                    asLong(positionNode.get("expectedPeriod")),
+                    asInteger(positionNode.get("careerMinYears")),
+                    asInteger(positionNode.get("careerMaxYears")),
+                    normalizeText(positionNode.get("workPlace")),
                     parseSkills(positionNode.get("skills"))
             ));
         }
@@ -326,6 +348,17 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
         } catch (NumberFormatException exception) {
             throw new AiBriefGenerationException("숫자 필드 파싱에 실패했습니다. value=" + value, exception);
         }
+    }
+
+    private Integer asInteger(JsonNode node) {
+        Long value = asLong(node);
+        if (value == null) {
+            return null;
+        }
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new AiBriefGenerationException("정수 범위를 벗어났습니다. value=" + value);
+        }
+        return value.intValue();
     }
 
     private String normalizeRequiredText(JsonNode node, String message) {

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -1,6 +1,9 @@
 package com.generic4.itda.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerItemPayload;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.skill.Skill;
@@ -22,6 +25,7 @@ public class ResumeService {
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
     private final SkillRepository skillRepository;
+    private final ObjectMapper objectMapper;
 
     // 이력서 생성
     @Transactional
@@ -58,8 +62,8 @@ public class ResumeService {
         resume.update(
                 form.getIntroduction(),
                 form.getCareerYears(),
-                form.getCareer(),
-                form.getPreferredWorkType(), // 서비스에서는 preferredWorkType, 엔티티는 workType일 수 있으니 이름 확인!
+                resume.getCareer(), // 경력은 AJAX(/career/add,update,remove)로만 관리 — 메인 폼이 덮어쓰지 않도록 기존 값 유지
+                form.getPreferredWorkType(),
                 form.getWritingStatus(),
                 form.getPortfolioUrl()
         );
@@ -70,6 +74,35 @@ public class ResumeService {
         }
         if (resume.isAiMatchingEnabled() != form.isAiMatchingEnabled()) {
             resume.toggleAiMatchingEnabled();
+        }
+    }
+
+    // 경력 추가
+    public void addCareer(String email, CareerItemPayload item) {
+        Resume resume = getResumeByEmail(email);
+        resume.addCareerItem(item);
+        resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+    }
+
+    // 경력 수정
+    public void updateCareer(String email, int index, CareerItemPayload item) {
+        Resume resume = getResumeByEmail(email);
+        resume.updateCareerItem(index, item);
+        resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+    }
+
+    // 경력 삭제
+    public void removeCareer(String email, int index) {
+        Resume resume = getResumeByEmail(email);
+        resume.removeCareerItem(index);
+        resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+    }
+
+    private String toCareerJson(Resume resume) {
+        try {
+            return objectMapper.writeValueAsString(resume.getCareer());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("경력 JSON 직렬화에 실패했습니다.", e);
         }
     }
 

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.service.recommend;
 
-import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class RecommendationFingerprintGenerator {
 
     public String generate(
-            Proposal proposal,
             ProposalPosition proposalPosition,
             RecommendationAlgorithm algorithm,
             int topK
@@ -27,27 +25,14 @@ public class RecommendationFingerprintGenerator {
                 .collect(Collectors.joining("|"));
 
         String raw = String.join("::",
-                "proposal.id=" + proposal.getId(),
-                "proposal.title=" + nullSafe(proposal.getTitle()),
-                "proposal.description=" + nullSafe(proposal.getDescription()),
-                "proposal.totalBudgetMin=" + proposal.getTotalBudgetMin(),
-                "proposal.totalBudgetMax=" + proposal.getTotalBudgetMax(),
-                "proposal.expectedPeriod=" + proposal.getExpectedPeriod(),
-                "proposal.status=" + proposal.getStatus().name(),
-
-                "proposalPosition.id=" + proposalPosition.getId(),
-                "proposalPosition.positionId=" + proposalPosition.getPosition().getId(),
-                "proposalPosition.positionName=" + proposalPosition.getPosition().getName(),
-                "proposalPosition.title=" + nullSafe(proposalPosition.getTitle()),
+                "proposalPosition.id=" + number(proposalPosition.getId()),
+                "proposalPosition.positionId=" + number(proposalPosition.getPosition().getId()),
                 "proposalPosition.workType=" + enumName(proposalPosition.getWorkType()),
-                "proposalPosition.headCount=" + proposalPosition.getHeadCount(),
-                "proposalPosition.status=" + proposalPosition.getStatus().name(),
-                "proposalPosition.unitBudgetMin=" + proposalPosition.getUnitBudgetMin(),
-                "proposalPosition.unitBudgetMax=" + proposalPosition.getUnitBudgetMax(),
-                "proposalPosition.expectedPeriod=" + proposalPosition.getExpectedPeriod(),
-                "proposalPosition.workPlace=" + nullSafe(proposalPosition.getWorkPlace()),
-                "proposalPosition.careerMinYears=" + proposalPosition.getCareerMinYears(),
-                "proposalPosition.careerMaxYears=" + proposalPosition.getCareerMaxYears(),
+                "proposalPosition.careerMinYears=" + number(proposalPosition.getCareerMinYears()),
+                "proposalPosition.careerMaxYears=" + number(proposalPosition.getCareerMaxYears()),
+
+                "proposalPosition.unitBudgetMin=" + number(proposalPosition.getUnitBudgetMin()),
+                "proposalPosition.unitBudgetMax=" + number(proposalPosition.getUnitBudgetMax()),
 
                 "proposalPosition.skills=" + skillPart,
 
@@ -63,8 +48,8 @@ public class RecommendationFingerprintGenerator {
                 + ":" + skill.getImportance().name();
     }
 
-    private String nullSafe(String value) {
-        return value == null ? "" : value;
+    private String number(Number value) {
+        return value == null ? "null" : String.valueOf(value);
     }
 
     private String enumName(Enum<?> value) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
@@ -45,7 +45,6 @@ public class RecommendationRunService {
         validatePositionStatus(proposalPosition);
 
         String fingerprint = fingerprintGenerator.generate(
-                proposal,
                 proposalPosition,
                 DEFAULT_ALGORITHM,
                 DEFAULT_TOP_K

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -3,7 +3,9 @@
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <header th:fragment="headerFragment" class="px-8 py-6 flex items-center justify-between bg-white border-b border-slate-200 shadow-sm relative z-10">
-    <a th:href="@{/}" class="flex items-center gap-2 transition-transform hover:scale-[1.02] active:scale-95">
+    <a th:href="@{/}"
+       onclick="if(window.handleBackAction){ event.preventDefault(); handleBackAction('/'); }"
+       class="flex items-center gap-2 transition-transform hover:scale-[1.02] active:scale-95">
         <img th:src="@{/IT-da_logo.png}" alt="IT-da Logo" class="h-12 w-auto" />
     </a>
 

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -18,6 +18,80 @@
         <main class="min-h-screen bg-slate-50 py-10 px-6">
             <div class="max-w-4xl mx-auto space-y-6">
 
+                <!-- ===== 경력 모달 ===== -->
+                <div id="careerModal" class="fixed inset-0 z-[9998] hidden">
+                    <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" onclick="closeCareerModal()"></div>
+                    <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg px-4">
+                        <div class="bg-white rounded-3xl p-8 shadow-2xl border border-slate-100 max-h-[90vh] overflow-y-auto">
+                            <h3 id="careerModalTitle" class="text-lg font-bold text-slate-900 mb-6">경력 추가</h3>
+                            <form id="careerForm" class="space-y-4">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                                <input type="hidden" id="careerIndex" name="index">
+
+                                <div>
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">회사명 *</label>
+                                    <input type="text" name="companyName" id="careerCompanyName" placeholder="회사명을 입력하세요"
+                                           class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                </div>
+
+                                <div>
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">직책 *</label>
+                                    <input type="text" name="position" id="careerPosition" placeholder="직책을 입력하세요"
+                                           class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                </div>
+
+                                <div>
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">고용 형태 *</label>
+                                    <select name="employmentType" id="careerEmploymentType"
+                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm appearance-none focus:border-blue-400 focus:outline-none">
+                                        <option value="">선택하세요</option>
+                                        <option th:each="et : ${employmentTypes}" th:value="${et}" th:text="${et.description}"></option>
+                                    </select>
+                                </div>
+
+                                <div class="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label class="text-xs font-bold text-slate-400 block mb-1.5">시작 연월 *</label>
+                                        <input type="text" name="startYearMonth" id="careerStart" placeholder="yyyy-MM"
+                                               class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                    </div>
+                                    <div>
+                                        <label class="text-xs font-bold text-slate-400 block mb-1.5">종료 연월</label>
+                                        <input type="text" name="endYearMonth" id="careerEnd" placeholder="yyyy-MM"
+                                               class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                    </div>
+                                </div>
+
+                                <label class="flex items-center gap-2 cursor-pointer">
+                                    <input type="checkbox" name="currentlyWorking" id="careerCurrentlyWorking" value="true"
+                                           class="w-4 h-4 rounded" onchange="toggleCareerEndField(this)">
+                                    <span class="text-sm text-slate-700 font-medium">현재 재직중</span>
+                                </label>
+
+                                <div>
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">요약</label>
+                                    <textarea name="summary" id="careerSummary" rows="3" placeholder="주요 업무 및 성과를 입력하세요"
+                                              class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none resize-none"></textarea>
+                                </div>
+
+                                <div>
+                                    <label class="text-xs font-bold text-slate-400 block mb-1.5">기술 스택</label>
+                                    <input type="text" name="techStackRaw" id="careerTechStack" placeholder="Java, Spring Boot, MySQL"
+                                           class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                    <p class="text-xs text-slate-400 mt-1">쉼표(,)로 구분하여 입력하세요</p>
+                                </div>
+
+                                <div class="flex gap-3 pt-2">
+                                    <button type="button" onclick="closeCareerModal()"
+                                            class="flex-1 px-5 py-3 rounded-2xl bg-slate-100 text-slate-600 font-bold text-sm hover:bg-slate-200 transition-all">취소</button>
+                                    <button type="submit"
+                                            class="flex-1 px-5 py-3 rounded-2xl bg-blue-600 text-white font-bold text-sm hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all">저장</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
                 <div id="exitModal" class="fixed inset-0 z-[9999] hidden">
                     <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"></div>
 
@@ -52,7 +126,7 @@
 
                         <!-- 뒤로가기 + 구분선 + 프로필 정보 -->
                         <div class="flex items-center gap-4">
-                            <button type="button" onclick="handleBackAction()"
+                            <button type="button" onclick="handleBackAction('/freelancers/dashboard')"
                                     class="flex items-center justify-center w-9 h-9 text-slate-400 rounded-xl hover:bg-slate-100 hover:text-slate-600 transition-all active:scale-95 shrink-0">
                                 <i data-lucide="arrow-left" class="w-5 h-5"></i>
                             </button>
@@ -91,7 +165,7 @@
 
                             <!-- [기존 이력서 - 편집 모드] 취소 + 저장하기 -->
                             <th:block th:if="${isNew eq false and isEditing eq true}">
-                                <button type="button" onclick="handleBackAction()"
+                                <button type="button" onclick="handleBackAction('/resumes/me')"
                                         class="px-6 py-3 text-slate-500 font-bold text-sm hover:text-slate-700 transition-all">취소</button>
                                 <button type="submit" form="profileForm"
                                         class="bg-blue-600 text-white px-8 py-3 rounded-2xl font-bold hover:bg-blue-700 shadow-lg shadow-blue-200 transition-all active:scale-95 flex items-center gap-2">
@@ -260,6 +334,73 @@
 
                 </form>
 
+                <!-- ===== 경력 사항 (AJAX — 별도 POST, #careerSection 전체 교체) ===== -->
+                <div id="careerSection" class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
+                    <div class="flex items-center justify-between">
+                        <h3 class="text-base font-bold text-slate-700">경력 사항</h3>
+                        <button th:if="${isEditing}" type="button" onclick="openCareerModal('add')"
+                                class="flex items-center gap-1.5 px-4 py-2 bg-slate-800 text-white text-sm font-bold rounded-xl hover:bg-slate-700 transition-all active:scale-95">
+                            <i data-lucide="plus" class="w-4 h-4"></i>추가
+                        </button>
+                    </div>
+
+                    <th:block th:if="${resume == null}">
+                        <p class="text-sm text-slate-400">이력서를 먼저 저장한 후 경력을 등록할 수 있습니다.</p>
+                    </th:block>
+
+                    <th:block th:if="${resume != null}">
+                        <p th:if="${resume.career.items.isEmpty()}" class="text-sm text-slate-400">등록된 경력이 없습니다.</p>
+
+                        <div th:if="${not resume.career.items.isEmpty()}" class="space-y-4">
+                            <div th:each="item, stat : ${resume.career.items}"
+                                 class="p-5 border border-slate-100 rounded-2xl bg-slate-50 space-y-2"
+                                 th:data-index="${stat.index}"
+                                 th:data-company="${item.companyName}"
+                                 th:data-position="${item.position}"
+                                 th:data-employment-type="${item.employmentType}"
+                                 th:data-start="${item.startYearMonth}"
+                                 th:data-end="${item.endYearMonth}"
+                                 th:data-currently-working="${item.currentlyWorking}"
+                                 th:data-summary="${item.summary}"
+                                 th:data-tech-stack="${item.techStackJoined}">
+
+                                <div class="flex items-start justify-between gap-2">
+                                    <div class="space-y-1 flex-1">
+                                        <div class="flex items-center gap-2 flex-wrap">
+                                            <p class="text-sm font-bold text-slate-900" th:text="${item.companyName}">회사명</p>
+                                            <span class="text-xs px-2 py-0.5 bg-slate-200 text-slate-600 rounded-lg font-medium"
+                                                  th:text="${item.employmentType != null ? item.employmentType.description : ''}">정규직</span>
+                                        </div>
+                                        <p class="text-sm text-slate-500" th:text="${item.position}">직책</p>
+                                        <p class="text-xs text-slate-400"
+                                           th:text="${item.startYearMonth} + ' - ' + (${item.currentlyWorking} ? '현재' : ${item.endYearMonth})">기간</p>
+                                    </div>
+                                    <th:block th:if="${isEditing}">
+                                        <div class="flex items-center gap-2 shrink-0">
+                                            <button type="button"
+                                                    onclick="openCareerModal('edit', this.closest('[data-index]'))"
+                                                    class="text-xs font-semibold text-slate-500 hover:text-blue-600 transition-colors">수정하기</button>
+                                            <button type="button"
+                                                    th:onclick="'removeCareer(' + ${stat.index} + ')'"
+                                                    class="text-slate-300 hover:text-red-400 transition-colors flex items-center">
+                                                <i data-lucide="x" class="w-4 h-4"></i>
+                                            </button>
+                                        </div>
+                                    </th:block>
+                                </div>
+
+                                <p th:if="${item.summary != null and not #strings.isEmpty(item.summary)}"
+                                   class="text-xs text-slate-500 leading-relaxed" th:text="${item.summary}">요약</p>
+
+                                <div th:if="${not item.techStack.isEmpty()}" class="flex flex-wrap gap-1.5 pt-1">
+                                    <span th:each="tech : ${item.techStack}" th:text="${tech}"
+                                          class="px-2 py-0.5 bg-white border border-slate-200 text-slate-600 text-xs font-medium rounded-lg">기술</span>
+                                </div>
+                            </div>
+                        </div>
+                    </th:block>
+                </div>
+
                 <!-- ===== 기술 스택 (AJAX — 별도 POST, #skillSection 전체 교체) ===== -->
                 <div id="skillSection" class="bg-white border border-slate-200 rounded-3xl p-8 shadow-sm space-y-5">
                     <h3 class="text-base font-bold text-slate-700">기술 스택</h3>
@@ -412,6 +553,98 @@
         }
     });
 
+    // ─── 경력 모달 ────────────────────────────────────────
+    (function () {
+        var form = document.getElementById('careerForm');
+        if (!form) return;
+
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var index = document.getElementById('careerIndex').value;
+            var url   = index !== '' ? '/resumes/career/update' : '/resumes/career/add';
+
+            fetch(url, { method: 'POST', body: new FormData(form) })
+                .then(function (r) { if (!r.ok) throw r; return r.text(); })
+                .then(function (html) {
+                    var tmp  = document.createElement('div');
+                    tmp.innerHTML = html;
+                    var next = tmp.querySelector('#careerSection') || tmp.firstElementChild;
+                    var old  = document.getElementById('careerSection');
+                    if (next && old) { old.replaceWith(next); if (window.lucide) lucide.createIcons(); }
+                    closeCareerModal();
+                })
+                .catch(function (err) { console.error('경력 저장 오류', err); });
+        });
+    })();
+
+    window.openCareerModal = function (mode, card) {
+        var modal = document.getElementById('careerModal');
+        var title = document.getElementById('careerModalTitle');
+        if (!modal) return;
+
+        document.getElementById('careerForm').reset();
+        document.getElementById('careerIndex').value = '';
+        document.getElementById('careerEnd').disabled = false;
+
+        if (mode === 'edit' && card) {
+            title.textContent = '경력 수정';
+            document.getElementById('careerIndex').value          = card.dataset.index;
+            document.getElementById('careerCompanyName').value    = card.dataset.company    || '';
+            document.getElementById('careerPosition').value       = card.dataset.position   || '';
+            document.getElementById('careerEmploymentType').value = card.dataset.employmentType || '';
+            document.getElementById('careerStart').value          = card.dataset.start      || '';
+            var currentlyWorking = card.dataset.currentlyWorking === 'true';
+            document.getElementById('careerCurrentlyWorking').checked = currentlyWorking;
+            if (currentlyWorking) {
+                document.getElementById('careerEnd').disabled = true;
+                document.getElementById('careerEnd').value = '';
+            } else {
+                document.getElementById('careerEnd').value = card.dataset.end || '';
+            }
+            document.getElementById('careerSummary').value        = card.dataset.summary    || '';
+            document.getElementById('careerTechStack').value      = card.dataset.techStack  || '';
+        } else {
+            title.textContent = '경력 추가';
+        }
+
+        modal.classList.remove('hidden');
+    };
+
+    window.closeCareerModal = function () {
+        var modal = document.getElementById('careerModal');
+        if (modal) modal.classList.add('hidden');
+    };
+
+    window.toggleCareerEndField = function (checkbox) {
+        var endField = document.getElementById('careerEnd');
+        if (checkbox.checked) {
+            endField.dataset.prev = endField.value; // 기존 날짜 저장
+            endField.value = '재직중';
+            endField.disabled = true;
+        } else {
+            endField.value = endField.dataset.prev || ''; // 복원
+            endField.disabled = false;
+        }
+    };
+
+    window.removeCareer = function (index) {
+        var csrfInput = document.querySelector('#careerForm input[name="_csrf"]');
+        var data = new FormData();
+        data.append('index', index);
+        if (csrfInput) data.append('_csrf', csrfInput.value);
+        fetch('/resumes/career/remove', { method: 'POST', body: data })
+            .then(function (r) { if (!r.ok) throw r; return r.text(); })
+            .then(function (html) {
+                var tmp  = document.createElement('div');
+                tmp.innerHTML = html;
+                var next = tmp.querySelector('#careerSection') || tmp.firstElementChild;
+                var old  = document.getElementById('careerSection');
+                if (next && old) { old.replaceWith(next); if (window.lucide) lucide.createIcons(); }
+            })
+            .catch(function (err) { console.error('경력 삭제 오류', err); });
+    };
+    // ──────────────────────────────────────────────────────
+
     let isDirty = document.getElementById('isEditingFlag')?.value === 'true';
 
     (function () {
@@ -449,16 +682,16 @@
         });
 
         // 전역 함수로 등록
-        window.handleBackAction = function() {
-            console.log('[DEBUG] 뒤로가기 클릭됨, 현재 isDirty:', isDirty);
+        var exitDest = '/resumes/me';
 
-            // 이제 isDirty가 정의되어 있으므로 에러가 나지 않습니다.
+        window.handleBackAction = function(dest) {
+            exitDest = dest || '/resumes/me';
             if (isDirty) {
                 if (modal) {
                     modal.classList.remove('hidden');
                 }
             } else {
-                location.href = "/freelancers/dashboard";
+                location.href = exitDest;
             }
         };
 
@@ -468,7 +701,7 @@
 
         window.confirmExit = function() {
             isDirty = false;
-            location.href = "/freelancers/dashboard";
+            location.href = exitDest;
         };
     })();
 </script>

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -1,4 +1,4 @@
-rb<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -32,12 +32,14 @@
                                     <label class="text-xs font-bold text-slate-400 block mb-1.5">회사명 *</label>
                                     <input type="text" name="companyName" id="careerCompanyName" placeholder="회사명을 입력하세요"
                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                    <p id="err-companyName" class="text-xs text-red-500 mt-1 hidden"></p>
                                 </div>
 
                                 <div>
                                     <label class="text-xs font-bold text-slate-400 block mb-1.5">직책 *</label>
                                     <input type="text" name="position" id="careerPosition" placeholder="직책을 입력하세요"
                                            class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                    <p id="err-position" class="text-xs text-red-500 mt-1 hidden"></p>
                                 </div>
 
                                 <div>
@@ -47,6 +49,7 @@
                                         <option value="">선택하세요</option>
                                         <option th:each="et : ${employmentTypes}" th:value="${et}" th:text="${et.description}"></option>
                                     </select>
+                                    <p id="err-employmentType" class="text-xs text-red-500 mt-1 hidden"></p>
                                 </div>
 
                                 <div class="grid grid-cols-2 gap-4">
@@ -54,19 +57,25 @@
                                         <label class="text-xs font-bold text-slate-400 block mb-1.5">시작 연월 *</label>
                                         <input type="text" name="startYearMonth" id="careerStart" placeholder="yyyy-MM"
                                                class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                        <p id="err-startYearMonth" class="text-xs text-red-500 mt-1 hidden"></p>
                                     </div>
                                     <div>
                                         <label class="text-xs font-bold text-slate-400 block mb-1.5">종료 연월</label>
                                         <input type="text" name="endYearMonth" id="careerEnd" placeholder="yyyy-MM"
                                                class="w-full p-3 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:border-blue-400 focus:outline-none">
+                                        <p id="err-endYearMonth" class="text-xs text-red-500 mt-1 hidden"></p>
                                     </div>
                                 </div>
 
                                 <label class="flex items-center gap-2 cursor-pointer">
                                     <input type="checkbox" name="currentlyWorking" id="careerCurrentlyWorking" value="true"
                                            class="w-4 h-4 rounded" onchange="toggleCareerEndField(this)">
+                                    <!-- Spring field marker: unchecked checkbox -> currentlyWorking=false without duplicate param values -->
+                                    <input type="hidden" name="_currentlyWorking" value="on">
                                     <span class="text-sm text-slate-700 font-medium">현재 재직중</span>
                                 </label>
+
+                                <p id="err-currentlyWorking" class="text-xs text-red-500 mt-1 hidden"></p>
 
                                 <div>
                                     <label class="text-xs font-bold text-slate-400 block mb-1.5">요약</label>
@@ -554,24 +563,47 @@
     });
 
     // ─── 경력 모달 ────────────────────────────────────────
+    window.clearCareerErrors = function () {
+        document.querySelectorAll('[id^="err-"]').forEach(function (el) {
+            el.textContent = '';
+            el.classList.add('hidden');
+        });
+    };
+
     (function () {
         var form = document.getElementById('careerForm');
         if (!form) return;
 
+        function showCareerErrors(errors) {
+            Object.keys(errors).forEach(function (field) {
+                var el = document.getElementById('err-' + field);
+                if (el) {
+                    el.textContent = errors[field];
+                    el.classList.remove('hidden');
+                }
+            });
+        }
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
+            clearCareerErrors();
             var index = document.getElementById('careerIndex').value;
             var url   = index !== '' ? '/resumes/career/update' : '/resumes/career/add';
 
             fetch(url, { method: 'POST', body: new FormData(form) })
-                .then(function (r) { if (!r.ok) throw r; return r.text(); })
-                .then(function (html) {
-                    var tmp  = document.createElement('div');
-                    tmp.innerHTML = html;
-                    var next = tmp.querySelector('#careerSection') || tmp.firstElementChild;
-                    var old  = document.getElementById('careerSection');
-                    if (next && old) { old.replaceWith(next); if (window.lucide) lucide.createIcons(); }
-                    closeCareerModal();
+                .then(function (r) {
+                    if (r.status === 400) {
+                        return r.json().then(function (errors) { showCareerErrors(errors); });
+                    }
+                    if (!r.ok) throw r;
+                    return r.text().then(function (html) {
+                        var tmp  = document.createElement('div');
+                        tmp.innerHTML = html;
+                        var next = tmp.querySelector('#careerSection') || tmp.firstElementChild;
+                        var old  = document.getElementById('careerSection');
+                        if (next && old) { old.replaceWith(next); if (window.lucide) lucide.createIcons(); }
+                        closeCareerModal();
+                    });
                 })
                 .catch(function (err) { console.error('경력 저장 오류', err); });
         });
@@ -585,6 +617,7 @@
         document.getElementById('careerForm').reset();
         document.getElementById('careerIndex').value = '';
         document.getElementById('careerEnd').disabled = false;
+        document.getElementById('careerEnd').placeholder = 'yyyy-MM';
 
         if (mode === 'edit' && card) {
             title.textContent = '경력 수정';
@@ -598,6 +631,7 @@
             if (currentlyWorking) {
                 document.getElementById('careerEnd').disabled = true;
                 document.getElementById('careerEnd').value = '';
+                document.getElementById('careerEnd').placeholder = '재직중';
             } else {
                 document.getElementById('careerEnd').value = card.dataset.end || '';
             }
@@ -613,16 +647,21 @@
     window.closeCareerModal = function () {
         var modal = document.getElementById('careerModal');
         if (modal) modal.classList.add('hidden');
+        clearCareerErrors();
     };
 
     window.toggleCareerEndField = function (checkbox) {
         var endField = document.getElementById('careerEnd');
+        if (!endField) return;
+
         if (checkbox.checked) {
-            endField.dataset.prev = endField.value; // 기존 날짜 저장
-            endField.value = '재직중';
+            endField.dataset.prev = endField.value;
+            endField.value = '';
+            endField.placeholder = '재직중';
             endField.disabled = true;
         } else {
-            endField.value = endField.dataset.prev || ''; // 복원
+            endField.value = endField.dataset.prev || '';
+            endField.placeholder = 'yyyy-MM';
             endField.disabled = false;
         }
     };

--- a/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
@@ -52,15 +52,19 @@ class ProposalAiBriefControllerTest {
                 "AI가 만든 설명",
                 3_000_000L,
                 5_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 6L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 1L,
                                 3_000_000L,
                                 4_000_000L,
+                                6L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(
                                         AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL),
                                         AiBriefSkillResult.of("Spring Boot",
@@ -82,8 +86,9 @@ class ProposalAiBriefControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("AI가 만든 제목"))
                 .andExpect(jsonPath("$.description").value("AI가 만든 설명"))
-                .andExpect(jsonPath("$.workType").value("HYBRID"))
-                .andExpect(jsonPath("$.positions[0].positionName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].positionCategoryName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].title").value("Node.js 백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].workType").value("HYBRID"))
                 .andExpect(jsonPath("$.positions[0].skills[0].skillName").value("Java"))
                 .andExpect(jsonPath("$.positions[0].skills[0].importance").value("ESSENTIAL"));
 

--- a/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ResumeControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -468,6 +469,47 @@ class ResumeControllerTest {
                     .andExpect(model().attribute("isEditing", true));
 
             then(resumeService).should().updateSkill("user@example.com", 3L, Proficiency.ADVANCED);
+        }
+    }
+
+    // =========================================================
+    // POST /resumes/career/add
+    // =========================================================
+
+    @Nested
+    @DisplayName("POST /resumes/career/add")
+    class AddCareerTest {
+
+        @Test
+        @DisplayName("종료 연월이 시작 연월보다 빠르면 400과 endYearMonth 오류를 반환한다")
+        void return400WhenEndYearMonthIsBeforeStartYearMonth() throws Exception {
+            mockMvc.perform(post("/resumes/career/add").with(authentication(auth)).with(csrf())
+                            .param("companyName", "ACME")
+                            .param("position", "Backend Engineer")
+                            .param("employmentType", "FULL_TIME")
+                            .param("startYearMonth", "2024-05")
+                            .param("endYearMonth", "2024-04")
+                            .param("currentlyWorking", "false"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.endYearMonth").exists());
+
+            then(resumeService).should(never()).addCareer(any(), any());
+        }
+
+        @Test
+        @DisplayName("재직중이 아닌데 종료 연월이 비어있으면 400과 endYearMonth 오류를 반환한다")
+        void return400WhenEndYearMonthIsMissing() throws Exception {
+            mockMvc.perform(post("/resumes/career/add").with(authentication(auth)).with(csrf())
+                            .param("companyName", "ACME")
+                            .param("position", "Backend Engineer")
+                            .param("employmentType", "FULL_TIME")
+                            .param("startYearMonth", "2024-05")
+                            .param("endYearMonth", "")
+                            .param("currentlyWorking", "false"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.endYearMonth").exists());
+
+            then(resumeService).should(never()).addCareer(any(), any());
         }
     }
 }

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -59,15 +59,19 @@ class AiBriefProposalMapperTest {
                 "AI가 정리한 설명",
                 5_000_000L,
                 8_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 12L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 2L,
                                 3_000_000L,
                                 4_000_000L,
+                                12L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(AiBriefSkillResult.of("Java", null))
                         )
                 )
@@ -82,6 +86,12 @@ class AiBriefProposalMapperTest {
         assertThat(proposal.getExpectedPeriod()).isEqualTo(12L);
         assertThat(proposal.getPositions()).hasSize(1);
         assertThat(proposal.getPositions().get(0).getPosition().getName()).isEqualTo("백엔드 개발자");
+        assertThat(proposal.getPositions().get(0).getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(proposal.getPositions().get(0).getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposal.getPositions().get(0).getExpectedPeriod()).isEqualTo(12L);
+        assertThat(proposal.getPositions().get(0).getCareerMinYears()).isEqualTo(3);
+        assertThat(proposal.getPositions().get(0).getCareerMaxYears()).isEqualTo(6);
+        assertThat(proposal.getPositions().get(0).getWorkPlace()).isEqualTo("판교");
         assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill().getName()).isEqualTo("Java");
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getImportance())
@@ -97,8 +107,6 @@ class AiBriefProposalMapperTest {
                 "설명만 갱신",
                 null,
                 null,
-                ProposalWorkType.REMOTE,
-                "강남",
                 8L,
                 List.of()
         );
@@ -121,8 +129,6 @@ class AiBriefProposalMapperTest {
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
                 " ",
-                null,
-                null,
                 null,
                 null,
                 null,
@@ -160,12 +166,16 @@ class AiBriefProposalMapperTest {
                 null,
                 null,
                 null,
-                null,
-                null,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
                                 1L,
+                                null,
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 List.of(AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL))
@@ -191,8 +201,6 @@ class AiBriefProposalMapperTest {
                 "기존 설명",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 3L
         );
     }

--- a/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
@@ -70,19 +70,23 @@ class OpenAiAiBriefGeneratorTest {
                 "description", "백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.",
                 "totalBudgetMin", 5000000,
                 "totalBudgetMax", 8000000,
-                "workType", "HYBRID",
-                "workPlace", "판교",
                 "expectedPeriod", 6,
                 "positions", List.of(
-                        Map.of(
-                                "positionName", "백엔드 개발자",
-                                "headCount", 1,
-                                "unitBudgetMin", 3000000,
-                                "unitBudgetMax", 4000000,
-                                "skills", List.of(
+                        Map.ofEntries(
+                                Map.entry("positionCategoryName", "백엔드 개발자"),
+                                Map.entry("title", "Node.js 백엔드 개발자"),
+                                Map.entry("workType", "HYBRID"),
+                                Map.entry("headCount", 1),
+                                Map.entry("unitBudgetMin", 3000000),
+                                Map.entry("unitBudgetMax", 4000000),
+                                Map.entry("expectedPeriod", 6),
+                                Map.entry("careerMinYears", 3),
+                                Map.entry("careerMaxYears", 6),
+                                Map.entry("workPlace", "판교"),
+                                Map.entry("skills", List.of(
                                         Map.of("skillName", "Java", "importance", "ESSENTIAL"),
                                         Map.of("skillName", "Spring Boot", "importance", "PREFERENCE")
-                                )
+                                ))
                         )
                 )
         ));
@@ -101,14 +105,25 @@ class OpenAiAiBriefGeneratorTest {
                         "description",
                         "totalBudgetMin",
                         "totalBudgetMax",
-                        "workType",
-                        "workPlace",
                         "expectedPeriod",
                         "positions"
                 )))
                 .andExpect(jsonPath("$.text.format.schema.properties.title.type[*]").value(containsInAnyOrder(
                         "string",
                         "null"
+                )))
+                .andExpect(jsonPath("$.text.format.schema.properties.positions.items.required[*]").value(containsInAnyOrder(
+                        "positionCategoryName",
+                        "title",
+                        "workType",
+                        "headCount",
+                        "unitBudgetMin",
+                        "unitBudgetMax",
+                        "expectedPeriod",
+                        "careerMinYears",
+                        "careerMaxYears",
+                        "workPlace",
+                        "skills"
                 )))
                 .andExpect(jsonPath("$.text.format.schema.properties.positions.items.properties.skills.items.required[*]")
                         .value(containsInAnyOrder("skillName", "importance")))
@@ -123,11 +138,15 @@ class OpenAiAiBriefGeneratorTest {
         assertThat(result.getDescription()).isEqualTo("백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.");
         assertThat(result.getTotalBudgetMin()).isEqualTo(5_000_000L);
         assertThat(result.getTotalBudgetMax()).isEqualTo(8_000_000L);
-        assertThat(result.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
-        assertThat(result.getWorkPlace()).isEqualTo("판교");
         assertThat(result.getExpectedPeriod()).isEqualTo(6L);
         assertThat(result.getPositions()).hasSize(1);
-        assertThat(result.getPositions().get(0).getPositionName()).isEqualTo("백엔드 개발자");
+        assertThat(result.getPositions().get(0).getPositionCategoryName()).isEqualTo("백엔드 개발자");
+        assertThat(result.getPositions().get(0).getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(result.getPositions().get(0).getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(result.getPositions().get(0).getExpectedPeriod()).isEqualTo(6L);
+        assertThat(result.getPositions().get(0).getCareerMinYears()).isEqualTo(3);
+        assertThat(result.getPositions().get(0).getCareerMaxYears()).isEqualTo(6);
+        assertThat(result.getPositions().get(0).getWorkPlace()).isEqualTo("판교");
         assertThat(result.getPositions().get(0).getSkills()).hasSize(2);
         assertThat(result.getPositions().get(0).getSkills().get(0).getSkillName()).isEqualTo("Java");
         assertThat(result.getPositions().get(0).getSkills().get(0).getImportance())
@@ -155,8 +174,21 @@ class OpenAiAiBriefGeneratorTest {
         String briefJson = objectMapper.writeValueAsString(Map.of(
                 "title", "제목",
                 "description", "설명",
-                "workType", "OFFICE",
-                "positions", List.of()
+                "positions", List.of(
+                        Map.ofEntries(
+                                Map.entry("positionCategoryName", "백엔드 개발자"),
+                                Map.entry("title", "백엔드 개발자"),
+                                Map.entry("workType", "OFFICE"),
+                                Map.entry("headCount", 1),
+                                Map.entry("unitBudgetMin", 1000000),
+                                Map.entry("unitBudgetMax", 2000000),
+                                Map.entry("expectedPeriod", 4),
+                                Map.entry("careerMinYears", 1),
+                                Map.entry("careerMaxYears", 3),
+                                Map.entry("workPlace", "판교"),
+                                Map.entry("skills", List.of())
+                        )
+                )
         ));
 
         server.expect(requestTo(API_URL))

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceIntegrationTest.java
@@ -76,8 +76,6 @@ class ProposalAiBriefServiceIntegrationTest {
                 "기존 설명",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 4L
         );
         ProposalPosition existingPosition = proposal.addPosition(oldPosition, 1L, 500_000L, 700_000L);
@@ -89,15 +87,19 @@ class ProposalAiBriefServiceIntegrationTest {
                 "웹 서비스 개발 외주입니다. 백엔드 개발자 1명과 프론트엔드 개발자 1명을 12주 동안 채용합니다.",
                 8_000_000L,
                 8_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 12L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 1L,
                                 null,
                                 null,
+                                12L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(
                                         AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL),
                                         AiBriefSkillResult.of("Spring Boot",
@@ -106,8 +108,14 @@ class ProposalAiBriefServiceIntegrationTest {
                         ),
                         AiBriefPositionResult.of(
                                 "프론트엔드 개발자",
+                                "React 프론트엔드 개발자",
+                                ProposalWorkType.REMOTE,
                                 1L,
                                 null,
+                                null,
+                                10L,
+                                null,
+                                4,
                                 null,
                                 List.of(AiBriefSkillResult.of("React", null))
                         )
@@ -140,6 +148,12 @@ class ProposalAiBriefServiceIntegrationTest {
 
         ProposalPosition backendPosition = positionsByName.get("백엔드 개발자");
         assertThat(backendPosition).isNotNull();
+        assertThat(backendPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(backendPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(backendPosition.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(backendPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(backendPosition.getCareerMaxYears()).isEqualTo(6);
+        assertThat(backendPosition.getWorkPlace()).isEqualTo("판교");
         assertThat(backendPosition.getHeadCount()).isEqualTo(1L);
         assertThat(backendPosition.getSkills())
                 .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())
@@ -150,6 +164,12 @@ class ProposalAiBriefServiceIntegrationTest {
 
         ProposalPosition frontendPosition = positionsByName.get("프론트엔드 개발자");
         assertThat(frontendPosition).isNotNull();
+        assertThat(frontendPosition.getTitle()).isEqualTo("React 프론트엔드 개발자");
+        assertThat(frontendPosition.getWorkType()).isEqualTo(ProposalWorkType.REMOTE);
+        assertThat(frontendPosition.getExpectedPeriod()).isEqualTo(10L);
+        assertThat(frontendPosition.getCareerMinYears()).isNull();
+        assertThat(frontendPosition.getCareerMaxYears()).isEqualTo(4);
+        assertThat(frontendPosition.getWorkPlace()).isNull();
         assertThat(frontendPosition.getHeadCount()).isEqualTo(1L);
         assertThat(frontendPosition.getSkills())
                 .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
@@ -55,8 +55,6 @@ class ProposalAiBriefServiceTest {
                 "AI가 만든 설명",
                 3_000_000L,
                 5_000_000L,
-                ProposalWorkType.REMOTE,
-                "판교",
                 6L,
                 null
         );
@@ -142,8 +140,6 @@ class ProposalAiBriefServiceTest {
                 "제안서 본문",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 3L
         );
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
@@ -17,11 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * FingerprintGenerator 계약 검증: 1. 결정성(determinism): 동일 입력 → 동일 fingerprint 2. 순서 불변성: skills 삽입 순서가 달라도 동일 fingerprint
- * (정렬 로직) 3. 민감도(sensitivity): 입력 필드 하나가 바뀌면 fingerprint가 달라진다 4. null-safe: nullable 필드가 null이어도 예외 없이 생성된다 5. skill
- * id fallback: skill.id=null이면 name으로 대체된다
- * <p>
- * ※ Spring 컨텍스트 없이 new RecommendationFingerprintGeneratorTest()로 직접 인스턴스화한다.
+ * FingerprintGenerator 계약 검증:
+ * 1. 동일한 proposalPosition 입력이면 항상 같은 fingerprint를 만든다.
+ * 2. skills 입력 순서가 달라도 fingerprint는 동일하다.
+ * 3. fingerprint를 구성하는 proposalPosition/추천 파라미터가 바뀌면 fingerprint도 달라진다.
+ * 4. nullable 필드가 null이어도 예외 없이 fingerprint를 생성한다.
+ * 5. skill.id가 없으면 name으로 fallback 한다.
  */
 class RecommendationFingerprintGeneratorTest {
 
@@ -32,112 +33,105 @@ class RecommendationFingerprintGeneratorTest {
         generator = new RecommendationFingerprintGenerator();
     }
 
-    // ============================================================
-    // 결정성
-    // ============================================================
-
     @Test
     @DisplayName("동일 입력으로 여러 번 호출해도 같은 fingerprint를 반환한다")
     void generate_isDeterministic() {
-        // 이 값이 같아야 하는 이유:
-        // SHA-256은 순수 함수(pure function)다. 입력 바이트가 동일하면 출력 해시는 항상 동일하다.
-        // 난수·시간·외부 상태에 의존하지 않으므로 반복 호출에도 동일한 값이 나와야 한다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
         addSkillWithId(position, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isEqualTo(fp2);
     }
-
-    // ============================================================
-    // 순서 불변성
-    // ============================================================
 
     @Test
     @DisplayName("skills 추가 순서가 달라도 fingerprint가 동일하다")
     void generate_isOrderInvariantForSkills() {
-        // 이 값이 같아야 하는 이유:
-        // generate() 내부에서 skills를 name → importance 기준으로 정렬(Comparator.comparing)한 뒤 "|"로 결합한다.
-        // 따라서 addSkill() 호출 순서(삽입 순서)가 달라도 skillPart 문자열이 동일하게 구성된다.
-        Proposal proposalA = createBaseProposal();
-        ProposalPosition posOrderA = createBasePosition(proposalA);
-        addSkillWithId(posOrderA, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);   // Java 먼저
-        addSkillWithId(posOrderA, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 나중
+        ProposalPosition posOrderA = createBasePosition(createBaseProposal());
+        addSkillWithId(posOrderA, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
+        addSkillWithId(posOrderA, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE);
 
-        Proposal proposalB = createBaseProposal(); // id=1L (동일)
-        ProposalPosition posOrderB = createBasePosition(proposalB);
-        addSkillWithId(posOrderB, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 먼저 (역순)
-        addSkillWithId(posOrderB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);    // Java 나중 (역순)
+        ProposalPosition posOrderB = createBasePosition(createBaseProposal());
+        addSkillWithId(posOrderB, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE);
+        addSkillWithId(posOrderB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposalA, posOrderA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posOrderB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posOrderA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posOrderB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: proposal 필드 변경
-    // ============================================================
-
     @Test
-    @DisplayName("proposal.title이 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenTitleChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposal.title=<value>"가 포함된다.
-        // title이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createProposalWithTitle("제목 A");
-        Proposal proposalB = createProposalWithTitle("제목 B"); // title만 다름, id=1L 동일
-        ProposalPosition posA = createBasePosition(proposalA);
-        ProposalPosition posB = createBasePosition(proposalB);
+    @DisplayName("proposalPosition.id가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenProposalPositionIdChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        setId(posB, 11L);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
     @Test
-    @DisplayName("proposal.description이 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenDescriptionChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposal.description=<value>"가 포함된다.
-        // description이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createProposalWithDescription("설명 A");
-        Proposal proposalB = createProposalWithDescription("설명 B"); // description만 다름, id=1L 동일
-        ProposalPosition posA = createBasePosition(proposalA);
-        ProposalPosition posB = createBasePosition(proposalB);
+    @DisplayName("position.id가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenPositionIdChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        setId(posB.getPosition(), 1002L);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: position 필드 변경
-    // ============================================================
+    @Test
+    @DisplayName("proposalPosition.unitBudgetMax가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenUnitBudgetMaxChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        posB.update(
+                posB.getPosition(),
+                posB.getTitle(),
+                posB.getWorkType(),
+                posB.getHeadCount(),
+                posB.getUnitBudgetMin(),
+                2_500_000L,
+                posB.getExpectedPeriod(),
+                posB.getCareerMinYears(),
+                posB.getCareerMaxYears(),
+                posB.getWorkPlace()
+        );
+
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
 
     @Test
-    @DisplayName("proposalPosition.headCount가 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenHeadCountChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposalPosition.headCount=<value>"가 포함된다.
-        // headCount가 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createBaseProposal();
-        Proposal proposalB = createBaseProposal(); // id=1L 동일
+    @DisplayName("proposalPosition.careerMinYears가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenCareerMinYearsChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        posB.update(
+                posB.getPosition(),
+                posB.getTitle(),
+                posB.getWorkType(),
+                posB.getHeadCount(),
+                posB.getUnitBudgetMin(),
+                posB.getUnitBudgetMax(),
+                posB.getExpectedPeriod(),
+                3,
+                posB.getCareerMaxYears(),
+                posB.getWorkPlace()
+        );
 
-        // 같은 proposal에 동일 position 이름을 두 번 추가할 수 없으므로 각각 별도 proposal에 추가
-        ProposalPosition posA = proposalA.addPosition(Position.create("포지션"), 3L, null, null);
-        setId(posA, 10L);
-
-        ProposalPosition posB = proposalB.addPosition(Position.create("포지션"), 5L, null, null); // headCount만 다름
-        setId(posB, 10L);
-
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
@@ -145,39 +139,25 @@ class RecommendationFingerprintGeneratorTest {
     @Test
     @DisplayName("skill importance가 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenSkillImportanceChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // toSkillToken()이 "id:importance.name()"으로 토큰을 만든다.
-        // PREFERENCE → ESSENTIAL로 바뀌면 skillPart 문자열이 달라지고, fingerprint도 달라진다.
-        Proposal proposalA = createBaseProposal();
-        Proposal proposalB = createBaseProposal(); // id=1L 동일
-
-        ProposalPosition posA = createBasePosition(proposalA);
+        ProposalPosition posA = createBasePosition(createBaseProposal());
         addSkillWithId(posA, 1L, "Java", ProposalPositionSkillImportance.PREFERENCE);
 
-        ProposalPosition posB = createBasePosition(proposalB);
-        addSkillWithId(posB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // importance만 다름
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        addSkillWithId(posB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: 추천 파라미터 변경
-    // ============================================================
-
     @Test
     @DisplayName("algorithm이 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenAlgorithmChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "recommendation.algorithm=<value>"가 포함된다.
-        // HEURISTIC_V1 vs VECTOR_ENGINE_V1은 name()이 다르므로 raw string이 달라진다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.VECTOR_ENGINE_V1, 5);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.VECTOR_ENGINE_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
@@ -185,133 +165,118 @@ class RecommendationFingerprintGeneratorTest {
     @Test
     @DisplayName("topK가 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenTopKChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "recommendation.topK=<value>"가 포함된다.
-        // topK=5 vs topK=10은 숫자가 달라 raw string이 달라진다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 10);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 10);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // null-safe
-    // ============================================================
-
     @Test
-    @DisplayName("proposal.description=null이어도 예외 없이 fingerprint가 생성된다")
-    void generate_nullSafe_whenDescriptionIsNull() {
-        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "제목", "원본 입력", null, // description = null
-                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+    @DisplayName("nullable 필드가 null이어도 예외 없이 fingerprint가 생성된다")
+    void generate_nullSafe_whenOptionalFieldsAreNull() {
+        ProposalPosition position = createPositionWithOptionalFields(
+                createBaseProposal(),
+                10L,
+                1001L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
         );
-        setId(proposal, 1L);
-        ProposalPosition position = createBasePosition(proposal);
 
         assertThatCode(() ->
-                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
+                generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5)
         ).doesNotThrowAnyException();
     }
-
-    @Test
-    @DisplayName("proposal.workPlace=null이어도 예외 없이 fingerprint가 생성된다")
-    void generate_nullSafe_whenWorkPlaceIsNull() {
-        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "제목", "원본 입력", "설명",
-                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, null, // workPlace = null
-                3L
-        );
-        setId(proposal, 1L);
-        ProposalPosition position = createBasePosition(proposal);
-
-        assertThatCode(() ->
-                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
-        ).doesNotThrowAnyException();
-    }
-
-    // ============================================================
-    // skill id fallback
-    // ============================================================
 
     @Test
     @DisplayName("skill.id=null이면 name으로 fallback하여 결정적으로 fingerprint를 생성하며, id가 있는 경우와 다르다")
     void generate_skillIdNullFallsBackToName() {
-        // 이 값이 달라져야 하는 이유:
-        // toSkillToken()이 id != null ? id : name 으로 토큰을 결정한다.
-        //   - skill.id=null  → 토큰: "Java:ESSENTIAL"
-        //   - skill.id=1L    → 토큰: "1:ESSENTIAL"
-        // 두 토큰이 다르므로 fingerprint도 달라야 한다.
-        //
-        // 각 경우는 결정적이어야 한다: 동일 입력으로 두 번 호출 시 같은 fingerprint가 나와야 한다.
-        Proposal proposalWithNullId = createBaseProposal();
-        ProposalPosition posNullId = createBasePosition(proposalWithNullId);
-        Skill skillNoId = Skill.create("Java", null); // id = null (JPA 미할당 상태)
+        ProposalPosition posNullId = createBasePosition(createBaseProposal());
+        Skill skillNoId = Skill.create("Java", null);
         posNullId.addSkill(skillNoId, ProposalPositionSkillImportance.ESSENTIAL);
 
-        Proposal proposalWithId = createBaseProposal(); // id=1L 동일
-        ProposalPosition posWithId = createBasePosition(proposalWithId);
-        addSkillWithId(posWithId, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // id=1L
+        ProposalPosition posWithId = createBasePosition(createBaseProposal());
+        addSkillWithId(posWithId, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fpNullId1 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fpNullId2 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fpWithId = generator.generate(proposalWithId, posWithId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpNullId1 = generator.generate(posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpNullId2 = generator.generate(posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpWithId = generator.generate(posWithId, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
-        // null id 경우도 결정적이어야 한다
         assertThat(fpNullId1).isEqualTo(fpNullId2);
-
-        // id가 있을 때와 없을 때는 토큰이 달라 fingerprint가 달라야 한다
         assertThat(fpNullId1).isNotEqualTo(fpWithId);
     }
-
-    // ============================================================
-    // private helpers
-    // ============================================================
 
     private Proposal createBaseProposal() {
         Proposal proposal = Proposal.create(
                 MemberFixture.createMember(),
-                "기본 제안서 제목", "원본 입력 텍스트", "기본 설명",
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
-        );
-        setId(proposal, 1L);
-        return proposal;
-    }
-
-    private Proposal createProposalWithTitle(String title) {
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                title, "원본 입력 텍스트", "기본 설명",
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
-        );
-        setId(proposal, 1L);
-        return proposal;
-    }
-
-    private Proposal createProposalWithDescription(String description) {
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "기본 제안서 제목", "원본 입력 텍스트", description,
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+                "기본 제안서 제목",
+                "원본 입력 텍스트",
+                "기본 설명",
+                1_000_000L,
+                5_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                3L
         );
         setId(proposal, 1L);
         return proposal;
     }
 
     private ProposalPosition createBasePosition(Proposal proposal) {
-        ProposalPosition position = proposal.addPosition(Position.create("백엔드 개발자"), 2L, null, null);
-        setId(position, 10L);
-        return position;
+        return createPositionWithOptionalFields(
+                proposal,
+                10L,
+                1001L,
+                null,
+                1_000_000L,
+                2_000_000L,
+                null,
+                null,
+                null
+        );
     }
 
-    private void addSkillWithId(ProposalPosition position, Long skillId, String name,
-            ProposalPositionSkillImportance importance) {
+    private ProposalPosition createPositionWithOptionalFields(
+            Proposal proposal,
+            Long proposalPositionId,
+            Long positionId,
+            ProposalWorkType workType,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
+        Position position = Position.create("백엔드 개발자");
+        setId(position, positionId);
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "백엔드 개발자",
+                workType,
+                2L,
+                unitBudgetMin,
+                unitBudgetMax,
+                null,
+                careerMinYears,
+                careerMaxYears,
+                workPlace
+        );
+        setId(proposalPosition, proposalPositionId);
+        return proposalPosition;
+    }
+
+    private void addSkillWithId(
+            ProposalPosition position,
+            Long skillId,
+            String name,
+            ProposalPositionSkillImportance importance
+    ) {
         Skill skill = Skill.create(name, null);
         setId(skill, skillId);
         position.addSkill(skill, importance);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
@@ -94,7 +94,6 @@ class RecommendationRunServiceIntegrationTest {
         Proposal persistedProposal = loadProposalDetail(proposalId);
         ProposalPosition persistedPosition = findPosition(persistedProposal, proposalPositionId);
         String expectedFingerprint = fingerprintGenerator.generate(
-                persistedProposal,
                 persistedPosition,
                 DEFAULT_ALGORITHM,
                 DEFAULT_TOP_K
@@ -142,14 +141,19 @@ class RecommendationRunServiceIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Proposal editableProposal = proposalRepository.findById(proposalId).orElseThrow();
-        editableProposal.update(
-                "수정된 제목",
-                editableProposal.getRawInputText(),
-                editableProposal.getDescription(),
-                editableProposal.getTotalBudgetMin(),
-                editableProposal.getTotalBudgetMax(),
-                editableProposal.getExpectedPeriod()
+        Proposal editableProposal = loadProposalDetail(proposalId);
+        ProposalPosition editablePosition = findPosition(editableProposal, proposalPositionId);
+        editablePosition.update(
+                editablePosition.getPosition(),
+                editablePosition.getTitle(),
+                editablePosition.getWorkType(),
+                editablePosition.getHeadCount(),
+                editablePosition.getUnitBudgetMin(),
+                2_200_000L,
+                editablePosition.getExpectedPeriod(),
+                editablePosition.getCareerMinYears(),
+                editablePosition.getCareerMaxYears(),
+                editablePosition.getWorkPlace()
         );
         proposalRepository.saveAndFlush(editableProposal);
         entityManager.clear();

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
@@ -90,7 +90,7 @@ class RecommendationRunServiceTest {
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
-        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+        given(fingerprintGenerator.generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
                 .willReturn(FINGERPRINT);
         given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                 SELECTED_POSITION_ID,
@@ -108,7 +108,7 @@ class RecommendationRunServiceTest {
         inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
         inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
         inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
-        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(fingerprintGenerator).generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
         inOrder.verify(recommendationRunRepository)
                 .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                         SELECTED_POSITION_ID,
@@ -130,7 +130,7 @@ class RecommendationRunServiceTest {
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
-        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+        given(fingerprintGenerator.generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
                 .willReturn(FINGERPRINT);
         given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                 SELECTED_POSITION_ID,
@@ -155,7 +155,7 @@ class RecommendationRunServiceTest {
         inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
         inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
         inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
-        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(fingerprintGenerator).generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
         inOrder.verify(recommendationRunRepository)
                 .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                         SELECTED_POSITION_ID,


### PR DESCRIPTION
## 🔎 What

이력서 관리 페이지 화면에서 경력사항 데이터를 카드 형태로 보여주고, 모달창을 통한 추가/수정/삭제 기능을 구현합니다.
커리어에 대한 백엔드(도메인, 서비스, 컨트롤러)는 구현 완료 상태이므로, 이번 이슈에서는 화면 및 AJAX 연동만 작업했습니다.

(+)추가로 이력서 편집중 헤더 로고 클릭하여 페이지를 떠날시 경고 모달 출력과 취소 클릭시 프리랜서 대시보드록 가던 것을 /resumes/me 로 돌아가도록 수정했습니다

## 🔗 Issue

- Closes: #53 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?