### PR TITLE
[Feat] RecommendationRun fingerprint를 ProposalPosition 기반으로 재구성

### DIFF
--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.service.recommend;
 
-import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class RecommendationFingerprintGenerator {
 
     public String generate(
-            Proposal proposal,
             ProposalPosition proposalPosition,
             RecommendationAlgorithm algorithm,
             int topK
@@ -27,27 +25,14 @@ public class RecommendationFingerprintGenerator {
                 .collect(Collectors.joining("|"));
 
         String raw = String.join("::",
-                "proposal.id=" + proposal.getId(),
-                "proposal.title=" + nullSafe(proposal.getTitle()),
-                "proposal.description=" + nullSafe(proposal.getDescription()),
-                "proposal.totalBudgetMin=" + proposal.getTotalBudgetMin(),
-                "proposal.totalBudgetMax=" + proposal.getTotalBudgetMax(),
-                "proposal.expectedPeriod=" + proposal.getExpectedPeriod(),
-                "proposal.status=" + proposal.getStatus().name(),
-
-                "proposalPosition.id=" + proposalPosition.getId(),
-                "proposalPosition.positionId=" + proposalPosition.getPosition().getId(),
-                "proposalPosition.positionName=" + proposalPosition.getPosition().getName(),
-                "proposalPosition.title=" + nullSafe(proposalPosition.getTitle()),
+                "proposalPosition.id=" + number(proposalPosition.getId()),
+                "proposalPosition.positionId=" + number(proposalPosition.getPosition().getId()),
                 "proposalPosition.workType=" + enumName(proposalPosition.getWorkType()),
-                "proposalPosition.headCount=" + proposalPosition.getHeadCount(),
-                "proposalPosition.status=" + proposalPosition.getStatus().name(),
-                "proposalPosition.unitBudgetMin=" + proposalPosition.getUnitBudgetMin(),
-                "proposalPosition.unitBudgetMax=" + proposalPosition.getUnitBudgetMax(),
-                "proposalPosition.expectedPeriod=" + proposalPosition.getExpectedPeriod(),
-                "proposalPosition.workPlace=" + nullSafe(proposalPosition.getWorkPlace()),
-                "proposalPosition.careerMinYears=" + proposalPosition.getCareerMinYears(),
-                "proposalPosition.careerMaxYears=" + proposalPosition.getCareerMaxYears(),
+                "proposalPosition.careerMinYears=" + number(proposalPosition.getCareerMinYears()),
+                "proposalPosition.careerMaxYears=" + number(proposalPosition.getCareerMaxYears()),
+
+                "proposalPosition.unitBudgetMin=" + number(proposalPosition.getUnitBudgetMin()),
+                "proposalPosition.unitBudgetMax=" + number(proposalPosition.getUnitBudgetMax()),
 
                 "proposalPosition.skills=" + skillPart,
 
@@ -63,8 +48,8 @@ public class RecommendationFingerprintGenerator {
                 + ":" + skill.getImportance().name();
     }
 
-    private String nullSafe(String value) {
-        return value == null ? "" : value;
+    private String number(Number value) {
+        return value == null ? "null" : String.valueOf(value);
     }
 
     private String enumName(Enum<?> value) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
@@ -45,7 +45,6 @@ public class RecommendationRunService {
         validatePositionStatus(proposalPosition);
 
         String fingerprint = fingerprintGenerator.generate(
-                proposal,
                 proposalPosition,
                 DEFAULT_ALGORITHM,
                 DEFAULT_TOP_K

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
@@ -17,11 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * FingerprintGenerator 계약 검증: 1. 결정성(determinism): 동일 입력 → 동일 fingerprint 2. 순서 불변성: skills 삽입 순서가 달라도 동일 fingerprint
- * (정렬 로직) 3. 민감도(sensitivity): 입력 필드 하나가 바뀌면 fingerprint가 달라진다 4. null-safe: nullable 필드가 null이어도 예외 없이 생성된다 5. skill
- * id fallback: skill.id=null이면 name으로 대체된다
- * <p>
- * ※ Spring 컨텍스트 없이 new RecommendationFingerprintGeneratorTest()로 직접 인스턴스화한다.
+ * FingerprintGenerator 계약 검증:
+ * 1. 동일한 proposalPosition 입력이면 항상 같은 fingerprint를 만든다.
+ * 2. skills 입력 순서가 달라도 fingerprint는 동일하다.
+ * 3. fingerprint를 구성하는 proposalPosition/추천 파라미터가 바뀌면 fingerprint도 달라진다.
+ * 4. nullable 필드가 null이어도 예외 없이 fingerprint를 생성한다.
+ * 5. skill.id가 없으면 name으로 fallback 한다.
  */
 class RecommendationFingerprintGeneratorTest {
 
@@ -32,112 +33,105 @@ class RecommendationFingerprintGeneratorTest {
         generator = new RecommendationFingerprintGenerator();
     }
 
-    // ============================================================
-    // 결정성
-    // ============================================================
-
     @Test
     @DisplayName("동일 입력으로 여러 번 호출해도 같은 fingerprint를 반환한다")
     void generate_isDeterministic() {
-        // 이 값이 같아야 하는 이유:
-        // SHA-256은 순수 함수(pure function)다. 입력 바이트가 동일하면 출력 해시는 항상 동일하다.
-        // 난수·시간·외부 상태에 의존하지 않으므로 반복 호출에도 동일한 값이 나와야 한다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
         addSkillWithId(position, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isEqualTo(fp2);
     }
-
-    // ============================================================
-    // 순서 불변성
-    // ============================================================
 
     @Test
     @DisplayName("skills 추가 순서가 달라도 fingerprint가 동일하다")
     void generate_isOrderInvariantForSkills() {
-        // 이 값이 같아야 하는 이유:
-        // generate() 내부에서 skills를 name → importance 기준으로 정렬(Comparator.comparing)한 뒤 "|"로 결합한다.
-        // 따라서 addSkill() 호출 순서(삽입 순서)가 달라도 skillPart 문자열이 동일하게 구성된다.
-        Proposal proposalA = createBaseProposal();
-        ProposalPosition posOrderA = createBasePosition(proposalA);
-        addSkillWithId(posOrderA, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);   // Java 먼저
-        addSkillWithId(posOrderA, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 나중
+        ProposalPosition posOrderA = createBasePosition(createBaseProposal());
+        addSkillWithId(posOrderA, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
+        addSkillWithId(posOrderA, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE);
 
-        Proposal proposalB = createBaseProposal(); // id=1L (동일)
-        ProposalPosition posOrderB = createBasePosition(proposalB);
-        addSkillWithId(posOrderB, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE); // Spring 먼저 (역순)
-        addSkillWithId(posOrderB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);    // Java 나중 (역순)
+        ProposalPosition posOrderB = createBasePosition(createBaseProposal());
+        addSkillWithId(posOrderB, 2L, "Spring", ProposalPositionSkillImportance.PREFERENCE);
+        addSkillWithId(posOrderB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposalA, posOrderA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posOrderB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posOrderA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posOrderB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: proposal 필드 변경
-    // ============================================================
-
     @Test
-    @DisplayName("proposal.title이 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenTitleChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposal.title=<value>"가 포함된다.
-        // title이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createProposalWithTitle("제목 A");
-        Proposal proposalB = createProposalWithTitle("제목 B"); // title만 다름, id=1L 동일
-        ProposalPosition posA = createBasePosition(proposalA);
-        ProposalPosition posB = createBasePosition(proposalB);
+    @DisplayName("proposalPosition.id가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenProposalPositionIdChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        setId(posB, 11L);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
     @Test
-    @DisplayName("proposal.description이 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenDescriptionChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposal.description=<value>"가 포함된다.
-        // description이 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createProposalWithDescription("설명 A");
-        Proposal proposalB = createProposalWithDescription("설명 B"); // description만 다름, id=1L 동일
-        ProposalPosition posA = createBasePosition(proposalA);
-        ProposalPosition posB = createBasePosition(proposalB);
+    @DisplayName("position.id가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenPositionIdChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        setId(posB.getPosition(), 1002L);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: position 필드 변경
-    // ============================================================
+    @Test
+    @DisplayName("proposalPosition.unitBudgetMax가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenUnitBudgetMaxChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        posB.update(
+                posB.getPosition(),
+                posB.getTitle(),
+                posB.getWorkType(),
+                posB.getHeadCount(),
+                posB.getUnitBudgetMin(),
+                2_500_000L,
+                posB.getExpectedPeriod(),
+                posB.getCareerMinYears(),
+                posB.getCareerMaxYears(),
+                posB.getWorkPlace()
+        );
+
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
 
     @Test
-    @DisplayName("proposalPosition.headCount가 바뀌면 fingerprint가 달라진다")
-    void generate_changesWhenHeadCountChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "proposalPosition.headCount=<value>"가 포함된다.
-        // headCount가 달라지면 raw string이 달라지고, SHA-256 출력도 달라진다.
-        Proposal proposalA = createBaseProposal();
-        Proposal proposalB = createBaseProposal(); // id=1L 동일
+    @DisplayName("proposalPosition.careerMinYears가 바뀌면 fingerprint가 달라진다")
+    void generate_changesWhenCareerMinYearsChanges() {
+        ProposalPosition posA = createBasePosition(createBaseProposal());
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        posB.update(
+                posB.getPosition(),
+                posB.getTitle(),
+                posB.getWorkType(),
+                posB.getHeadCount(),
+                posB.getUnitBudgetMin(),
+                posB.getUnitBudgetMax(),
+                posB.getExpectedPeriod(),
+                3,
+                posB.getCareerMaxYears(),
+                posB.getWorkPlace()
+        );
 
-        // 같은 proposal에 동일 position 이름을 두 번 추가할 수 없으므로 각각 별도 proposal에 추가
-        ProposalPosition posA = proposalA.addPosition(Position.create("포지션"), 3L, null, null);
-        setId(posA, 10L);
-
-        ProposalPosition posB = proposalB.addPosition(Position.create("포지션"), 5L, null, null); // headCount만 다름
-        setId(posB, 10L);
-
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
@@ -145,39 +139,25 @@ class RecommendationFingerprintGeneratorTest {
     @Test
     @DisplayName("skill importance가 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenSkillImportanceChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // toSkillToken()이 "id:importance.name()"으로 토큰을 만든다.
-        // PREFERENCE → ESSENTIAL로 바뀌면 skillPart 문자열이 달라지고, fingerprint도 달라진다.
-        Proposal proposalA = createBaseProposal();
-        Proposal proposalB = createBaseProposal(); // id=1L 동일
-
-        ProposalPosition posA = createBasePosition(proposalA);
+        ProposalPosition posA = createBasePosition(createBaseProposal());
         addSkillWithId(posA, 1L, "Java", ProposalPositionSkillImportance.PREFERENCE);
 
-        ProposalPosition posB = createBasePosition(proposalB);
-        addSkillWithId(posB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // importance만 다름
+        ProposalPosition posB = createBasePosition(createBaseProposal());
+        addSkillWithId(posB, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fp1 = generator.generate(proposalA, posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposalB, posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp1 = generator.generate(posA, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(posB, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // 민감도: 추천 파라미터 변경
-    // ============================================================
-
     @Test
     @DisplayName("algorithm이 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenAlgorithmChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "recommendation.algorithm=<value>"가 포함된다.
-        // HEURISTIC_V1 vs VECTOR_ENGINE_V1은 name()이 다르므로 raw string이 달라진다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.VECTOR_ENGINE_V1, 5);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.VECTOR_ENGINE_V1, 5);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
@@ -185,133 +165,118 @@ class RecommendationFingerprintGeneratorTest {
     @Test
     @DisplayName("topK가 바뀌면 fingerprint가 달라진다")
     void generate_changesWhenTopKChanges() {
-        // 이 값이 달라져야 하는 이유:
-        // raw string에 "recommendation.topK=<value>"가 포함된다.
-        // topK=5 vs topK=10은 숫자가 달라 raw string이 달라진다.
-        Proposal proposal = createBaseProposal();
-        ProposalPosition position = createBasePosition(proposal);
+        ProposalPosition position = createBasePosition(createBaseProposal());
 
-        String fp1 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fp2 = generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 10);
+        String fp1 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fp2 = generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 10);
 
         assertThat(fp1).isNotEqualTo(fp2);
     }
 
-    // ============================================================
-    // null-safe
-    // ============================================================
-
     @Test
-    @DisplayName("proposal.description=null이어도 예외 없이 fingerprint가 생성된다")
-    void generate_nullSafe_whenDescriptionIsNull() {
-        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "제목", "원본 입력", null, // description = null
-                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+    @DisplayName("nullable 필드가 null이어도 예외 없이 fingerprint가 생성된다")
+    void generate_nullSafe_whenOptionalFieldsAreNull() {
+        ProposalPosition position = createPositionWithOptionalFields(
+                createBaseProposal(),
+                10L,
+                1001L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
         );
-        setId(proposal, 1L);
-        ProposalPosition position = createBasePosition(proposal);
 
         assertThatCode(() ->
-                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
+                generator.generate(position, RecommendationAlgorithm.HEURISTIC_V1, 5)
         ).doesNotThrowAnyException();
     }
-
-    @Test
-    @DisplayName("proposal.workPlace=null이어도 예외 없이 fingerprint가 생성된다")
-    void generate_nullSafe_whenWorkPlaceIsNull() {
-        // nullSafe()가 null → ""으로 변환하므로 NullPointerException 없이 동작해야 한다.
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "제목", "원본 입력", "설명",
-                1_000_000L, 2_000_000L, ProposalWorkType.REMOTE, null, // workPlace = null
-                3L
-        );
-        setId(proposal, 1L);
-        ProposalPosition position = createBasePosition(proposal);
-
-        assertThatCode(() ->
-                generator.generate(proposal, position, RecommendationAlgorithm.HEURISTIC_V1, 5)
-        ).doesNotThrowAnyException();
-    }
-
-    // ============================================================
-    // skill id fallback
-    // ============================================================
 
     @Test
     @DisplayName("skill.id=null이면 name으로 fallback하여 결정적으로 fingerprint를 생성하며, id가 있는 경우와 다르다")
     void generate_skillIdNullFallsBackToName() {
-        // 이 값이 달라져야 하는 이유:
-        // toSkillToken()이 id != null ? id : name 으로 토큰을 결정한다.
-        //   - skill.id=null  → 토큰: "Java:ESSENTIAL"
-        //   - skill.id=1L    → 토큰: "1:ESSENTIAL"
-        // 두 토큰이 다르므로 fingerprint도 달라야 한다.
-        //
-        // 각 경우는 결정적이어야 한다: 동일 입력으로 두 번 호출 시 같은 fingerprint가 나와야 한다.
-        Proposal proposalWithNullId = createBaseProposal();
-        ProposalPosition posNullId = createBasePosition(proposalWithNullId);
-        Skill skillNoId = Skill.create("Java", null); // id = null (JPA 미할당 상태)
+        ProposalPosition posNullId = createBasePosition(createBaseProposal());
+        Skill skillNoId = Skill.create("Java", null);
         posNullId.addSkill(skillNoId, ProposalPositionSkillImportance.ESSENTIAL);
 
-        Proposal proposalWithId = createBaseProposal(); // id=1L 동일
-        ProposalPosition posWithId = createBasePosition(proposalWithId);
-        addSkillWithId(posWithId, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL); // id=1L
+        ProposalPosition posWithId = createBasePosition(createBaseProposal());
+        addSkillWithId(posWithId, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        String fpNullId1 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fpNullId2 = generator.generate(proposalWithNullId, posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
-        String fpWithId = generator.generate(proposalWithId, posWithId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpNullId1 = generator.generate(posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpNullId2 = generator.generate(posNullId, RecommendationAlgorithm.HEURISTIC_V1, 5);
+        String fpWithId = generator.generate(posWithId, RecommendationAlgorithm.HEURISTIC_V1, 5);
 
-        // null id 경우도 결정적이어야 한다
         assertThat(fpNullId1).isEqualTo(fpNullId2);
-
-        // id가 있을 때와 없을 때는 토큰이 달라 fingerprint가 달라야 한다
         assertThat(fpNullId1).isNotEqualTo(fpWithId);
     }
-
-    // ============================================================
-    // private helpers
-    // ============================================================
 
     private Proposal createBaseProposal() {
         Proposal proposal = Proposal.create(
                 MemberFixture.createMember(),
-                "기본 제안서 제목", "원본 입력 텍스트", "기본 설명",
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
-        );
-        setId(proposal, 1L);
-        return proposal;
-    }
-
-    private Proposal createProposalWithTitle(String title) {
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                title, "원본 입력 텍스트", "기본 설명",
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
-        );
-        setId(proposal, 1L);
-        return proposal;
-    }
-
-    private Proposal createProposalWithDescription(String description) {
-        Proposal proposal = Proposal.create(
-                MemberFixture.createMember(),
-                "기본 제안서 제목", "원본 입력 텍스트", description,
-                1_000_000L, 5_000_000L, ProposalWorkType.REMOTE, "판교", 3L
+                "기본 제안서 제목",
+                "원본 입력 텍스트",
+                "기본 설명",
+                1_000_000L,
+                5_000_000L,
+                ProposalWorkType.REMOTE,
+                "판교",
+                3L
         );
         setId(proposal, 1L);
         return proposal;
     }
 
     private ProposalPosition createBasePosition(Proposal proposal) {
-        ProposalPosition position = proposal.addPosition(Position.create("백엔드 개발자"), 2L, null, null);
-        setId(position, 10L);
-        return position;
+        return createPositionWithOptionalFields(
+                proposal,
+                10L,
+                1001L,
+                null,
+                1_000_000L,
+                2_000_000L,
+                null,
+                null,
+                null
+        );
     }
 
-    private void addSkillWithId(ProposalPosition position, Long skillId, String name,
-            ProposalPositionSkillImportance importance) {
+    private ProposalPosition createPositionWithOptionalFields(
+            Proposal proposal,
+            Long proposalPositionId,
+            Long positionId,
+            ProposalWorkType workType,
+            Long unitBudgetMin,
+            Long unitBudgetMax,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            String workPlace
+    ) {
+        Position position = Position.create("백엔드 개발자");
+        setId(position, positionId);
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "백엔드 개발자",
+                workType,
+                2L,
+                unitBudgetMin,
+                unitBudgetMax,
+                null,
+                careerMinYears,
+                careerMaxYears,
+                workPlace
+        );
+        setId(proposalPosition, proposalPositionId);
+        return proposalPosition;
+    }
+
+    private void addSkillWithId(
+            ProposalPosition position,
+            Long skillId,
+            String name,
+            ProposalPositionSkillImportance importance
+    ) {
         Skill skill = Skill.create(name, null);
         setId(skill, skillId);
         position.addSkill(skill, importance);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceIntegrationTest.java
@@ -94,7 +94,6 @@ class RecommendationRunServiceIntegrationTest {
         Proposal persistedProposal = loadProposalDetail(proposalId);
         ProposalPosition persistedPosition = findPosition(persistedProposal, proposalPositionId);
         String expectedFingerprint = fingerprintGenerator.generate(
-                persistedProposal,
                 persistedPosition,
                 DEFAULT_ALGORITHM,
                 DEFAULT_TOP_K
@@ -142,14 +141,19 @@ class RecommendationRunServiceIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Proposal editableProposal = proposalRepository.findById(proposalId).orElseThrow();
-        editableProposal.update(
-                "수정된 제목",
-                editableProposal.getRawInputText(),
-                editableProposal.getDescription(),
-                editableProposal.getTotalBudgetMin(),
-                editableProposal.getTotalBudgetMax(),
-                editableProposal.getExpectedPeriod()
+        Proposal editableProposal = loadProposalDetail(proposalId);
+        ProposalPosition editablePosition = findPosition(editableProposal, proposalPositionId);
+        editablePosition.update(
+                editablePosition.getPosition(),
+                editablePosition.getTitle(),
+                editablePosition.getWorkType(),
+                editablePosition.getHeadCount(),
+                editablePosition.getUnitBudgetMin(),
+                2_200_000L,
+                editablePosition.getExpectedPeriod(),
+                editablePosition.getCareerMinYears(),
+                editablePosition.getCareerMaxYears(),
+                editablePosition.getWorkPlace()
         );
         proposalRepository.saveAndFlush(editableProposal);
         entityManager.clear();

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
@@ -90,7 +90,7 @@ class RecommendationRunServiceTest {
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
-        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+        given(fingerprintGenerator.generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
                 .willReturn(FINGERPRINT);
         given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                 SELECTED_POSITION_ID,
@@ -108,7 +108,7 @@ class RecommendationRunServiceTest {
         inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
         inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
         inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
-        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(fingerprintGenerator).generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
         inOrder.verify(recommendationRunRepository)
                 .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                         SELECTED_POSITION_ID,
@@ -130,7 +130,7 @@ class RecommendationRunServiceTest {
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
-        given(fingerprintGenerator.generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
+        given(fingerprintGenerator.generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K))
                 .willReturn(FINGERPRINT);
         given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                 SELECTED_POSITION_ID,
@@ -155,7 +155,7 @@ class RecommendationRunServiceTest {
         inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
         inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
         inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
-        inOrder.verify(fingerprintGenerator).generate(proposal, selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        inOrder.verify(fingerprintGenerator).generate(selectedPosition, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
         inOrder.verify(recommendationRunRepository)
                 .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
                         SELECTED_POSITION_ID,


### PR DESCRIPTION
## 🔎 What

- run의 fingerprint를 추천 시스템에서 사용하는 필드들로 교체하였습니다.
- 기존 fingerprint는 추천 로직이 확정되지 않은 상태였기에, 확장성 있도록 많은 필드들을 포함하도록 했습니다.
- 하지만, 추천 시스템은 proposalPosition에 resume를 추천해주는 구조이기에, proposal 정보는 필요치 않다고 판단하여 수정하게 되었습니다.
- 또한, proposalPosition 중 후보풀 구성 / 스코어링 등에 사용되는 필드들만 fingerprint에 남겨 좀 더 엄밀한 캐싱이 가능하도록 변경했습니다.

## 🔗 Issue

- Closes: #46 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?