### PR TITLE
[Bug] 제안서 수정 페이지 접속시 LazyInitializationException 발생 해결

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ProposalRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ProposalRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
@@ -39,4 +40,28 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
             where pp.proposal.id = :proposalId
             """)
     List<ProposalPosition> findPositionsWithSkillsByProposalId(Long proposalId);
+
+    @Query("""
+            select distinct p
+            from Proposal p
+            left join fetch p.positions pp
+            left join fetch pp.position pos
+            where p.member.email.value = :email
+            order by p.modifiedAt desc
+            """)
+    List<Proposal> findAllWithPositionsByMemberEmail(@Param("email") String email);
+
+    @Query("""
+            select distinct p
+            from Proposal p
+            left join fetch p.positions pp
+            left join fetch pp.position pos
+            where p.member.email.value = :email
+            and p.status = :status
+            order by p.modifiedAt desc
+            """)
+    List<Proposal> findAllWithPositionsByMemberEmailAndStatus(
+            @Param("email") String email,
+            @Param("status") ProposalStatus status
+    );
 }

--- a/src/main/java/com/generic4/itda/service/ClientDashboardService.java
+++ b/src/main/java/com/generic4/itda/service/ClientDashboardService.java
@@ -44,10 +44,10 @@ public class ClientDashboardService {
 
     private List<Proposal> loadProjects(String memberEmail, ClientDashboardFilter filter) {
         if (filter.isAll()) {
-            return proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(memberEmail);
+            return proposalRepository.findAllWithPositionsByMemberEmail(memberEmail);
         }
 
-        return proposalRepository.findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(
+        return proposalRepository.findAllWithPositionsByMemberEmailAndStatus(
                 memberEmail,
                 filter.toProposalStatus()
         );

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -16,6 +16,7 @@ import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
+import jakarta.persistence.EntityManager;
 import java.util.EnumSet;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -44,6 +45,7 @@ public class ProposalService {
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
     private final MatchingRepository matchingRepository;
+    private final EntityManager entityManager;
 
     public Proposal saveDraft(String memberEmail, ProposalForm form) {
         Member member = getMemberByEmail(memberEmail);
@@ -129,7 +131,17 @@ public class ProposalService {
 
     @Transactional(readOnly = true)
     public Proposal findOwnedProposal(Long proposalId, String memberEmail) {
-        return getOwnedProposal(proposalId, memberEmail);
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+
+        if (!proposal.getMember().getEmail().getValue().equals(memberEmail)) {
+            throw new AccessDeniedException("본인 제안서만 조회하거나 수정할 수 있습니다.");
+        }
+
+        // ProposalPosition.skills도 1차 캐시에 로드 (LazyInitializationException 방지)
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+
+        return proposal;
     }
 
     public Long calculateTotalBudgetMin(ProposalForm form) {
@@ -145,6 +157,10 @@ public class ProposalService {
         for (ProposalPosition existingPosition : existingPositions) {
             proposal.removePosition(existingPosition);
         }
+
+        // DELETE가 INSERT보다 먼저 실행되도록 강제 flush
+        // (미실행 시 unique constraint 위반 발생)
+        entityManager.flush();
 
         for (ProposalPositionForm positionForm : positionForms) {
             Position position = getPosition(positionForm.getPositionId());

--- a/src/test/java/com/generic4/itda/repository/ProposalRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ProposalRepositoryTest.java
@@ -12,6 +12,7 @@ import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.skill.Skill;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -343,6 +344,50 @@ class ProposalRepositoryTest {
         found.getPositions().forEach(p ->
                 assertThat(util.isLoaded(p, "skills")).isTrue()
         );
+    }
+
+    @DisplayName("findAllWithPositionsByMemberEmail은 해당 회원의 모든 제안서와 positions를 함께 조회한다")
+    @Test
+    void findAllWithPositionsByMemberEmail_positions를_함께_조회한다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Position frontend = persist(Position.create("프론트엔드 개발자"));
+
+        Proposal proposal1 = Proposal.create(member, "제안서1", "원문", null, null, null, null);
+        proposal1.addPosition(backend, "백엔드", null, 1L, null, null, null, null, null, null);
+        Proposal proposal2 = Proposal.create(member, "제안서2", "원문", null, null, null, null);
+        proposal2.addPosition(frontend, "프론트", null, 1L, null, null, null, null, null, null);
+        proposalRepository.saveAndFlush(proposal1);
+        proposalRepository.saveAndFlush(proposal2);
+        entityManager.clear();
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        List<Proposal> result = proposalRepository.findAllWithPositionsByMemberEmail(
+                member.getEmail().getValue());
+
+        assertThat(result).hasSize(2);
+        result.forEach(p -> assertThat(util.isLoaded(p, "positions")).isTrue());
+        assertThat(result).flatExtracting(Proposal::getPositions).hasSize(2);
+    }
+
+    @DisplayName("findAllWithPositionsByMemberEmailAndStatus는 상태 필터링된 제안서와 positions를 함께 조회한다")
+    @Test
+    void findAllWithPositionsByMemberEmailAndStatus_상태별_positions를_함께_조회한다() {
+        Member member = memberRepository.save(createMember());
+        Position backend = persist(Position.create("백엔드 개발자"));
+
+        Proposal writingProposal = Proposal.create(member, "작성중 제안서", "원문", null, null, null, null);
+        writingProposal.addPosition(backend, "백엔드", null, 1L, null, null, null, null, null, null);
+        proposalRepository.saveAndFlush(writingProposal);
+        entityManager.clear();
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        List<Proposal> result = proposalRepository.findAllWithPositionsByMemberEmailAndStatus(
+                member.getEmail().getValue(), com.generic4.itda.domain.proposal.ProposalStatus.WRITING);
+
+        assertThat(result).hasSize(1);
+        assertThat(util.isLoaded(result.get(0), "positions")).isTrue();
+        assertThat(result.get(0).getPositions()).hasSize(1);
     }
 
     private <T> T persist(T entity) {

--- a/src/test/java/com/generic4/itda/service/ClientDashboardServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ClientDashboardServiceTest.java
@@ -58,14 +58,14 @@ class ClientDashboardServiceTest {
                 2
         );
 
-        given(proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL))
+        given(proposalRepository.findAllWithPositionsByMemberEmail(OWNER_EMAIL))
                 .willReturn(List.of(waitingProposal, matchingProposal));
         stubCounts(6L, 2L, 3L, 1L);
 
         ClientDashboardViewModel result = clientDashboardService.getDashboard(OWNER_EMAIL, ClientDashboardFilter.ALL);
 
         InOrder inOrder = inOrder(proposalRepository);
-        inOrder.verify(proposalRepository).findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL);
+        inOrder.verify(proposalRepository).findAllWithPositionsByMemberEmail(OWNER_EMAIL);
         verifyCountQueries(inOrder);
 
         assertThat(result.selectedFilterKey()).isEqualTo("all");
@@ -107,7 +107,7 @@ class ClientDashboardServiceTest {
                 2
         );
 
-        given(proposalRepository.findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(
+        given(proposalRepository.findAllWithPositionsByMemberEmailAndStatus(
                 OWNER_EMAIL,
                 ProposalStatus.WRITING
         )).willReturn(List.of(waitingProposal));
@@ -117,7 +117,7 @@ class ClientDashboardServiceTest {
 
         InOrder inOrder = inOrder(proposalRepository);
         inOrder.verify(proposalRepository)
-                .findAllByMember_Email_ValueAndStatusOrderByModifiedAtDesc(OWNER_EMAIL, ProposalStatus.WRITING);
+                .findAllWithPositionsByMemberEmailAndStatus(OWNER_EMAIL, ProposalStatus.WRITING);
         verifyCountQueries(inOrder);
 
         assertThat(result.selectedFilterKey()).isEqualTo("waiting");
@@ -134,14 +134,14 @@ class ClientDashboardServiceTest {
     @Test
     @DisplayName("필터가 null이면 전체 필터로 조회한다")
     void getDashboard_defaultsToAllFilterWhenFilterIsNull() {
-        given(proposalRepository.findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL))
+        given(proposalRepository.findAllWithPositionsByMemberEmail(OWNER_EMAIL))
                 .willReturn(List.of());
         stubCounts(0L, 0L, 0L, 0L);
 
         ClientDashboardViewModel result = clientDashboardService.getDashboard(OWNER_EMAIL, null);
 
         InOrder inOrder = inOrder(proposalRepository);
-        inOrder.verify(proposalRepository).findAllByMember_Email_ValueOrderByModifiedAtDesc(OWNER_EMAIL);
+        inOrder.verify(proposalRepository).findAllWithPositionsByMemberEmail(OWNER_EMAIL);
         verifyCountQueries(inOrder);
 
         assertThat(result.selectedFilterKey()).isEqualTo("all");

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -20,6 +20,7 @@ import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
+import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +53,9 @@ class ProposalServiceTest {
 
     @Mock
     private MatchingRepository matchingRepository;
+
+    @Mock
+    private EntityManager entityManager;
 
     private Member member;
 


### PR DESCRIPTION
## 🔎 What

-  ProposalRepository에 대시보드 목록 조회용 findAllWithPositionsByMemberEmail 메서드 추가
-  ProposalRepository에 상태별 목록 조회용 findAllWithPositionsByMemberEmailAndStatus 메서드 추가
-  ProposalService.findOwnedProposal이 수정 페이지 조회 시 findWithPositionsById + findPositionsWithSkillsByProposalId 사용하도록 변경 (positions/skills LazyInitializationException 해결)
-  ClientDashboardService.loadProjects가 새 Fetch Join 메서드를 사용하도록 변경 (N+1 해결)
-  ClientDashboardServiceTest mock 메서드명 업데이트
-  ProposalRepositoryTest에 새 메서드 Fetch Join 검증 테스트 추가

추가 발견 및 수정
- replacePositions에서 entityManager.flush() 추가
- 이슈 수정 중 발견된 버그로, Hibernate가 DELETE보다 INSERT를 먼저 실행해 unique constraint 위반이 발생하던 문제 수정

## 🔗 Issue

- Closes: #67 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?