### PR TITLE
[Bug] 신규 회원 이력서 미작성 이탈 후 재진입 시 500 에러

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ResumeController.java
+++ b/src/main/java/com/generic4/itda/controller/ResumeController.java
@@ -41,7 +41,12 @@ public class ResumeController {
 
     @GetMapping("/me")
     public String viewFrom (@AuthenticationPrincipal ItDaPrincipal principal, Model model){
-        Resume resume = resumeService.findByEmail(principal.getEmail());
+        Resume resume;
+        try {
+            resume = resumeService.findByEmail(principal.getEmail());
+        } catch (IllegalStateException ignored) {
+            return "redirect:/resumes/new";
+        }
         ResumeForm form = ResumeForm.from(resume);
 
         addCommonAttributes(model);
@@ -105,7 +110,12 @@ public class ResumeController {
 
     @GetMapping("/edit")
     public String editForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
-        Resume resume = resumeService.findByEmail(principal.getEmail());
+        Resume resume;
+        try {
+            resume = resumeService.findByEmail(principal.getEmail());
+        } catch (IllegalStateException ignored) {
+            return "redirect:/resumes/new";
+        }
         ResumeForm form = ResumeForm.from(resume);
 
         addCommonAttributes(model);

--- a/src/main/resources/templates/freelancer/resumeForm.html
+++ b/src/main/resources/templates/freelancer/resumeForm.html
@@ -135,7 +135,7 @@
 
                         <!-- 뒤로가기 + 구분선 + 프로필 정보 -->
                         <div class="flex items-center gap-4">
-                            <button type="button" onclick="handleBackAction('/freelancers/dashboard')"
+                            <button type="button" th:onclick="${isNew} ? 'handleBackAction(\'/\')' : 'handleBackAction(\'/freelancers/dashboard\')'"
                                     class="flex items-center justify-center w-9 h-9 text-slate-400 rounded-xl hover:bg-slate-100 hover:text-slate-600 transition-all active:scale-95 shrink-0">
                                 <i data-lucide="arrow-left" class="w-5 h-5"></i>
                             </button>


### PR DESCRIPTION
## 🔎 What

 - 신규 이력서 생성 중 뒤로가기 제어 로직 추가 : 이력서 신규 작성 중 이탈 시, 저장되지 않은 상태라면 대시보드가 아닌 메인 페이지로 유도.
 - 강제 리다이렉트: 이력서 관리 또는 대시보드 진입 시, 이력서 데이터가 없으면 **/new (작성 페이지)**로 즉시 이동. 
    ※프리랜서 대시보드 진입시 이력서 검사 로직 이미 있으므로 냅두고 /me, /edit 직접 접근시 이력서 존재여부 검사 하여 없다면 /new로 보내주도록 방어 로직 추가

## 🔗 Issue

- Closes: #68

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?