### PR TITLE
[Feat] RecommendationCandidateFinder 후보 풀 구성 정책 반영

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
@@ -1,11 +1,19 @@
 package com.generic4.itda.repository;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import java.util.List;
 
 public interface ResumeQueryRepository {
 
-    List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize);
+    List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            int candidatePoolSize
+    );
 
-    List<Long> findRecommendableResumeIds(int candidatePoolSize);
+    List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            int candidatePoolSize
+    );
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.generic4.itda.repository;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.QResume;
 import com.generic4.itda.domain.resume.QResumeSkill;
 import com.generic4.itda.domain.resume.ResumeStatus;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,7 +28,11 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     private static final QResumeSkill resumeSkill = QResumeSkill.resumeSkill;
 
     @Override
-    public List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize) {
+    public List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            int candidatePoolSize
+    ) {
         NumberExpression<Integer> proficiencySquaredSum = new CaseBuilder()
                 .when(resumeSkill.proficiency.eq(Proficiency.BEGINNER)).then(1)
                 .when(resumeSkill.proficiency.eq(Proficiency.INTERMEDIATE)).then(4)
@@ -45,10 +53,8 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .from(resume)
                 .join(resume.skills, resumeSkill)
                 .where(
-                        resume.status.eq(ResumeStatus.ACTIVE),
-                        resume.publiclyVisible.isTrue(),
-                        resume.aiMatchingEnabled.isTrue(),
-                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
+                        recommendable(),
+                        workTypeMatches(proposalPosition),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -63,15 +69,16 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     }
 
     @Override
-    public List<Long> findRecommendableResumeIds(int candidatePoolSize) {
+    public List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            int candidatePoolSize
+    ) {
         return queryFactory
                 .select(resume.id)
                 .from(resume)
                 .where(
-                        resume.status.eq(ResumeStatus.ACTIVE),
-                        resume.publiclyVisible.isTrue(),
-                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
-                        resume.aiMatchingEnabled.isTrue()
+                        recommendable(),
+                        workTypeMatches(proposalPosition)
                 )
                 .orderBy(
                         resume.careerYears.desc(),
@@ -79,5 +86,26 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 )
                 .limit(candidatePoolSize)
                 .fetch();
+    }
+
+    private BooleanExpression recommendable() {
+        return resume.status.eq(ResumeStatus.ACTIVE)
+                .and(resume.publiclyVisible.isTrue())
+                .and(resume.aiMatchingEnabled.isTrue())
+                .and(resume.writingStatus.eq(ResumeWritingStatus.DONE));
+    }
+
+    private BooleanExpression workTypeMatches(ProposalPosition proposalPosition) {
+        ProposalWorkType workType = proposalPosition.getWorkType();
+
+        if (workType == null) {
+            return null;
+        }
+
+        return switch (workType) {
+            case SITE -> resume.preferredWorkType.in(WorkType.SITE, WorkType.HYBRID);
+            case REMOTE -> resume.preferredWorkType.in(WorkType.REMOTE, WorkType.HYBRID);
+            case HYBRID -> resume.preferredWorkType.eq(WorkType.HYBRID);
+        };
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -52,7 +52,7 @@ public class RecommendationCandidateFinder {
         return candidateResumeIds.stream()
                 .map(resumeMap::get)
                 .filter(Objects::nonNull)
-                .filter(resume -> passesCareerRage(resume, proposalPosition))
+                .filter(resume -> passesCareerRange(resume, proposalPosition))
                 .map(this::toCandidate)
                 .toList();
     }
@@ -68,7 +68,7 @@ public class RecommendationCandidateFinder {
         return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
     }
 
-    private boolean passesCareerRage(Resume resume, ProposalPosition proposalPosition) {
+    private boolean passesCareerRange(Resume resume, ProposalPosition proposalPosition) {
         Integer candidateCareerYears = Integer.valueOf(resume.getCareerYears());
         Integer careerMinYears = proposalPosition.getCareerMinYears();
         Integer careerMaxYears = proposalPosition.getCareerMaxYears();

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -1,7 +1,7 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
-import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.repository.ResumeQueryRepository;
 import com.generic4.itda.repository.ResumeRepository;
@@ -24,9 +24,9 @@ public class RecommendationCandidateFinder {
     private final ResumeQueryRepository resumeQueryRepository;
     private final ResumeRepository resumeRepository;
 
-    public List<RecommendationCandidate> findCandidates(RecommendationRun run) {
-        List<Long> requiredSkillIds = extractRequiredSkillIds(run);
-        int candidatePoolSize = resolveCandidatePoolSize(run.getTopK());
+    public List<RecommendationCandidate> findCandidates(ProposalPosition proposalPosition, int topK) {
+        List<Long> requiredSkillIds = extractRequiredSkillIds(proposalPosition);
+        int candidatePoolSize = resolveCandidatePoolSize(topK);
 
         List<Long> candidateResumeIds;
         if (requiredSkillIds.isEmpty()) {
@@ -52,8 +52,8 @@ public class RecommendationCandidateFinder {
                 .toList();
     }
 
-    private List<Long> extractRequiredSkillIds(RecommendationRun run) {
-        return run.getProposalPosition().getSkills().stream()
+    private List<Long> extractRequiredSkillIds(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
                 .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
                 .map(pps -> pps.getSkill().getId())
                 .toList();

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -30,9 +30,13 @@ public class RecommendationCandidateFinder {
 
         List<Long> candidateResumeIds;
         if (requiredSkillIds.isEmpty()) {
-            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(candidatePoolSize);
+            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(proposalPosition, candidatePoolSize);
         } else {
-            candidateResumeIds = resumeQueryRepository.findCandidatePool(requiredSkillIds, candidatePoolSize).stream()
+            candidateResumeIds = resumeQueryRepository.findCandidatePool(
+                            proposalPosition,
+                            requiredSkillIds,
+                            candidatePoolSize
+                    ).stream()
                     .map(CandidatePoolRow::resumeId)
                     .toList();
         }
@@ -48,6 +52,7 @@ public class RecommendationCandidateFinder {
         return candidateResumeIds.stream()
                 .map(resumeMap::get)
                 .filter(Objects::nonNull)
+                .filter(resume -> passesCareerRage(resume, proposalPosition))
                 .map(this::toCandidate)
                 .toList();
     }
@@ -61,6 +66,22 @@ public class RecommendationCandidateFinder {
 
     private int resolveCandidatePoolSize(int topK) {
         return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
+    }
+
+    private boolean passesCareerRage(Resume resume, ProposalPosition proposalPosition) {
+        Integer candidateCareerYears = Integer.valueOf(resume.getCareerYears());
+        Integer careerMinYears = proposalPosition.getCareerMinYears();
+        Integer careerMaxYears = proposalPosition.getCareerMaxYears();
+
+        if (careerMinYears != null && candidateCareerYears < careerMinYears) {
+            return false;
+        }
+
+        if (careerMaxYears != null && candidateCareerYears > careerMaxYears) {
+            return false;
+        }
+
+        return true;
     }
 
     private RecommendationCandidate toCandidate(Resume resume) {

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -2,7 +2,12 @@ package com.generic4.itda.repository;
 
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.resume.CareerPayload;
@@ -13,8 +18,12 @@ import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -70,7 +79,9 @@ class ResumeQueryRepositoryTest {
                 skill(aws, Proficiency.ADVANCED));
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 10
         );
@@ -110,7 +121,9 @@ class ResumeQueryRepositoryTest {
                 skill(java, Proficiency.ADVANCED));
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 2
         );
@@ -137,7 +150,7 @@ class ResumeQueryRepositoryTest {
         saveResume("recommend-inactive", (byte) 99, true, true, false);
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 10);
 
         // then
         assertThat(result).containsExactly(
@@ -176,7 +189,9 @@ class ResumeQueryRepositoryTest {
         );
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 10
         );
@@ -184,6 +199,56 @@ class ResumeQueryRepositoryTest {
         // then
         assertThat(result).extracting(CandidatePoolRow::resumeId)
                 .containsExactly(doneResume.getId());
+    }
+
+    @DisplayName("findCandidatePool은 근무 형태 정책 조합에 따라 후보를 필터링한다")
+    @ParameterizedTest(name = "proposalWorkType={0}")
+    @MethodSource("workTypePolicyCases")
+    void findCandidatePool_filtersByProposalWorkTypePolicies(
+            ProposalWorkType proposalWorkType,
+            List<WorkType> expectedWorkTypes
+    ) {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-work-type", null));
+
+        Resume remote = saveResume(
+                "pool-work-type-remote",
+                (byte) 4,
+                true,
+                true,
+                true,
+                WorkType.REMOTE,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+        Resume hybrid = saveResume(
+                "pool-work-type-hybrid",
+                (byte) 5,
+                true,
+                true,
+                true,
+                WorkType.HYBRID,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+        Resume site = saveResume(
+                "pool-work-type-site",
+                (byte) 20,
+                true,
+                true,
+                true,
+                WorkType.SITE,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                createProposalPosition(proposalWorkType),
+                List.of(java.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactlyElementsOf(expectedResumeIds(expectedWorkTypes, site, hybrid, remote));
     }
 
     @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
@@ -196,7 +261,7 @@ class ResumeQueryRepositoryTest {
         saveResume("recommend-limit-4", (byte) 1, true, true, true);
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(2);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 2);
 
         // then
         assertThat(result).hasSize(2);
@@ -228,10 +293,53 @@ class ResumeQueryRepositoryTest {
         );
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 10);
 
         // then
         assertThat(result).containsExactly(doneResume.getId());
+    }
+
+    @DisplayName("findRecommendableResumeIds는 fallback 조회 경로에서도 근무 형태 정책 조합을 적용한다")
+    @ParameterizedTest(name = "proposalWorkType={0}")
+    @MethodSource("workTypePolicyCases")
+    void findRecommendableResumeIds_filtersByProposalWorkTypePolicies(
+            ProposalWorkType proposalWorkType,
+            List<WorkType> expectedWorkTypes
+    ) {
+        // given
+        Resume remote = saveResume("recommend-remote", (byte) 4, true, true, true, WorkType.REMOTE);
+        Resume hybrid = saveResume("recommend-hybrid", (byte) 5, true, true, true, WorkType.HYBRID);
+        Resume site = saveResume("recommend-site", (byte) 6, true, true, true, WorkType.SITE);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(
+                createProposalPosition(proposalWorkType),
+                10
+        );
+
+        // then
+        assertThat(result).containsExactlyElementsOf(expectedResumeIds(expectedWorkTypes, site, hybrid, remote));
+    }
+
+    private static Stream<Arguments> workTypePolicyCases() {
+        return Stream.of(
+                arguments(null, List.of(WorkType.SITE, WorkType.HYBRID, WorkType.REMOTE)),
+                arguments(ProposalWorkType.SITE, List.of(WorkType.SITE, WorkType.HYBRID)),
+                arguments(ProposalWorkType.REMOTE, List.of(WorkType.HYBRID, WorkType.REMOTE)),
+                arguments(ProposalWorkType.HYBRID, List.of(WorkType.HYBRID))
+        );
+    }
+
+    private List<Long> expectedResumeIds(
+            List<WorkType> expectedWorkTypes,
+            Resume site,
+            Resume hybrid,
+            Resume remote
+    ) {
+        return Stream.of(site, hybrid, remote)
+                .filter(resume -> expectedWorkTypes.contains(resume.getPreferredWorkType()))
+                .map(Resume::getId)
+                .toList();
     }
 
     private Resume saveResume(
@@ -248,6 +356,7 @@ class ResumeQueryRepositoryTest {
                 publiclyVisible,
                 aiMatchingEnabled,
                 active,
+                WorkType.REMOTE,
                 ResumeWritingStatus.DONE,
                 skills
         );
@@ -259,6 +368,49 @@ class ResumeQueryRepositoryTest {
             boolean publiclyVisible,
             boolean aiMatchingEnabled,
             boolean active,
+            WorkType preferredWorkType,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                preferredWorkType,
+                ResumeWritingStatus.DONE,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            ResumeWritingStatus writingStatus,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                WorkType.REMOTE,
+                writingStatus,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            WorkType preferredWorkType,
             ResumeWritingStatus writingStatus,
             SkillAssignment... skills
     ) {
@@ -276,7 +428,7 @@ class ResumeQueryRepositoryTest {
                 "소개-" + suffix,
                 careerYears,
                 new CareerPayload(),
-                WorkType.REMOTE,
+                preferredWorkType,
                 writingStatus,
                 null
         );
@@ -299,6 +451,32 @@ class ResumeQueryRepositoryTest {
 
     private static SkillAssignment skill(Skill skill, Proficiency proficiency) {
         return new SkillAssignment(skill, proficiency);
+    }
+
+    private ProposalPosition createProposalPosition(ProposalWorkType workType) {
+        Proposal proposal = Proposal.create(
+                createMember(),
+                "추천 요청",
+                "raw-input",
+                null,
+                null,
+                null,
+                null
+        );
+
+        String workPlace = workType == ProposalWorkType.REMOTE ? null : "서울";
+        return proposal.addPosition(
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                workType,
+                1L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                workPlace
+        );
     }
 
     private record SkillAssignment(Skill skill, Proficiency proficiency) {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -11,6 +11,7 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
@@ -50,7 +51,7 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findRecommendableResumeIds(100)).willReturn(List.of(11L, 22L));
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L));
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
 
         // when
@@ -62,7 +63,7 @@ class RecommendationCandidateFinderTest {
         assertThat(result.get(0).skills()).extracting(RecommendationCandidate.CandidateSkill::skillName)
                 .containsExactly("Java");
 
-        verify(resumeQueryRepository).findRecommendableResumeIds(100);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -78,7 +79,7 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 9, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 4, skillData(101L, "Java", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findCandidatePool(List.of(101L), 120)).willReturn(List.of(
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 120)).willReturn(List.of(
                 new CandidatePoolRow(22L, 1L, 4, (byte) 4),
                 new CandidatePoolRow(11L, 1L, 9, (byte) 9)
         ));
@@ -91,7 +92,7 @@ class RecommendationCandidateFinderTest {
         assertThat(result).extracting(RecommendationCandidate::resumeId)
                 .containsExactly(22L, 11L);
 
-        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 120);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 120);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -103,19 +104,59 @@ class RecommendationCandidateFinderTest {
         ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
         );
-        given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 100)).willReturn(List.of());
 
         // when
         List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 5);
 
         // then
         assertThat(result).isEmpty();
-        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 100);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 100);
         verifyNoInteractions(resumeRepository);
         verifyNoMoreInteractions(resumeQueryRepository);
     }
 
+    @DisplayName("후보 이력서가 경력 범위를 벗어나면 최종 후보에서 제외한다")
+    @Test
+    void findCandidates_filtersResumesOutsideCareerRange() {
+        // given
+        ProposalPosition proposalPosition = createProposalPosition(
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                3,
+                7,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume inRange = createResume(11L, (byte) 5, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume belowRange = createResume(22L, (byte) 2, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+        Resume aboveRange = createResume(33L, (byte) 9, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L, 33L));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L, 33L)))
+                .willReturn(List.of(aboveRange, inRange, belowRange));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L, 33L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
     private ProposalPosition createProposalPosition(SkillRequirement... requirements) {
+        return createProposalPosition("백엔드", null, null, null, requirements);
+    }
+
+    private ProposalPosition createProposalPosition(
+            String title,
+            ProposalWorkType workType,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            SkillRequirement... requirements
+    ) {
         Proposal proposal = Proposal.create(
                 createMember(),
                 "추천 요청",
@@ -123,11 +164,20 @@ class RecommendationCandidateFinderTest {
                 null,
                 null,
                 null,
-                null,
-                null,
                 null
         );
-        ProposalPosition proposalPosition = proposal.addPosition(Position.create("백엔드"), 1L, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                Position.create(title),
+                title,
+                workType,
+                1L,
+                null,
+                null,
+                null,
+                careerMinYears,
+                careerMaxYears,
+                workType == ProposalWorkType.REMOTE || workType == null ? null : "서울"
+        );
 
         for (SkillRequirement requirement : requirements) {
             Skill skill = Skill.create(requirement.name(), null);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -11,8 +11,6 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
-import com.generic4.itda.domain.recommendation.RecommendationRun;
-import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
@@ -46,8 +44,7 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_usesRecommendablePoolWhenNoEssentialSkills() {
         // given
-        RecommendationRun run = createRun(
-                3,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(201L, "Communication", ProposalPositionSkillImportance.PREFERENCE)
         );
         Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
@@ -57,7 +54,7 @@ class RecommendationCandidateFinderTest {
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3);
 
         // then
         assertThat(result).extracting(RecommendationCandidate::resumeId)
@@ -74,8 +71,7 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_usesEssentialSkillsAndExpandedPoolSize() {
         // given
-        RecommendationRun run = createRun(
-                6,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL),
                 skillRequirement(202L, "React", ProposalPositionSkillImportance.PREFERENCE)
         );
@@ -89,7 +85,7 @@ class RecommendationCandidateFinderTest {
         given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(first, second));
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 6);
 
         // then
         assertThat(result).extracting(RecommendationCandidate::resumeId)
@@ -104,14 +100,13 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_returnsEmptyWhenCandidatePoolIsEmpty() {
         // given
-        RecommendationRun run = createRun(
-                5,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
         );
         given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 5);
 
         // then
         assertThat(result).isEmpty();
@@ -120,7 +115,7 @@ class RecommendationCandidateFinderTest {
         verifyNoMoreInteractions(resumeQueryRepository);
     }
 
-    private RecommendationRun createRun(int topK, SkillRequirement... requirements) {
+    private ProposalPosition createProposalPosition(SkillRequirement... requirements) {
         Proposal proposal = Proposal.create(
                 createMember(),
                 "추천 요청",
@@ -140,12 +135,7 @@ class RecommendationCandidateFinderTest {
             proposalPosition.addSkill(skill, requirement.importance());
         }
 
-        return RecommendationRun.create(
-                proposalPosition,
-                "fingerprint",
-                RecommendationAlgorithm.HEURISTIC_V1,
-                topK
-        );
+        return proposalPosition;
     }
 
     private Resume createResume(long resumeId, byte careerYears, SkillData... skills) {


### PR DESCRIPTION
## 🔎 What

기존 추천 후보 조회 파이프라인에 ProposalPosition 기반 필터링 정책을 반영했습니다.

- 후보 조회 시 ProposalPosition을 직접 사용하도록 Finder / QueryRepository 시그니처를 정리했습니다.
- DB pre-filter 단계에서 근무 형태(workType) 조건을 반영했습니다.
- Finder 단계에서 경력 범위(careerMinYears, careerMaxYears) 기반 hard filter를 추가했습니다.
- 기존 fallback 로직(required skill 없을 경우 전체 후보 조회)은 유지했습니다.

예산(budget) 관련 필터는 Resume 측 데이터 부재로 이번 PR에서는 제외했습니다.

## 🔗 Issue

- Closes: #48 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?