### PR TITLE
[Feat] AI 브리프를 proposal_position 새 모델에 맞게 개편

### DIFF
--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefPositionResult.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.dto.proposal;
 
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,30 +10,51 @@ import org.springframework.util.Assert;
 @Getter
 public class AiBriefPositionResult {
 
-    private final String positionName;
+    private final String positionCategoryName;
+    private final String title;
+    private final ProposalWorkType workType;
     private final Long headCount;
     private final Long unitBudgetMin;
     private final Long unitBudgetMax;
+    private final Long expectedPeriod;
+    private final Integer careerMinYears;
+    private final Integer careerMaxYears;
+    private final String workPlace;
     private final List<AiBriefSkillResult> skills;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private AiBriefPositionResult(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
-            List<AiBriefSkillResult> skills) {
-        Assert.hasText(positionName, "AI 브리프 직무명은 필수값입니다.");
-        this.positionName = positionName.trim();
+    private AiBriefPositionResult(String positionCategoryName, String title, ProposalWorkType workType, Long headCount,
+            Long unitBudgetMin, Long unitBudgetMax, Long expectedPeriod, Integer careerMinYears,
+            Integer careerMaxYears, String workPlace, List<AiBriefSkillResult> skills) {
+        Assert.hasText(positionCategoryName, "AI 브리프 포지션 카테고리는 필수값입니다.");
+        Assert.hasText(title, "AI 브리프 포지션 제목은 필수값입니다.");
+        this.positionCategoryName = positionCategoryName.trim();
+        this.title = title.trim();
+        this.workType = workType;
         this.headCount = headCount;
         this.unitBudgetMin = unitBudgetMin;
         this.unitBudgetMax = unitBudgetMax;
+        this.expectedPeriod = expectedPeriod;
+        this.careerMinYears = careerMinYears;
+        this.careerMaxYears = careerMaxYears;
+        this.workPlace = workPlace;
         this.skills = skills == null ? List.of() : List.copyOf(skills);
     }
 
-    public static AiBriefPositionResult of(String positionName, Long headCount, Long unitBudgetMin, Long unitBudgetMax,
-            List<AiBriefSkillResult> skills) {
+    public static AiBriefPositionResult of(String positionCategoryName, String title, ProposalWorkType workType,
+            Long headCount, Long unitBudgetMin, Long unitBudgetMax, Long expectedPeriod, Integer careerMinYears,
+            Integer careerMaxYears, String workPlace, List<AiBriefSkillResult> skills) {
         return AiBriefPositionResult.builder()
-                .positionName(positionName)
+                .positionCategoryName(positionCategoryName)
+                .title(title)
+                .workType(workType)
                 .headCount(headCount)
                 .unitBudgetMin(unitBudgetMin)
                 .unitBudgetMax(unitBudgetMax)
+                .expectedPeriod(expectedPeriod)
+                .careerMinYears(careerMinYears)
+                .careerMaxYears(careerMaxYears)
+                .workPlace(workPlace)
                 .skills(skills)
                 .build();
     }

--- a/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiBriefResult.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.dto.proposal;
 
-import com.generic4.itda.domain.proposal.ProposalWorkType;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,35 +12,27 @@ public class AiBriefResult {
     private final String description;
     private final Long totalBudgetMin;
     private final Long totalBudgetMax;
-    private final ProposalWorkType workType;
-    private final String workPlace;
     private final Long expectedPeriod;
     private final List<AiBriefPositionResult> positions;
 
     @Builder(access = AccessLevel.PRIVATE)
     private AiBriefResult(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
-            ProposalWorkType workType, String workPlace, Long expectedPeriod,
-            List<AiBriefPositionResult> positions) {
+            Long expectedPeriod, List<AiBriefPositionResult> positions) {
         this.title = title;
         this.description = description;
         this.totalBudgetMin = totalBudgetMin;
         this.totalBudgetMax = totalBudgetMax;
-        this.workType = workType;
-        this.workPlace = workPlace;
         this.expectedPeriod = expectedPeriod;
         this.positions = positions == null ? List.of() : List.copyOf(positions);
     }
 
     public static AiBriefResult of(String title, String description, Long totalBudgetMin, Long totalBudgetMax,
-            ProposalWorkType workType, String workPlace, Long expectedPeriod,
-            List<AiBriefPositionResult> positions) {
+            Long expectedPeriod, List<AiBriefPositionResult> positions) {
         return AiBriefResult.builder()
                 .title(title)
                 .description(description)
                 .totalBudgetMin(totalBudgetMin)
                 .totalBudgetMax(totalBudgetMax)
-                .workType(workType)
-                .workPlace(workPlace)
                 .expectedPeriod(expectedPeriod)
                 .positions(positions)
                 .build();

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -50,18 +50,18 @@ public class AiBriefProposalMapper {
         }
 
         for (AiBriefPositionResult positionResult : positions) {
-            Position position = findOrCreatePosition(positionResult.getPositionName());
+            Position position = findOrCreatePosition(positionResult.getPositionCategoryName());
             ProposalPosition proposalPosition = proposal.addPosition(
                     position,
-                    positionResult.getPositionName(),
-                    null,
+                    positionResult.getTitle(),
+                    positionResult.getWorkType(),
                     positionResult.getHeadCount(),
                     positionResult.getUnitBudgetMin(),
                     positionResult.getUnitBudgetMax(),
-                    null,
-                    null,
-                    null,
-                    null
+                    positionResult.getExpectedPeriod(),
+                    positionResult.getCareerMinYears(),
+                    positionResult.getCareerMaxYears(),
+                    positionResult.getWorkPlace()
             );
             addSkills(proposalPosition, positionResult.getSkills());
         }
@@ -74,9 +74,9 @@ public class AiBriefProposalMapper {
         }
     }
 
-    private Position findOrCreatePosition(String positionName) {
-        return positionRepository.findByName(positionName)
-                .orElseGet(() -> positionRepository.save(Position.create(positionName)));
+    private Position findOrCreatePosition(String positionCategoryName) {
+        return positionRepository.findByName(positionCategoryName)
+                .orElseGet(() -> positionRepository.save(Position.create(positionCategoryName)));
     }
 
     private Skill findOrCreateSkill(String skillName) {

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -36,13 +36,17 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - 반드시 JSON만 반환한다.
             - title, description은 한국어로 자연스럽게 작성한다.
             - 근거가 부족한 값은 추측하지 말고 null로 반환한다.
-            - workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
             - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
             - expectedPeriod는 주 단위 기준 정수로 반환한다.
-            - positions는 직무명별로 나누고 같은 직무를 중복 생성하지 않는다.
+            - positions는 실제 모집 단위 배열이다.
+            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 프론트엔드 개발자, 앱 개발자
+            - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Node.js 백엔드 개발자, React Native 앱 개발자
+            - position별 workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
+            - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
+            - 동일한 title을 불필요하게 중복 생성하지 않는다.
             - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
             - importance를 확신할 수 없으면 PREFERENCE를 사용한다.
-            - skillName, positionName은 짧고 일반적인 명칭으로 정리한다.
+            - skillName은 짧고 일반적인 명칭으로 정리한다.
             """;
 
     private final RestClient restClient;
@@ -115,8 +119,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 "description",
                 "totalBudgetMin",
                 "totalBudgetMax",
-                "workType",
-                "workPlace",
                 "expectedPeriod",
                 "positions"
         ));
@@ -125,8 +127,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 "description", nullableStringSchema(),
                 "totalBudgetMin", nullableIntegerSchema(),
                 "totalBudgetMax", nullableIntegerSchema(),
-                "workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"),
-                "workPlace", nullableStringSchema(),
                 "expectedPeriod", nullableIntegerSchema(),
                 "positions", Map.of(
                         "type", "array",
@@ -139,17 +139,35 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
 
     private Map<String, Object> buildPositionSchema() {
         Map<String, Object> schema = objectSchema();
-        schema.put("required", List.of("positionName", "headCount", "unitBudgetMin", "unitBudgetMax", "skills"));
-        schema.put("properties", Map.of(
-                "positionName", Map.of("type", "string"),
-                "headCount", nullableIntegerSchema(),
-                "unitBudgetMin", nullableIntegerSchema(),
-                "unitBudgetMax", nullableIntegerSchema(),
-                "skills", Map.of(
-                        "type", "array",
-                        "items", buildSkillSchema()
-                )
+        schema.put("required", List.of(
+                "positionCategoryName",
+                "title",
+                "workType",
+                "headCount",
+                "unitBudgetMin",
+                "unitBudgetMax",
+                "expectedPeriod",
+                "careerMinYears",
+                "careerMaxYears",
+                "workPlace",
+                "skills"
         ));
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("positionCategoryName", Map.of("type", "string"));
+        properties.put("title", Map.of("type", "string"));
+        properties.put("workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"));
+        properties.put("headCount", nullableIntegerSchema());
+        properties.put("unitBudgetMin", nullableIntegerSchema());
+        properties.put("unitBudgetMax", nullableIntegerSchema());
+        properties.put("expectedPeriod", nullableIntegerSchema());
+        properties.put("careerMinYears", nullableIntegerSchema());
+        properties.put("careerMaxYears", nullableIntegerSchema());
+        properties.put("workPlace", nullableStringSchema());
+        properties.put("skills", Map.of(
+                "type", "array",
+                "items", buildSkillSchema()
+        ));
+        schema.put("properties", properties);
         return schema;
     }
 
@@ -246,8 +264,6 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 normalizeText(root.get("description")),
                 asLong(root.get("totalBudgetMin")),
                 asLong(root.get("totalBudgetMax")),
-                parseWorkType(root.get("workType")),
-                normalizeText(root.get("workPlace")),
                 asLong(root.get("expectedPeriod")),
                 parsePositions(root.get("positions"))
         );
@@ -261,10 +277,16 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
         List<AiBriefPositionResult> positions = new ArrayList<>();
         for (JsonNode positionNode : positionsNode) {
             positions.add(AiBriefPositionResult.of(
-                    normalizeRequiredText(positionNode.get("positionName"), "AI 브리프 직무명은 필수값입니다."),
+                    normalizeRequiredText(positionNode.get("positionCategoryName"), "AI 브리프 포지션 카테고리는 필수값입니다."),
+                    normalizeRequiredText(positionNode.get("title"), "AI 브리프 포지션 제목은 필수값입니다."),
+                    parseWorkType(positionNode.get("workType")),
                     asLong(positionNode.get("headCount")),
                     asLong(positionNode.get("unitBudgetMin")),
                     asLong(positionNode.get("unitBudgetMax")),
+                    asLong(positionNode.get("expectedPeriod")),
+                    asInteger(positionNode.get("careerMinYears")),
+                    asInteger(positionNode.get("careerMaxYears")),
+                    normalizeText(positionNode.get("workPlace")),
                     parseSkills(positionNode.get("skills"))
             ));
         }
@@ -326,6 +348,17 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
         } catch (NumberFormatException exception) {
             throw new AiBriefGenerationException("숫자 필드 파싱에 실패했습니다. value=" + value, exception);
         }
+    }
+
+    private Integer asInteger(JsonNode node) {
+        Long value = asLong(node);
+        if (value == null) {
+            return null;
+        }
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new AiBriefGenerationException("정수 범위를 벗어났습니다. value=" + value);
+        }
+        return value.intValue();
     }
 
     private String normalizeRequiredText(JsonNode node, String message) {

--- a/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiBriefControllerTest.java
@@ -52,15 +52,19 @@ class ProposalAiBriefControllerTest {
                 "AI가 만든 설명",
                 3_000_000L,
                 5_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 6L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 1L,
                                 3_000_000L,
                                 4_000_000L,
+                                6L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(
                                         AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL),
                                         AiBriefSkillResult.of("Spring Boot",
@@ -82,8 +86,9 @@ class ProposalAiBriefControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("AI가 만든 제목"))
                 .andExpect(jsonPath("$.description").value("AI가 만든 설명"))
-                .andExpect(jsonPath("$.workType").value("HYBRID"))
-                .andExpect(jsonPath("$.positions[0].positionName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].positionCategoryName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].title").value("Node.js 백엔드 개발자"))
+                .andExpect(jsonPath("$.positions[0].workType").value("HYBRID"))
                 .andExpect(jsonPath("$.positions[0].skills[0].skillName").value("Java"))
                 .andExpect(jsonPath("$.positions[0].skills[0].importance").value("ESSENTIAL"));
 

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -59,15 +59,19 @@ class AiBriefProposalMapperTest {
                 "AI가 정리한 설명",
                 5_000_000L,
                 8_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 12L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 2L,
                                 3_000_000L,
                                 4_000_000L,
+                                12L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(AiBriefSkillResult.of("Java", null))
                         )
                 )
@@ -82,6 +86,12 @@ class AiBriefProposalMapperTest {
         assertThat(proposal.getExpectedPeriod()).isEqualTo(12L);
         assertThat(proposal.getPositions()).hasSize(1);
         assertThat(proposal.getPositions().get(0).getPosition().getName()).isEqualTo("백엔드 개발자");
+        assertThat(proposal.getPositions().get(0).getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(proposal.getPositions().get(0).getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(proposal.getPositions().get(0).getExpectedPeriod()).isEqualTo(12L);
+        assertThat(proposal.getPositions().get(0).getCareerMinYears()).isEqualTo(3);
+        assertThat(proposal.getPositions().get(0).getCareerMaxYears()).isEqualTo(6);
+        assertThat(proposal.getPositions().get(0).getWorkPlace()).isEqualTo("판교");
         assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill().getName()).isEqualTo("Java");
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getImportance())
@@ -97,8 +107,6 @@ class AiBriefProposalMapperTest {
                 "설명만 갱신",
                 null,
                 null,
-                ProposalWorkType.REMOTE,
-                "강남",
                 8L,
                 List.of()
         );
@@ -121,8 +129,6 @@ class AiBriefProposalMapperTest {
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
                 " ",
-                null,
-                null,
                 null,
                 null,
                 null,
@@ -160,12 +166,16 @@ class AiBriefProposalMapperTest {
                 null,
                 null,
                 null,
-                null,
-                null,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
                                 1L,
+                                null,
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 List.of(AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL))
@@ -191,8 +201,6 @@ class AiBriefProposalMapperTest {
                 "기존 설명",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 3L
         );
     }

--- a/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
@@ -70,19 +70,23 @@ class OpenAiAiBriefGeneratorTest {
                 "description", "백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.",
                 "totalBudgetMin", 5000000,
                 "totalBudgetMax", 8000000,
-                "workType", "HYBRID",
-                "workPlace", "판교",
                 "expectedPeriod", 6,
                 "positions", List.of(
-                        Map.of(
-                                "positionName", "백엔드 개발자",
-                                "headCount", 1,
-                                "unitBudgetMin", 3000000,
-                                "unitBudgetMax", 4000000,
-                                "skills", List.of(
+                        Map.ofEntries(
+                                Map.entry("positionCategoryName", "백엔드 개발자"),
+                                Map.entry("title", "Node.js 백엔드 개발자"),
+                                Map.entry("workType", "HYBRID"),
+                                Map.entry("headCount", 1),
+                                Map.entry("unitBudgetMin", 3000000),
+                                Map.entry("unitBudgetMax", 4000000),
+                                Map.entry("expectedPeriod", 6),
+                                Map.entry("careerMinYears", 3),
+                                Map.entry("careerMaxYears", 6),
+                                Map.entry("workPlace", "판교"),
+                                Map.entry("skills", List.of(
                                         Map.of("skillName", "Java", "importance", "ESSENTIAL"),
                                         Map.of("skillName", "Spring Boot", "importance", "PREFERENCE")
-                                )
+                                ))
                         )
                 )
         ));
@@ -101,14 +105,25 @@ class OpenAiAiBriefGeneratorTest {
                         "description",
                         "totalBudgetMin",
                         "totalBudgetMax",
-                        "workType",
-                        "workPlace",
                         "expectedPeriod",
                         "positions"
                 )))
                 .andExpect(jsonPath("$.text.format.schema.properties.title.type[*]").value(containsInAnyOrder(
                         "string",
                         "null"
+                )))
+                .andExpect(jsonPath("$.text.format.schema.properties.positions.items.required[*]").value(containsInAnyOrder(
+                        "positionCategoryName",
+                        "title",
+                        "workType",
+                        "headCount",
+                        "unitBudgetMin",
+                        "unitBudgetMax",
+                        "expectedPeriod",
+                        "careerMinYears",
+                        "careerMaxYears",
+                        "workPlace",
+                        "skills"
                 )))
                 .andExpect(jsonPath("$.text.format.schema.properties.positions.items.properties.skills.items.required[*]")
                         .value(containsInAnyOrder("skillName", "importance")))
@@ -123,11 +138,15 @@ class OpenAiAiBriefGeneratorTest {
         assertThat(result.getDescription()).isEqualTo("백엔드와 프론트엔드 개발자를 찾는 프로젝트입니다.");
         assertThat(result.getTotalBudgetMin()).isEqualTo(5_000_000L);
         assertThat(result.getTotalBudgetMax()).isEqualTo(8_000_000L);
-        assertThat(result.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
-        assertThat(result.getWorkPlace()).isEqualTo("판교");
         assertThat(result.getExpectedPeriod()).isEqualTo(6L);
         assertThat(result.getPositions()).hasSize(1);
-        assertThat(result.getPositions().get(0).getPositionName()).isEqualTo("백엔드 개발자");
+        assertThat(result.getPositions().get(0).getPositionCategoryName()).isEqualTo("백엔드 개발자");
+        assertThat(result.getPositions().get(0).getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(result.getPositions().get(0).getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(result.getPositions().get(0).getExpectedPeriod()).isEqualTo(6L);
+        assertThat(result.getPositions().get(0).getCareerMinYears()).isEqualTo(3);
+        assertThat(result.getPositions().get(0).getCareerMaxYears()).isEqualTo(6);
+        assertThat(result.getPositions().get(0).getWorkPlace()).isEqualTo("판교");
         assertThat(result.getPositions().get(0).getSkills()).hasSize(2);
         assertThat(result.getPositions().get(0).getSkills().get(0).getSkillName()).isEqualTo("Java");
         assertThat(result.getPositions().get(0).getSkills().get(0).getImportance())
@@ -155,8 +174,21 @@ class OpenAiAiBriefGeneratorTest {
         String briefJson = objectMapper.writeValueAsString(Map.of(
                 "title", "제목",
                 "description", "설명",
-                "workType", "OFFICE",
-                "positions", List.of()
+                "positions", List.of(
+                        Map.ofEntries(
+                                Map.entry("positionCategoryName", "백엔드 개발자"),
+                                Map.entry("title", "백엔드 개발자"),
+                                Map.entry("workType", "OFFICE"),
+                                Map.entry("headCount", 1),
+                                Map.entry("unitBudgetMin", 1000000),
+                                Map.entry("unitBudgetMax", 2000000),
+                                Map.entry("expectedPeriod", 4),
+                                Map.entry("careerMinYears", 1),
+                                Map.entry("careerMaxYears", 3),
+                                Map.entry("workPlace", "판교"),
+                                Map.entry("skills", List.of())
+                        )
+                )
         ));
 
         server.expect(requestTo(API_URL))

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceIntegrationTest.java
@@ -76,8 +76,6 @@ class ProposalAiBriefServiceIntegrationTest {
                 "기존 설명",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 4L
         );
         ProposalPosition existingPosition = proposal.addPosition(oldPosition, 1L, 500_000L, 700_000L);
@@ -89,15 +87,19 @@ class ProposalAiBriefServiceIntegrationTest {
                 "웹 서비스 개발 외주입니다. 백엔드 개발자 1명과 프론트엔드 개발자 1명을 12주 동안 채용합니다.",
                 8_000_000L,
                 8_000_000L,
-                ProposalWorkType.HYBRID,
-                "판교",
                 12L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
+                                "Node.js 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
                                 1L,
                                 null,
                                 null,
+                                12L,
+                                3,
+                                6,
+                                "판교",
                                 List.of(
                                         AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL),
                                         AiBriefSkillResult.of("Spring Boot",
@@ -106,8 +108,14 @@ class ProposalAiBriefServiceIntegrationTest {
                         ),
                         AiBriefPositionResult.of(
                                 "프론트엔드 개발자",
+                                "React 프론트엔드 개발자",
+                                ProposalWorkType.REMOTE,
                                 1L,
                                 null,
+                                null,
+                                10L,
+                                null,
+                                4,
                                 null,
                                 List.of(AiBriefSkillResult.of("React", null))
                         )
@@ -140,6 +148,12 @@ class ProposalAiBriefServiceIntegrationTest {
 
         ProposalPosition backendPosition = positionsByName.get("백엔드 개발자");
         assertThat(backendPosition).isNotNull();
+        assertThat(backendPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(backendPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(backendPosition.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(backendPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(backendPosition.getCareerMaxYears()).isEqualTo(6);
+        assertThat(backendPosition.getWorkPlace()).isEqualTo("판교");
         assertThat(backendPosition.getHeadCount()).isEqualTo(1L);
         assertThat(backendPosition.getSkills())
                 .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())
@@ -150,6 +164,12 @@ class ProposalAiBriefServiceIntegrationTest {
 
         ProposalPosition frontendPosition = positionsByName.get("프론트엔드 개발자");
         assertThat(frontendPosition).isNotNull();
+        assertThat(frontendPosition.getTitle()).isEqualTo("React 프론트엔드 개발자");
+        assertThat(frontendPosition.getWorkType()).isEqualTo(ProposalWorkType.REMOTE);
+        assertThat(frontendPosition.getExpectedPeriod()).isEqualTo(10L);
+        assertThat(frontendPosition.getCareerMinYears()).isNull();
+        assertThat(frontendPosition.getCareerMaxYears()).isEqualTo(4);
+        assertThat(frontendPosition.getWorkPlace()).isNull();
         assertThat(frontendPosition.getHeadCount()).isEqualTo(1L);
         assertThat(frontendPosition.getSkills())
                 .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
@@ -55,8 +55,6 @@ class ProposalAiBriefServiceTest {
                 "AI가 만든 설명",
                 3_000_000L,
                 5_000_000L,
-                ProposalWorkType.REMOTE,
-                "판교",
                 6L,
                 null
         );
@@ -142,8 +140,6 @@ class ProposalAiBriefServiceTest {
                 "제안서 본문",
                 1_000_000L,
                 2_000_000L,
-                ProposalWorkType.SITE,
-                "서울",
                 3L
         );
     }


### PR DESCRIPTION
## 🔎 What

- OpenAI AI 브리프 프롬프트 수정
- OpenAI structured output schema를 새 proposal_position 모델에 맞게 수정
- `AiBriefResult` DTO 재설계
- `AiBriefPositionResult` DTO 재설계
- 포지션 결과에 `category`, `title`, `workType`, `workPlace`, `expectedPeriod`, `career range`, `budget`, `skills` 반영
- `AiBriefProposalMapper` 수정
- position master 조회와 proposal_position title 저장 로직 분리
- proposal-level `workType`, `workPlace` 의존 제거
- AI 브리프 관련 서비스 테스트 수정
- AI 브리프 관련 컨트롤러/통합 테스트 수정

## 🔗 Issue

- Closes: #59 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?