### PR TITLE
[Feat] 프리랜서 대시보드 포지션 라벨을 position.name → proposalPosition.title로 교체

### DIFF
--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.generic4.itda.repository;
 import com.generic4.itda.domain.matching.QMatching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.QMember;
-import com.generic4.itda.domain.position.QPosition;
 import com.generic4.itda.domain.proposal.QProposal;
 import com.generic4.itda.domain.proposal.QProposalPosition;
 import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
@@ -22,7 +21,6 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
     private final QMatching matching = QMatching.matching;
     private final QProposalPosition proposalPosition = QProposalPosition.proposalPosition;
     private final QProposal proposal = QProposal.proposal;
-    private final QPosition position = QPosition.position;
     private final QMember clientMember = new QMember("clientMember");
 
     @Override
@@ -32,7 +30,7 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                         proposal.id,
                         proposal.title,
                         clientMember.nickname,
-                        position.name,
+                        proposalPosition.title,
                         matching.status, // 여기서 MatchingStatus를 가져옴
                         proposalPosition.unitBudgetMin,
                         proposalPosition.unitBudgetMax,
@@ -42,7 +40,6 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .join(matching.proposalPosition, proposalPosition)
                 .join(proposalPosition.proposal, proposal)
                 .join(matching.clientMember, clientMember)
-                .join(proposalPosition.position, position)
                 .where(
                         matching.freelancerMember.email.value.eq(email),
                         statusEq(status),


### PR DESCRIPTION
## 🔎 What

프리랜서 대시보드 화면에서 포지션 라벨을 position.name 대신 proposalPosition.title로 교체했습니다.

FreelancerDashboardService는 해당 쿼리 결과를 그대로 전달하는 구조라 별도 수정은 없습니다.

현재 제안 데이터가 없어 대시보드 화면에서 직접 확인이 불가한 상태입니다. 
이후 제안 데이터가 구성되면 추가 검증 예정이며, 문제 발생 시 대응하겠습니다.

## 🔗 Issue

- Closes: #58 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?