### PR TITLE
[Feat] 제안서 작성 화면 AI 인터뷰 위젯 실동작 연결

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -15,18 +15,18 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StringUtils;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -49,6 +49,7 @@ public class ProposalController {
         model.addAttribute("proposalForm", form);
         model.addAttribute("proposalId", null);
         model.addAttribute("isNew", true);
+        model.addAttribute("aiBriefRequested", false);
 
         return "client/proposalForm";
     }
@@ -59,6 +60,7 @@ public class ProposalController {
             @Valid @ModelAttribute("proposalForm") ProposalForm form,
             BindingResult bindingResult,
             @RequestParam(name = "submitAction", defaultValue = SAVE_ACTION) String submitAction,
+            @RequestParam(name = "aiBriefRequested", defaultValue = "false") boolean aiBriefRequested,
             Model model
     ) {
         boolean registerAction = isRegisterAction(submitAction);
@@ -70,6 +72,7 @@ public class ProposalController {
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", null);
             model.addAttribute("isNew", true);
+            model.addAttribute("aiBriefRequested", aiBriefRequested);
             return "client/proposalForm";
         }
 
@@ -78,15 +81,14 @@ public class ProposalController {
                     ? proposalService.register(principal.getEmail(), form)
                     : proposalService.saveDraft(principal.getEmail(), form);
 
-            return registerAction
-                    ? "redirect:/proposals/" + proposal.getId() + "/recommendations"
-                    : "redirect:/proposals/" + proposal.getId() + "/edit";
+            return redirectAfterCreate(proposal, registerAction, aiBriefRequested);
         } catch (IllegalArgumentException | IllegalStateException e) {
             rejectGlobal(bindingResult, e.getMessage());
             addCommonAttributes(model);
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", null);
             model.addAttribute("isNew", true);
+            model.addAttribute("aiBriefRequested", aiBriefRequested);
             return "client/proposalForm";
         }
     }
@@ -95,6 +97,7 @@ public class ProposalController {
     public String editForm(
             @PathVariable Long proposalId,
             @AuthenticationPrincipal ItDaPrincipal principal,
+            @RequestParam(name = "aiBriefRequested", defaultValue = "false") boolean aiBriefRequested,
             Model model,
             RedirectAttributes redirectAttributes
     ) {
@@ -121,6 +124,7 @@ public class ProposalController {
             model.addAttribute("proposalForm", form);
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
+            model.addAttribute("aiBriefRequested", aiBriefRequested);
 
             return "client/proposalForm";
         } catch (ProposalNotFoundException e) {
@@ -178,6 +182,7 @@ public class ProposalController {
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
+            model.addAttribute("aiBriefRequested", false);
             return "client/proposalForm";
         }
 
@@ -201,6 +206,7 @@ public class ProposalController {
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
+            model.addAttribute("aiBriefRequested", false);
             return "client/proposalForm";
         }
     }
@@ -213,6 +219,18 @@ public class ProposalController {
     private void addMemberAttributes(Model model, ItDaPrincipal principal) {
         model.addAttribute("memberName", principal.getName());
         model.addAttribute("memberEmail", principal.getEmail());
+    }
+
+    private String redirectAfterCreate(Proposal proposal, boolean registerAction, boolean aiBriefRequested) {
+        if (registerAction) {
+            return "redirect:/proposals/" + proposal.getId() + "/recommendations";
+        }
+
+        if (aiBriefRequested) {
+            return "redirect:/proposals/" + proposal.getId() + "/edit?aiBriefRequested=true";
+        }
+
+        return "redirect:/proposals/" + proposal.getId() + "/edit";
     }
 
     private boolean isRegisterAction(String submitAction) {

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -81,7 +81,7 @@ public class ProposalController {
                     ? proposalService.register(principal.getEmail(), form)
                     : proposalService.saveDraft(principal.getEmail(), form);
 
-            return redirectAfterCreate(proposal, registerAction, aiBriefRequested);
+            return redirectAfterSave(proposal, registerAction, aiBriefRequested);
         } catch (IllegalArgumentException | IllegalStateException e) {
             rejectGlobal(bindingResult, e.getMessage());
             addCommonAttributes(model);
@@ -117,7 +117,7 @@ public class ProposalController {
                 return "redirect:/client/dashboard";
             }
 
-            ProposalForm form = ProposalForm.from(proposal);
+            ProposalForm form = proposalService.findOwnedProposalForm(proposalId, principal.getEmail());
 
             addCommonAttributes(model);
             addMemberAttributes(model, principal);
@@ -170,6 +170,7 @@ public class ProposalController {
             @Valid @ModelAttribute("proposalForm") ProposalForm form,
             BindingResult bindingResult,
             @RequestParam(name = "submitAction", defaultValue = SAVE_ACTION) String submitAction,
+            @RequestParam(name = "aiBriefRequested", defaultValue = "false") boolean aiBriefRequested,
             Model model,
             RedirectAttributes redirectAttributes
     ) {
@@ -182,7 +183,7 @@ public class ProposalController {
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
-            model.addAttribute("aiBriefRequested", false);
+            model.addAttribute("aiBriefRequested", aiBriefRequested);
             return "client/proposalForm";
         }
 
@@ -191,9 +192,7 @@ public class ProposalController {
                     ? proposalService.register(proposalId, principal.getEmail(), form)
                     : proposalService.saveDraft(proposalId, principal.getEmail(), form);
 
-            return registerAction
-                    ? "redirect:/proposals/" + proposal.getId() + "/recommendations"
-                    : "redirect:/proposals/" + proposal.getId() + "/edit";
+            return redirectAfterSave(proposal, registerAction, aiBriefRequested);
         } catch (ProposalNotFoundException e) {
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
             return "redirect:/client/dashboard";
@@ -206,7 +205,7 @@ public class ProposalController {
             addMemberAttributes(model, principal);
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
-            model.addAttribute("aiBriefRequested", false);
+            model.addAttribute("aiBriefRequested", aiBriefRequested);
             return "client/proposalForm";
         }
     }
@@ -221,7 +220,7 @@ public class ProposalController {
         model.addAttribute("memberEmail", principal.getEmail());
     }
 
-    private String redirectAfterCreate(Proposal proposal, boolean registerAction, boolean aiBriefRequested) {
+    private String redirectAfterSave(Proposal proposal, boolean registerAction, boolean aiBriefRequested) {
         if (registerAction) {
             return "redirect:/proposals/" + proposal.getId() + "/recommendations";
         }

--- a/src/main/java/com/generic4/itda/domain/proposal/ProposalPosition.java
+++ b/src/main/java/com/generic4/itda/domain/proposal/ProposalPosition.java
@@ -170,6 +170,14 @@ public class ProposalPosition extends BaseEntity {
         });
     }
 
+    public void clearSkills() {
+        List<ProposalPositionSkill> existingSkills = new ArrayList<>(this.skills);
+        for (ProposalPositionSkill existingSkill : existingSkills) {
+            existingSkill.detachFromProposalPosition();
+            this.skills.remove(existingSkill);
+        }
+    }
+
     void detachFromProposal() {
         this.proposal = null;
     }

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -3,6 +3,9 @@ package com.generic4.itda.service;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkill;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.proposal.AiBriefPositionResult;
 import com.generic4.itda.dto.proposal.AiBriefResult;
@@ -10,7 +13,11 @@ import com.generic4.itda.dto.proposal.AiBriefSkillResult;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.SkillRepository;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -19,6 +26,10 @@ import org.springframework.util.StringUtils;
 @Component
 @RequiredArgsConstructor
 public class AiBriefProposalMapper {
+
+    private static final Long DEFAULT_HEAD_COUNT = 1L;
+    private static final ProposalWorkType DEFAULT_WORK_TYPE = ProposalWorkType.REMOTE;
+    private static final String DEFAULT_WORK_PLACE = "협의";
 
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
@@ -36,42 +47,156 @@ public class AiBriefProposalMapper {
                 resolveExpectedPeriod(proposal, aiBriefResult)
         );
 
-        replacePositions(proposal, aiBriefResult.getPositions());
+        mergePositions(proposal, aiBriefResult.getPositions());
     }
 
-    private void replacePositions(Proposal proposal, List<AiBriefPositionResult> positions) {
-        if (positions == null || positions.isEmpty()) {
+    private void mergePositions(Proposal proposal, List<AiBriefPositionResult> positionResults) {
+        if (positionResults == null || positionResults.isEmpty()) {
             return;
         }
 
-        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
-        for (ProposalPosition existingPosition : existingPositions) {
-            proposal.removePosition(existingPosition);
+        Map<String, ProposalPosition> existingByPositionName = existingPositionsByPositionName(proposal);
+        List<PositionApplication> applications = mergePositionApplicationsByPositionName(positionResults);
+        Set<ProposalPosition> appliedPositions = new HashSet<>();
+
+        for (PositionApplication application : applications) {
+            ProposalPosition proposalPosition = existingByPositionName.get(normalizeKey(application.position().getName()));
+            AiBriefPositionResult result = application.result();
+            ProposalWorkType workType = resolveWorkType(result);
+            String workPlace = resolveWorkPlace(workType, result.getWorkPlace());
+
+            if (proposalPosition == null) {
+                proposalPosition = proposal.addPosition(
+                        application.position(),
+                        result.getTitle(),
+                        workType,
+                        resolveHeadCount(result),
+                        result.getUnitBudgetMin(),
+                        result.getUnitBudgetMax(),
+                        result.getExpectedPeriod(),
+                        result.getCareerMinYears(),
+                        result.getCareerMaxYears(),
+                        workPlace
+                );
+            } else {
+                proposalPosition.update(
+                        application.position(),
+                        result.getTitle(),
+                        workType,
+                        resolveHeadCount(result),
+                        result.getUnitBudgetMin(),
+                        result.getUnitBudgetMax(),
+                        result.getExpectedPeriod(),
+                        result.getCareerMinYears(),
+                        result.getCareerMaxYears(),
+                        workPlace
+                );
+            }
+
+            replaceSkills(proposalPosition, result.getSkills());
+            appliedPositions.add(proposalPosition);
         }
 
-        for (AiBriefPositionResult positionResult : positions) {
-            Position position = findOrCreatePosition(positionResult.getPositionCategoryName());
-            ProposalPosition proposalPosition = proposal.addPosition(
-                    position,
-                    positionResult.getTitle(),
-                    positionResult.getWorkType(),
-                    positionResult.getHeadCount(),
-                    positionResult.getUnitBudgetMin(),
-                    positionResult.getUnitBudgetMax(),
-                    positionResult.getExpectedPeriod(),
-                    positionResult.getCareerMinYears(),
-                    positionResult.getCareerMaxYears(),
-                    positionResult.getWorkPlace()
-            );
-            addSkills(proposalPosition, positionResult.getSkills());
+        removePositionsNotInAiResult(proposal, appliedPositions);
+    }
+
+    private void removePositionsNotInAiResult(Proposal proposal, Set<ProposalPosition> appliedPositions) {
+        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
+        for (ProposalPosition existingPosition : existingPositions) {
+            if (!appliedPositions.contains(existingPosition)) {
+                proposal.removePosition(existingPosition);
+            }
         }
     }
 
-    private void addSkills(ProposalPosition proposalPosition, List<AiBriefSkillResult> skills) {
-        for (AiBriefSkillResult skillResult : skills) {
-            Skill skill = findOrCreateSkill(skillResult.getSkillName());
-            proposalPosition.addSkill(skill, skillResult.getImportance());
+    private Map<String, ProposalPosition> existingPositionsByPositionName(Proposal proposal) {
+        Map<String, ProposalPosition> existingPositions = new LinkedHashMap<>();
+        for (ProposalPosition proposalPosition : proposal.getPositions()) {
+            if (proposalPosition.getPosition() != null && StringUtils.hasText(proposalPosition.getPosition().getName())) {
+                existingPositions.put(normalizeKey(proposalPosition.getPosition().getName()), proposalPosition);
+            }
         }
+        return existingPositions;
+    }
+
+    private List<PositionApplication> mergePositionApplicationsByPositionName(List<AiBriefPositionResult> positionResults) {
+        Map<String, PositionApplication> merged = new LinkedHashMap<>();
+
+        for (AiBriefPositionResult positionResult : positionResults) {
+            Position position = findOrCreatePosition(positionResult.getPositionCategoryName());
+            merged.put(normalizeKey(position.getName()), new PositionApplication(position, positionResult));
+        }
+
+        return new ArrayList<>(merged.values());
+    }
+
+    private Long resolveHeadCount(AiBriefPositionResult result) {
+        if (result.getHeadCount() == null || result.getHeadCount() < 1) {
+            return DEFAULT_HEAD_COUNT;
+        }
+        return result.getHeadCount();
+    }
+
+    private ProposalWorkType resolveWorkType(AiBriefPositionResult result) {
+        if (result.getWorkType() == null) {
+            return DEFAULT_WORK_TYPE;
+        }
+        return result.getWorkType();
+    }
+
+    private String resolveWorkPlace(ProposalWorkType workType, String workPlace) {
+        if (workType == ProposalWorkType.REMOTE) {
+            return null;
+        }
+
+        if ((workType == ProposalWorkType.SITE || workType == ProposalWorkType.HYBRID)
+                && !StringUtils.hasText(workPlace)) {
+            return DEFAULT_WORK_PLACE;
+        }
+
+        return StringUtils.hasText(workPlace) ? workPlace.trim() : null;
+    }
+
+    private void replaceSkills(ProposalPosition proposalPosition, List<AiBriefSkillResult> skills) {
+        Map<String, SkillApplication> desiredSkills = buildDesiredSkills(skills);
+
+        List<ProposalPositionSkill> existingSkills = new ArrayList<>(proposalPosition.getSkills());
+        for (ProposalPositionSkill existingSkill : existingSkills) {
+            String key = normalizeKey(existingSkill.getSkill().getName());
+            SkillApplication desiredSkill = desiredSkills.remove(key);
+
+            if (desiredSkill == null) {
+                proposalPosition.removeSkill(existingSkill.getSkill());
+                continue;
+            }
+
+            existingSkill.changeImportance(desiredSkill.importance());
+        }
+
+        for (SkillApplication desiredSkill : desiredSkills.values()) {
+            proposalPosition.addSkill(desiredSkill.skill(), desiredSkill.importance());
+        }
+    }
+
+    private Map<String, SkillApplication> buildDesiredSkills(List<AiBriefSkillResult> skills) {
+        Map<String, SkillApplication> desiredSkills = new LinkedHashMap<>();
+        if (skills == null || skills.isEmpty()) {
+            return desiredSkills;
+        }
+
+        for (AiBriefSkillResult skillResult : skills) {
+            if (skillResult == null || !StringUtils.hasText(skillResult.getSkillName())) {
+                continue;
+            }
+
+            Skill skill = findOrCreateSkill(skillResult.getSkillName());
+            desiredSkills.putIfAbsent(
+                    normalizeKey(skill.getName()),
+                    new SkillApplication(skill, skillResult.getImportance())
+            );
+        }
+
+        return desiredSkills;
     }
 
     private Position findOrCreatePosition(String positionCategoryName) {
@@ -117,5 +242,15 @@ public class AiBriefProposalMapper {
             return aiBriefResult.getExpectedPeriod();
         }
         return proposal.getExpectedPeriod();
+    }
+
+    private String normalizeKey(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private record PositionApplication(Position position, AiBriefPositionResult result) {
+    }
+
+    private record SkillApplication(Skill skill, ProposalPositionSkillImportance importance) {
     }
 }

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+@Slf4j
 @Component
 @ConditionalOnProperty(prefix = "ai.brief", name = "enabled", havingValue = "true")
 public class OpenAiAiBriefGenerator implements AiBriefGenerator {
@@ -34,6 +36,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
 
             규칙:
             - 반드시 JSON만 반환한다.
+            - 마크다운 코드블록, 설명문, 주석, 추가 텍스트를 절대 포함하지 않는다.
             - title, description은 한국어로 자연스럽게 작성한다.
             - 근거가 부족한 값은 추측하지 말고 null로 반환한다.
             - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
@@ -47,6 +50,11 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
             - importance를 확신할 수 없으면 PREFERENCE를 사용한다.
             - skillName은 짧고 일반적인 명칭으로 정리한다.
+            - 정보가 부족하면 positions는 1~3개 이내로 생성한다.
+            - position별 skills는 최대 4개까지만 반환한다.
+            - 사용자가 명시하지 않은 포지션은 과도하게 늘리지 않는다.
+            - 입력은 시간순 요청 목록이다.
+            - 사용자가 제거/삭제/빼달라고 한 포지션은 positions에서 제외한다.
             """;
 
     private final RestClient restClient;
@@ -54,7 +62,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
     private final AiBriefProperties properties;
 
     public OpenAiAiBriefGenerator(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
-            AiBriefProperties properties) {
+                                  AiBriefProperties properties) {
         Assert.hasText(properties.getApiKey(), "AI 브리프 API 키는 필수값입니다.");
 
         this.restClient = restClientBuilder.build();
@@ -76,7 +84,12 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                     .body(JsonNode.class);
 
             String responseText = extractResponseText(responseBody);
-            return toAiBriefResult(responseText);
+            try {
+                return toAiBriefResult(responseText);
+            } catch (JsonProcessingException exception) {
+                log.warn("AI 브리프 응답 JSON 파싱 실패. responseText={}", abbreviate(responseText, 2000), exception);
+                throw exception;
+            }
         } catch (AiBriefGenerationException exception) {
             throw exception;
         } catch (RestClientException exception) {
@@ -257,7 +270,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
     }
 
     private AiBriefResult toAiBriefResult(String responseText) throws JsonProcessingException {
-        JsonNode root = objectMapper.readTree(responseText);
+        JsonNode root = objectMapper.readTree(extractJsonObject(responseText));
 
         return AiBriefResult.of(
                 normalizeText(root.get("title")),
@@ -267,6 +280,50 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 asLong(root.get("expectedPeriod")),
                 parsePositions(root.get("positions"))
         );
+    }
+
+    private String extractJsonObject(String responseText) throws JsonProcessingException {
+        if (!StringUtils.hasText(responseText)) {
+            throw new JsonProcessingException("AI 브리프 응답 본문이 비어 있습니다.") {
+            };
+        }
+
+        String text = stripCodeFence(responseText.trim());
+        int start = text.indexOf('{');
+        int end = text.lastIndexOf('}');
+
+        if (start < 0 || end < start) {
+            throw new JsonProcessingException("AI 브리프 응답에서 JSON 객체를 찾을 수 없습니다. responseText="
+                    + abbreviate(text, 500)) {
+            };
+        }
+
+        return text.substring(start, end + 1);
+    }
+
+    private String stripCodeFence(String responseText) {
+        String text = responseText.trim();
+
+        if (text.startsWith("```")) {
+            int firstLineEnd = text.indexOf('\n');
+            int lastFenceStart = text.lastIndexOf("```");
+
+            if (firstLineEnd >= 0 && lastFenceStart > firstLineEnd) {
+                return text.substring(firstLineEnd + 1, lastFenceStart).trim();
+            }
+        }
+
+        return text;
+    }
+
+    private String abbreviate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
     }
 
     private List<AiBriefPositionResult> parsePositions(JsonNode positionsNode) {

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -5,6 +5,7 @@ import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.skill.Skill;
@@ -16,11 +17,14 @@ import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
-import jakarta.persistence.EntityManager;
-import java.util.EnumSet;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -45,7 +49,6 @@ public class ProposalService {
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
     private final MatchingRepository matchingRepository;
-    private final EntityManager entityManager;
 
     public Proposal saveDraft(String memberEmail, ProposalForm form) {
         Member member = getMemberByEmail(memberEmail);
@@ -138,10 +141,14 @@ public class ProposalService {
             throw new AccessDeniedException("본인 제안서만 조회하거나 수정할 수 있습니다.");
         }
 
-        // ProposalPosition.skills도 1차 캐시에 로드 (LazyInitializationException 방지)
         proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
-
         return proposal;
+    }
+
+    @Transactional(readOnly = true)
+    public ProposalForm findOwnedProposalForm(Long proposalId, String memberEmail) {
+        Proposal proposal = findOwnedProposal(proposalId, memberEmail);
+        return ProposalForm.from(proposal);
     }
 
     public Long calculateTotalBudgetMin(ProposalForm form) {
@@ -153,45 +160,150 @@ public class ProposalService {
     }
 
     private void replacePositions(Proposal proposal, List<ProposalPositionForm> positionForms) {
-        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
-        for (ProposalPosition existingPosition : existingPositions) {
-            proposal.removePosition(existingPosition);
-        }
+        List<ProposalPositionForm> mergedPositionForms = mergePositionFormsByPositionId(positionForms);
+        Map<Long, ProposalPosition> existingById = existingPositionsById(proposal);
+        Map<Long, ProposalPosition> existingByPositionId = existingPositionsByPositionId(proposal);
+        Set<ProposalPosition> appliedPositions = new HashSet<>();
 
-        // DELETE가 INSERT보다 먼저 실행되도록 강제 flush
-        // (미실행 시 unique constraint 위반 발생)
-        entityManager.flush();
-
-        for (ProposalPositionForm positionForm : positionForms) {
+        for (ProposalPositionForm positionForm : mergedPositionForms) {
             Position position = getPosition(positionForm.getPositionId());
-            ProposalPosition proposalPosition = proposal.addPosition(
-                    position,
-                    positionForm.getTitle(),
-                    positionForm.getWorkType(),
-                    positionForm.getHeadCount(),
-                    positionForm.getUnitBudgetMin(),
-                    positionForm.getUnitBudgetMax(),
-                    positionForm.getExpectedPeriod(),
-                    positionForm.getCareerMinYears(),
-                    positionForm.getCareerMaxYears(),
-                    positionForm.getWorkPlace()
-            );
+            ProposalPosition proposalPosition = findExistingPosition(positionForm, position, existingById, existingByPositionId);
+
+            if (proposalPosition == null) {
+                proposalPosition = proposal.addPosition(
+                        position,
+                        positionForm.getTitle(),
+                        positionForm.getWorkType(),
+                        positionForm.getHeadCount(),
+                        positionForm.getUnitBudgetMin(),
+                        positionForm.getUnitBudgetMax(),
+                        positionForm.getExpectedPeriod(),
+                        positionForm.getCareerMinYears(),
+                        positionForm.getCareerMaxYears(),
+                        positionForm.getWorkPlace()
+                );
+            } else {
+                proposalPosition.update(
+                        position,
+                        positionForm.getTitle(),
+                        positionForm.getWorkType(),
+                        positionForm.getHeadCount(),
+                        positionForm.getUnitBudgetMin(),
+                        positionForm.getUnitBudgetMax(),
+                        positionForm.getExpectedPeriod(),
+                        positionForm.getCareerMinYears(),
+                        positionForm.getCareerMaxYears(),
+                        positionForm.getWorkPlace()
+                );
+            }
 
             if (positionForm.getStatus() != null) {
                 proposalPosition.changeStatus(positionForm.getStatus());
             }
 
-            addSkills(proposalPosition, positionForm.getEssentialSkillNames(), ProposalPositionSkillImportance.ESSENTIAL);
-            addSkills(proposalPosition, positionForm.getPreferredSkillNames(), ProposalPositionSkillImportance.PREFERENCE);
+            replaceSkills(proposalPosition, positionForm.getEssentialSkillNames(), positionForm.getPreferredSkillNames());
+            appliedPositions.add(proposalPosition);
+        }
+
+        removeMissingPositions(proposal, appliedPositions);
+    }
+
+    private List<ProposalPositionForm> mergePositionFormsByPositionId(List<ProposalPositionForm> positionForms) {
+        Map<Long, ProposalPositionForm> merged = new LinkedHashMap<>();
+        for (ProposalPositionForm positionForm : positionForms) {
+            if (positionForm.getPositionId() == null) {
+                continue;
+            }
+            merged.put(positionForm.getPositionId(), positionForm);
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    private Map<Long, ProposalPosition> existingPositionsById(Proposal proposal) {
+        Map<Long, ProposalPosition> existingPositions = new LinkedHashMap<>();
+        for (ProposalPosition proposalPosition : proposal.getPositions()) {
+            if (proposalPosition.getId() != null) {
+                existingPositions.put(proposalPosition.getId(), proposalPosition);
+            }
+        }
+        return existingPositions;
+    }
+
+    private Map<Long, ProposalPosition> existingPositionsByPositionId(Proposal proposal) {
+        Map<Long, ProposalPosition> existingPositions = new LinkedHashMap<>();
+        for (ProposalPosition proposalPosition : proposal.getPositions()) {
+            if (proposalPosition.getPosition() != null && proposalPosition.getPosition().getId() != null) {
+                existingPositions.put(proposalPosition.getPosition().getId(), proposalPosition);
+            }
+        }
+        return existingPositions;
+    }
+
+    private ProposalPosition findExistingPosition(
+            ProposalPositionForm positionForm,
+            Position position,
+            Map<Long, ProposalPosition> existingById,
+            Map<Long, ProposalPosition> existingByPositionId
+    ) {
+        if (positionForm.getId() != null && existingById.containsKey(positionForm.getId())) {
+            return existingById.get(positionForm.getId());
+        }
+        return existingByPositionId.get(position.getId());
+    }
+
+    private void removeMissingPositions(Proposal proposal, Set<ProposalPosition> appliedPositions) {
+        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
+        for (ProposalPosition existingPosition : existingPositions) {
+            if (!appliedPositions.contains(existingPosition)) {
+                proposal.removePosition(existingPosition);
+            }
         }
     }
 
-    private void addSkills(ProposalPosition proposalPosition, List<String> skillNames,
-            ProposalPositionSkillImportance importance) {
+    private void replaceSkills(
+            ProposalPosition proposalPosition,
+            List<String> essentialSkillNames,
+            List<String> preferredSkillNames
+    ) {
+        Map<String, SkillApplication> desiredSkills = buildDesiredSkills(essentialSkillNames, preferredSkillNames);
+
+        List<ProposalPositionSkill> existingSkills = new ArrayList<>(proposalPosition.getSkills());
+        for (ProposalPositionSkill existingSkill : existingSkills) {
+            String key = normalizeKey(existingSkill.getSkill().getName());
+            SkillApplication desiredSkill = desiredSkills.remove(key);
+
+            if (desiredSkill == null) {
+                proposalPosition.removeSkill(existingSkill.getSkill());
+                continue;
+            }
+
+            existingSkill.changeImportance(desiredSkill.importance());
+        }
+
+        for (SkillApplication desiredSkill : desiredSkills.values()) {
+            proposalPosition.addSkill(desiredSkill.skill(), desiredSkill.importance());
+        }
+    }
+
+    private Map<String, SkillApplication> buildDesiredSkills(
+            List<String> essentialSkillNames,
+            List<String> preferredSkillNames
+    ) {
+        Map<String, SkillApplication> desiredSkills = new LinkedHashMap<>();
+        addDesiredSkills(desiredSkills, essentialSkillNames, ProposalPositionSkillImportance.ESSENTIAL);
+        addDesiredSkills(desiredSkills, preferredSkillNames, ProposalPositionSkillImportance.PREFERENCE);
+        return desiredSkills;
+    }
+
+    private void addDesiredSkills(
+            Map<String, SkillApplication> desiredSkills,
+            List<String> skillNames,
+            ProposalPositionSkillImportance importance
+    ) {
         for (String skillName : normalizeSkillNames(skillNames)) {
             Skill skill = skillRepository.findByName(skillName)
                     .orElseGet(() -> skillRepository.save(Skill.create(skillName, null)));
-            proposalPosition.addSkill(skill, importance);
+            desiredSkills.putIfAbsent(normalizeKey(skill.getName()), new SkillApplication(skill, importance));
         }
     }
 
@@ -206,6 +318,10 @@ public class ProposalService {
                 .collect(Collectors.toCollection(LinkedHashSet::new))
                 .stream()
                 .toList();
+    }
+
+    private String normalizeKey(String value) {
+        return value == null ? "" : value.trim();
     }
 
     private Long calculateTotalBudgetMin(List<ProposalPositionForm> positions) {
@@ -334,5 +450,8 @@ public class ProposalService {
             throw new AccessDeniedException("본인 제안서만 조회하거나 수정할 수 있습니다.");
         }
         return proposal;
+    }
+
+    private record SkillApplication(Skill skill, ProposalPositionSkillImportance importance) {
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ ai:
     api-url: ${AI_BRIEF_API_URL:https://api.openai.com/v1/responses}
     api-key: ${AI_BRIEF_API_KEY:}
     model: ${AI_BRIEF_MODEL:gpt-5-mini}
-    max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:2000}
+    max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:4000}
 
 app:
   seed:

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -31,6 +31,7 @@
             <input type="hidden" name="status" :value="status">
             <input type="hidden" name="rawInputText" :value="rawInputText">
             <input type="hidden" name="submitAction" :value="submitAction">
+            <input type="hidden" name="aiBriefRequested" :value="aiBriefRequested">
 
             <template x-for="(position, index) in positions" :key="position.clientKey">
                 <div>
@@ -71,7 +72,7 @@
                                 <p class="text-xs font-black uppercase tracking-widest text-slate-400">AI Proposal Interview</p>
                                 <h1 class="mt-2 text-2xl font-black tracking-tight text-slate-950">AI 제안서 작성 도우미</h1>
                                 <p class="mt-2 text-sm leading-7 text-slate-500">
-                                    프로젝트 아이디어를 먼저 정리해두면, 다음 단계에서 AI 인터뷰 흐름과 폼 자동 채움 기능을 연결할 수 있습니다.
+                                    프로젝트 아이디어를 먼저 적어주세요. AI가 내용을 분석해 제안서 초안을 만들고, 오른쪽 폼에 자동으로 반영합니다.
                                 </p>
                             </div>
 
@@ -79,24 +80,29 @@
                                 <div class="space-y-5">
                                     <div class="max-w-[92%] rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-4 text-sm leading-7 text-slate-600">
                                         안녕하세요! 만들고 싶은 IT 서비스나 프로젝트를 자유롭게 적어주세요.
-                                        이 입력은 다음 단계에서 AI 브리프와 후속 질문의 기준이 됩니다.
+                                        전송하면 입력 내용을 저장하고 AI 브리프 생성 흐름을 시작합니다.
                                     </div>
 
                                     <template x-if="rawInputText.trim().length > 0">
                                         <div class="space-y-5">
-                                            <div class="ml-auto max-w-[88%] rounded-[24px] bg-slate-950 px-5 py-4 text-sm leading-7 text-white shadow-sm shadow-slate-900/10"
+                                            <div class="ml-auto max-w-[88%] whitespace-pre-line rounded-[24px] bg-slate-950 px-5 py-4 text-sm leading-7 text-white shadow-sm shadow-slate-900/10"
                                                  x-text="rawInputText"></div>
 
                                             <div class="max-w-[92%] rounded-[24px] border border-blue-100 bg-blue-50 px-5 py-4 text-sm leading-7 text-blue-700">
-                                                프로젝트 원본 입력을 확인했습니다. 실제 후속 질문과 제안서 자동 채움 로직은 다음 단계에서 연결할 예정입니다.
+                                                프로젝트 원본 입력을 확인했습니다. AI 브리프를 생성하면 오른쪽 폼이 갱신될 수 있습니다.
                                             </div>
                                         </div>
                                     </template>
 
                                     <template x-if="rawInputText.trim().length === 0">
                                         <div class="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-6 py-8 text-sm leading-7 text-slate-500">
-                                            아직 입력된 프로젝트 아이디어가 없습니다. 아래 입력창에 원하는 서비스를 적어두면, 이후 AI 인터뷰 단계에서 이 내용을 바탕으로 질문을 이어갑니다.
+                                            아직 입력된 프로젝트 아이디어가 없습니다. 아래 입력창에 원하는 서비스를 적어두면, AI가 제안서 초안을 만들기 위한 원본 입력으로 저장합니다.
                                         </div>
+                                    </template>
+
+                                    <template x-if="aiBriefNoticeMessage">
+                                        <div class="max-w-[92%] rounded-[24px] border border-amber-100 bg-amber-50 px-5 py-4 text-sm leading-7 text-amber-700"
+                                             x-text="aiBriefNoticeMessage"></div>
                                     </template>
                                 </div>
                             </div>
@@ -594,6 +600,7 @@
             status: /*[[${proposalForm.status != null ? proposalForm.status.name() : 'WRITING'}]]*/ 'WRITING',
             title: /*[[${proposalForm.title}]]*/ '',
             rawInputText: /*[[${proposalForm.rawInputText}]]*/ '',
+            aiBriefRequested: /*[[${aiBriefRequested}]]*/ false,
             description: /*[[${proposalForm.description}]]*/ '',
             expectedPeriod: /*[[${proposalForm.expectedPeriod}]]*/ null,
             workTypes: [
@@ -647,9 +654,11 @@
                 loaded: false,
                 chatOpen: true,
                 submitAction: 'save',
+                aiBriefRequested: Boolean(bootstrap.aiBriefRequested),
+                aiBriefNoticeMessage: '',
                 title: bootstrap.title || '',
                 rawInputText: bootstrap.rawInputText || '',
-                draftInput: bootstrap.rawInputText || '',
+                draftInput: '',
                 description: bootstrap.description || '',
                 expectedPeriod: bootstrap.expectedPeriod ?? '',
                 status: bootstrap.status || 'WRITING',
@@ -680,8 +689,39 @@
                     if (!this.draftInput || !this.draftInput.trim()) {
                         return;
                     }
-                    this.rawInputText = this.draftInput.trim();
+
+                    this.rawInputText = this.appendRawInput(this.rawInputText, this.draftInput);
+                    this.draftInput = '';
+                    this.aiBriefNoticeMessage = '프로젝트 원본 입력을 저장했습니다. 기존 입력값은 AI 결과로 갱신될 수 있습니다.';
+
+                    if (!this.title || !this.title.trim()) {
+                        this.title = 'AI 브리프 작성 중';
+                    }
+
+                    if (bootstrap.isNew) {
+                        this.aiBriefRequested = true;
+                        this.submitAction = 'save';
+                        this.$nextTick(() => {
+                            this.$root.requestSubmit();
+                        });
+                        return;
+                    }
+
                     this.refreshIcons();
+                },
+
+                appendRawInput(current, input) {
+                    const trimmed = (input || '').trim();
+                    if (!trimmed) {
+                        return current || '';
+                    }
+
+                    const line = `- ${trimmed}`;
+                    if (!current || !current.trim()) {
+                        return line;
+                    }
+
+                    return `${current.trim()}\n${line}`;
                 },
 
                 openAddPosition() {
@@ -760,6 +800,7 @@
 
                 submitProposal(action) {
                     this.submitAction = action;
+                    this.aiBriefRequested = false;
                     this.$nextTick(() => {
                         this.$root.requestSubmit();
                     });
@@ -846,7 +887,7 @@
                         errors.push('모집 인원은 1명 이상이어야 합니다.');
                     }
                     if ((position.workType === 'SITE' || position.workType === 'HYBRID')
-                            && (!position.workPlace || !position.workPlace.trim())) {
+                        && (!position.workPlace || !position.workPlace.trim())) {
                         errors.push('상주 또는 하이브리드 근무 포지션은 근무지를 입력해야 합니다.');
                     }
                     if (position.workType === 'REMOTE' && position.workPlace && position.workPlace.trim()) {

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -130,9 +130,19 @@
                                     <button type="button"
                                             @click="sendPrompt()"
                                             :disabled="aiBriefLoading"
-                                            class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-950 text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400">
-                                        <i x-show="!aiBriefLoading" data-lucide="send" class="h-4 w-4"></i>
-                                        <i x-show="aiBriefLoading" x-cloak data-lucide="loader-circle" class="h-4 w-4 animate-spin"></i>
+                                            aria-label="프로젝트 아이디어 전송"
+                                            class="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-slate-950 text-white shadow-sm shadow-slate-900/10 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400">
+                                        <svg xmlns="http://www.w3.org/2000/svg"
+                                             viewBox="0 0 24 24"
+                                             fill="none"
+                                             stroke="currentColor"
+                                             stroke-width="2"
+                                             stroke-linecap="round"
+                                             stroke-linejoin="round"
+                                             class="h-5 w-5 text-white">
+                                            <path d="m22 2-7 20-4-9-9-4Z"></path>
+                                            <path d="M22 2 11 13"></path>
+                                        </svg>
                                     </button>
                                 </div>
                                 <p th:if="${#fields.hasErrors('rawInputText')}"
@@ -152,58 +162,54 @@
 
                         <div class="h-full overflow-y-auto">
                             <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-5 backdrop-blur lg:px-8">
-                                <div class="flex flex-wrap items-start justify-between gap-5">
-                                    <div>
-                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">Proposal Editor</p>
-                                        <h2 class="mt-2 text-3xl font-black tracking-tight text-slate-950">제안서 작성</h2>
-                                        <p class="mt-2 text-sm leading-7 text-slate-500">
-                                            AI가 자동으로 작성하거나 직접 수정할 수 있습니다. 현재 단계에서는 편집기 구조와 포지션 편집 흐름을 먼저 맞춥니다.
-                                        </p>
-                                        <div class="mt-4 flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-400">
-                                            <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
-                                                <i data-lucide="user-round" class="h-3.5 w-3.5"></i>
-                                                <span th:text="${memberName}">클라이언트</span>
-                                            </span>
-                                            <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
-                                                <i data-lucide="mail" class="h-3.5 w-3.5"></i>
-                                                <span th:text="${memberEmail}">seed.client@itda.local</span>
-                                            </span>
-                                            <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
-                                                <i data-lucide="badge-check" class="h-3.5 w-3.5"></i>
-                                                <span th:text="${proposalForm.status != null ? proposalForm.status.description : '작성 중'}">작성 중</span>
-                                            </span>
-                                            <span th:if="${proposalId != null}"
-                                                  class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
-                                                <i data-lucide="hash" class="h-3.5 w-3.5"></i>
-                                                <span th:text="'Proposal #' + ${proposalId}">Proposal #1</span>
-                                            </span>
-                                        </div>
+                                <div class="max-w-5xl">
+                                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">Proposal Editor</p>
+                                    <h2 class="mt-2 text-3xl font-black tracking-tight text-slate-950">제안서 작성</h2>
+                                    <p class="mt-2 text-sm leading-7 text-slate-500">
+                                        AI가 자동으로 작성하거나 직접 수정할 수 있습니다. 현재 단계에서는 편집기 구조와 포지션 편집 흐름을 먼저 맞춥니다.
+                                    </p>
+                                    <div class="mt-4 flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-400">
+                                        <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                                            <i data-lucide="user-round" class="h-3.5 w-3.5"></i>
+                                            <span th:text="${memberName}">클라이언트</span>
+                                        </span>
+                                        <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                                            <i data-lucide="mail" class="h-3.5 w-3.5"></i>
+                                            <span th:text="${memberEmail}">seed.client@itda.local</span>
+                                        </span>
+                                        <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                                            <i data-lucide="badge-check" class="h-3.5 w-3.5"></i>
+                                            <span th:text="${proposalForm.status != null ? proposalForm.status.description : '작성 중'}">작성 중</span>
+                                        </span>
+                                        <span th:if="${proposalId != null}"
+                                              class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                                            <i data-lucide="hash" class="h-3.5 w-3.5"></i>
+                                            <span th:text="'Proposal #' + ${proposalId}">Proposal #1</span>
+                                        </span>
                                     </div>
 
-                                    <div class="flex flex-col items-start gap-3 sm:items-end">
-                                        <div class="flex flex-wrap items-center gap-3">
-                                            <a th:href="@{/client/dashboard}"
-                                               class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
-                                                <i data-lucide="arrow-left" class="h-4 w-4"></i>
-                                                대시보드로
-                                            </a>
-                                            <button type="button"
-                                                    @click="submitProposal('save')"
-                                                    class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
-                                                <i data-lucide="save" class="h-4 w-4"></i>
-                                                임시저장
-                                            </button>
-                                            <button type="button"
-                                                    @click="submitProposal('register')"
-                                                    class="inline-flex items-center gap-2 rounded-2xl bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-slate-900/10 transition hover:bg-slate-800">
-                                                <i data-lucide="rocket" class="h-4 w-4"></i>
-                                                제안서 등록
-                                            </button>
-                                        </div>
-                                        <p class="text-xs font-semibold text-slate-400">
-                                            임시저장은 작성 중 상태로 저장되고, 제안서 등록은 검증을 통과하면 MATCHING 상태로 전환됩니다.
-                                        </p>
+                                    <div class="mt-5 flex flex-wrap items-center gap-3">
+                                        <a th:href="@{/client/dashboard}"
+                                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                                            대시보드로
+                                        </a>
+                                        <button type="button"
+                                                @click="submitProposal('save')"
+                                                class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                            <i data-lucide="save" class="h-4 w-4"></i>
+                                            임시저장
+                                        </button>
+                                        <button type="button"
+                                                @click="submitProposal('register')"
+                                                class="inline-flex items-center gap-2 rounded-2xl bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-slate-900/10 transition hover:bg-slate-800">
+                                            <i data-lucide="rocket" class="h-4 w-4"></i>
+                                            제안서 등록
+                                        </button>
                                     </div>
+                                    <p class="mt-3 text-xs font-semibold text-slate-400">
+                                        임시저장은 작성 중 상태로 저장되고, 제안서 등록은 검증을 통과하면 MATCHING 상태로 전환됩니다.
+                                    </p>
                                 </div>
                             </div>
 
@@ -670,6 +676,8 @@
                 submitAction: 'save',
                 aiBriefRequested: Boolean(bootstrap.aiBriefRequested),
                 aiBriefNoticeMessage: '',
+                aiBriefLoading: false,
+                aiBriefErrorMessage: '',
                 title: bootstrap.title || '',
                 rawInputText: bootstrap.rawInputText || '',
                 draftInput: '',

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -104,6 +104,17 @@
                                         <div class="max-w-[92%] rounded-[24px] border border-amber-100 bg-amber-50 px-5 py-4 text-sm leading-7 text-amber-700"
                                              x-text="aiBriefNoticeMessage"></div>
                                     </template>
+
+                                    <template x-if="aiBriefLoading">
+                                        <div class="max-w-[92%] rounded-[24px] border border-blue-100 bg-blue-50 px-5 py-4 text-sm leading-7 text-blue-700">
+                                            AI가 프로젝트 내용을 분석하고 제안서 초안을 작성하고 있습니다. 잠시만 기다려주세요.
+                                        </div>
+                                    </template>
+
+                                    <template x-if="aiBriefErrorMessage">
+                                        <div class="max-w-[92%] rounded-[24px] border border-red-100 bg-red-50 px-5 py-4 text-sm leading-7 text-red-700"
+                                             x-text="aiBriefErrorMessage"></div>
+                                    </template>
                                 </div>
                             </div>
 
@@ -113,12 +124,15 @@
                                     <textarea id="draftInput"
                                               x-model="draftInput"
                                               rows="2"
+                                              :disabled="aiBriefLoading"
                                               placeholder="예: 온라인 쇼핑몰 앱을 만들고 싶어요. 결제와 관리자 화면이 필요합니다."
-                                              class="min-h-[72px] flex-1 rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100"></textarea>
+                                              class="min-h-[72px] flex-1 rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"></textarea>
                                     <button type="button"
                                             @click="sendPrompt()"
-                                            class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-950 text-white transition hover:bg-slate-800">
-                                        <i data-lucide="send" class="h-4 w-4"></i>
+                                            :disabled="aiBriefLoading"
+                                            class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-950 text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400">
+                                        <i x-show="!aiBriefLoading" data-lucide="send" class="h-4 w-4"></i>
+                                        <i x-show="aiBriefLoading" x-cloak data-lucide="loader-circle" class="h-4 w-4 animate-spin"></i>
                                     </button>
                                 </div>
                                 <p th:if="${#fields.hasErrors('rawInputText')}"
@@ -678,6 +692,12 @@
                     this.currentPosition = this.blankPosition();
                     this.loaded = true;
                     this.refreshIcons();
+
+                    if (this.aiBriefRequested && bootstrap.proposalId) {
+                        this.$nextTick(() => {
+                            this.generateAiBrief();
+                        });
+                    }
                 },
 
                 toggleChat() {
@@ -693,21 +713,17 @@
                     this.rawInputText = this.appendRawInput(this.rawInputText, this.draftInput);
                     this.draftInput = '';
                     this.aiBriefNoticeMessage = '프로젝트 원본 입력을 저장했습니다. 기존 입력값은 AI 결과로 갱신될 수 있습니다.';
+                    this.aiBriefErrorMessage = '';
 
                     if (!this.title || !this.title.trim()) {
                         this.title = 'AI 브리프 작성 중';
                     }
 
-                    if (bootstrap.isNew) {
-                        this.aiBriefRequested = true;
-                        this.submitAction = 'save';
-                        this.$nextTick(() => {
-                            this.$root.requestSubmit();
-                        });
-                        return;
-                    }
-
-                    this.refreshIcons();
+                    this.aiBriefRequested = true;
+                    this.submitAction = 'save';
+                    this.$nextTick(() => {
+                        this.$root.requestSubmit();
+                    });
                 },
 
                 appendRawInput(current, input) {
@@ -722,6 +738,61 @@
                     }
 
                     return `${current.trim()}\n${line}`;
+                },
+
+                async generateAiBrief() {
+                    if (!bootstrap.proposalId || this.aiBriefLoading) {
+                        return;
+                    }
+
+                    this.aiBriefLoading = true;
+                    this.aiBriefErrorMessage = '';
+                    this.aiBriefNoticeMessage = 'AI가 제안서 초안을 생성하고 있습니다. 기존 입력값은 AI 결과로 갱신될 수 있습니다.';
+                    this.refreshIcons();
+
+                    try {
+                        const response = await fetch(`/proposals/${bootstrap.proposalId}/ai-brief`, {
+                            method: 'POST',
+                            headers: {
+                                ...this.csrfHeaders(),
+                                'Accept': 'application/json'
+                            }
+                        });
+
+                        if (!response.ok) {
+                            throw new Error(await this.extractErrorMessage(response));
+                        }
+
+                        this.aiBriefNoticeMessage = 'AI 브리프가 제안서에 반영되었습니다. 자동 채움 결과를 불러옵니다.';
+                        window.location.replace(`/proposals/${bootstrap.proposalId}/edit`);
+                    } catch (error) {
+                        this.aiBriefErrorMessage = error.message || 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                        this.aiBriefNoticeMessage = '';
+                        this.aiBriefRequested = false;
+                    } finally {
+                        this.aiBriefLoading = false;
+                        this.refreshIcons();
+                    }
+                },
+
+                csrfHeaders() {
+                    const token = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
+                    const header = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content') || 'X-CSRF-TOKEN';
+
+                    if (!token) {
+                        return {};
+                    }
+
+                    return { [header]: token };
+                },
+
+                async extractErrorMessage(response) {
+                    try {
+                        const data = await response.json();
+                        return data.message || data.error || 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                    } catch (error) {
+                        return 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                    }
                 },
 
                 openAddPosition() {

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="_csrf" th:content="${_csrf != null ? _csrf.token : ''}">
+    <meta name="_csrf_header" th:content="${_csrf != null ? _csrf.headerName : 'X-CSRF-TOKEN'}">
     <title layout:title-pattern="$LAYOUT_TITLE | $CONTENT_TITLE">IT-da</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -220,6 +220,8 @@ class ProposalControllerTest {
         given(positionRepository.findAll(any(Sort.class)))
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+        given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
+                .willReturn(ProposalForm.from(proposal));
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
@@ -253,6 +255,8 @@ class ProposalControllerTest {
         given(positionRepository.findAll(any(Sort.class)))
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+        given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
+                .willReturn(ProposalForm.from(proposal));
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
@@ -271,6 +275,35 @@ class ProposalControllerTest {
                 .andExpect(model().attribute("proposalId", 1L))
                 .andExpect(model().attribute("isNew", false))
                 .andExpect(model().attribute("aiBriefRequested", true));
+    }
+
+    @Test
+    @DisplayName("수정 화면에서 AI 브리프 요청과 함께 임시저장하면 자동 생성 요청 파라미터를 유지한다")
+    void updateDraftAndRedirectToEditWithAiBriefRequested() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(proposalService.saveDraft(any(Long.class), anyString(), any(ProposalForm.class))).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("aiBriefRequested", "true")
+                        .param("title", "AI 브리프 작성 중")
+                        .param("rawInputText", "- 온라인 쇼핑몰 앱을 만들고 싶습니다."))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1/edit?aiBriefRequested=true"));
+
+        then(proposalService).should().saveDraft(any(Long.class), anyString(), any(ProposalForm.class));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -70,7 +70,8 @@ class ProposalControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
                 .andExpect(model().attributeExists("proposalForm", "positionOptions", "workTypes"))
-                .andExpect(model().attribute("isNew", true));
+                .andExpect(model().attribute("isNew", true))
+                .andExpect(model().attribute("aiBriefRequested", false));
     }
 
     @Test
@@ -97,6 +98,35 @@ class ProposalControllerTest {
                         .param("rawInputText", ""))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/proposals/1/edit"));
+
+        then(proposalService).should().saveDraft(anyString(), any(ProposalForm.class));
+    }
+
+    @Test
+    @DisplayName("AI 브리프 요청과 함께 임시저장하면 수정 화면에서 자동 생성을 요청한다")
+    void saveDraftAndRedirectToEditWithAiBriefRequested() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(proposalService.saveDraft(anyString(), any(ProposalForm.class))).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/new")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("aiBriefRequested", "true")
+                        .param("title", "AI 브리프 작성 중")
+                        .param("rawInputText", "- 온라인 쇼핑몰 앱을 만들고 싶습니다."))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1/edit?aiBriefRequested=true"));
 
         then(proposalService).should().saveDraft(anyString(), any(ProposalForm.class));
     }
@@ -157,10 +187,12 @@ class ProposalControllerTest {
                         .with(csrf())
                         .param("submitAction", "register")
                         .param("title", "쇼핑몰 앱 개발")
-                        .param("rawInputText", ""))
+                        .param("rawInputText", "")
+                        .param("aiBriefRequested", "true"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
-                .andExpect(model().attributeHasErrors("proposalForm"));
+                .andExpect(model().attributeHasErrors("proposalForm"))
+                .andExpect(model().attribute("aiBriefRequested", true));
 
         then(proposalService).should(never()).register(anyString(), any(ProposalForm.class));
     }
@@ -202,7 +234,43 @@ class ProposalControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
                 .andExpect(model().attributeExists("proposalForm"))
-                .andExpect(model().attribute("isNew", false));
+                .andExpect(model().attribute("isNew", false))
+                .andExpect(model().attribute("aiBriefRequested", false));
+    }
+
+    @Test
+    @DisplayName("AI 브리프 요청 파라미터가 있으면 수정 화면 모델에 전달한다")
+    void renderEditFormWithAiBriefRequested() throws Exception {
+        Proposal proposal = Proposal.create(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678"),
+                "AI 브리프 작성 중",
+                "- 온라인 쇼핑몰 앱을 만들고 싶습니다.",
+                "",
+                null,
+                null,
+                null
+        );
+        given(positionRepository.findAll(any(Sort.class)))
+                .willReturn(List.of(Position.create("백엔드 개발자")));
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/1/edit")
+                        .param("aiBriefRequested", "true")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalForm"))
+                .andExpect(model().attributeExists("proposalForm"))
+                .andExpect(model().attribute("proposalId", 1L))
+                .andExpect(model().attribute("isNew", false))
+                .andExpect(model().attribute("aiBriefRequested", true));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -41,8 +41,8 @@ class AiBriefProposalMapperTest {
     private AiBriefProposalMapper aiBriefProposalMapper;
 
     @Test
-    @DisplayName("AI 브리프를 적용하면 제안서 기본 정보가 바뀌고 기존 모집 단위는 새 결과로 교체된다")
-    void apply_updatesProposalFieldsAndReplacesPositions() {
+    @DisplayName("AI 브리프를 적용하면 제안서 기본 정보가 바뀌고 AI 결과 기준으로 모집 단위가 동기화된다")
+    void apply_updatesProposalFieldsAndSynchronizesPositionsByAiResult() {
         Proposal proposal = createProposal();
         Position oldPosition = Position.create("디자이너");
         Skill oldSkill = Skill.create("Figma", null);
@@ -96,17 +96,183 @@ class AiBriefProposalMapperTest {
         assertThat(proposal.getTotalBudgetMax()).isEqualTo(8_000_000L);
         assertThat(proposal.getExpectedPeriod()).isEqualTo(12L);
         assertThat(proposal.getPositions()).hasSize(1);
-        assertThat(proposal.getPositions().get(0).getPosition().getName()).isEqualTo("백엔드 개발자");
-        assertThat(proposal.getPositions().get(0).getTitle()).isEqualTo("Node.js 백엔드 개발자");
-        assertThat(proposal.getPositions().get(0).getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
-        assertThat(proposal.getPositions().get(0).getExpectedPeriod()).isEqualTo(12L);
-        assertThat(proposal.getPositions().get(0).getCareerMinYears()).isEqualTo(3);
-        assertThat(proposal.getPositions().get(0).getCareerMaxYears()).isEqualTo(6);
-        assertThat(proposal.getPositions().get(0).getWorkPlace()).isEqualTo("판교");
-        assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
-        assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill().getName()).isEqualTo("Java");
-        assertThat(proposal.getPositions().get(0).getSkills().get(0).getImportance())
+
+        ProposalPosition backendPosition = findProposalPosition(proposal, "백엔드 개발자");
+        assertThat(backendPosition.getTitle()).isEqualTo("Node.js 백엔드 개발자");
+        assertThat(backendPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(backendPosition.getExpectedPeriod()).isEqualTo(12L);
+        assertThat(backendPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(backendPosition.getCareerMaxYears()).isEqualTo(6);
+        assertThat(backendPosition.getWorkPlace()).isEqualTo("판교");
+        assertThat(backendPosition.getSkills()).hasSize(1);
+        assertThat(backendPosition.getSkills().get(0).getSkill().getName()).isEqualTo("Java");
+        assertThat(backendPosition.getSkills().get(0).getImportance())
                 .isEqualTo(ProposalPositionSkillImportance.PREFERENCE);
+    }
+
+    @Test
+    @DisplayName("AI 브리프가 기존 직무를 다시 제안하면 기존 모집 단위를 업데이트한다")
+    void apply_updatesExistingPositionWhenPositionNameMatches() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+        Skill oldSkill = Skill.create("Spring", null);
+        Skill newSkill = Skill.create("Java", null);
+        ProposalPosition existingPosition = proposal.addPosition(
+                backend,
+                "기존 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        existingPosition.addSkill(oldSkill, ProposalPositionSkillImportance.ESSENTIAL);
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(skillRepository.findByName("Java")).willReturn(Optional.of(newSkill));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                8L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.HYBRID,
+                                2L,
+                                3_000_000L,
+                                4_000_000L,
+                                8L,
+                                3,
+                                6,
+                                "판교",
+                                List.of(AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL))
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getPositions()).hasSize(1);
+        ProposalPosition updatedPosition = proposal.getPositions().get(0);
+        assertThat(updatedPosition).isSameAs(existingPosition);
+        assertThat(updatedPosition.getPosition()).isSameAs(backend);
+        assertThat(updatedPosition.getTitle()).isEqualTo("플랫폼 백엔드 개발자");
+        assertThat(updatedPosition.getWorkType()).isEqualTo(ProposalWorkType.HYBRID);
+        assertThat(updatedPosition.getHeadCount()).isEqualTo(2L);
+        assertThat(updatedPosition.getUnitBudgetMin()).isEqualTo(3_000_000L);
+        assertThat(updatedPosition.getUnitBudgetMax()).isEqualTo(4_000_000L);
+        assertThat(updatedPosition.getExpectedPeriod()).isEqualTo(8L);
+        assertThat(updatedPosition.getCareerMinYears()).isEqualTo(3);
+        assertThat(updatedPosition.getCareerMaxYears()).isEqualTo(6);
+        assertThat(updatedPosition.getWorkPlace()).isEqualTo("판교");
+        assertThat(updatedPosition.getSkills())
+                .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())
+                .containsExactly(tuple("Java", ProposalPositionSkillImportance.ESSENTIAL));
+    }
+
+    @Test
+    @DisplayName("AI 브리프가 기존 스킬을 다시 제안하면 중복 추가하지 않고 중요도만 갱신한다")
+    void apply_updatesExistingSkillImportanceWithoutDuplicatingSkill() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+        Skill java = Skill.create("Java", null);
+
+        ProposalPosition existingPosition = proposal.addPosition(
+                backend,
+                "기존 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        existingPosition.addSkill(java, ProposalPositionSkillImportance.PREFERENCE);
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(skillRepository.findByName("Java")).willReturn(Optional.of(java));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                8L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                null,
+                                null,
+                                8L,
+                                null,
+                                null,
+                                null,
+                                List.of(AiBriefSkillResult.of("Java", ProposalPositionSkillImportance.ESSENTIAL))
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        ProposalPosition updatedPosition = proposal.getPositions().get(0);
+        assertThat(updatedPosition.getSkills()).hasSize(1);
+        assertThat(updatedPosition.getSkills())
+                .extracting(skill -> skill.getSkill().getName(), skill -> skill.getImportance())
+                .containsExactly(tuple("Java", ProposalPositionSkillImportance.ESSENTIAL));
+    }
+
+    @Test
+    @DisplayName("AI 브리프 포지션 필수값이 비어 있으면 기본값으로 보정한다")
+    void apply_fillsDefaultRequiredPositionFieldsWhenAiOmitsThem() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                null,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "백엔드 개발자",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getPositions()).hasSize(1);
+        ProposalPosition proposalPosition = proposal.getPositions().get(0);
+        assertThat(proposalPosition.getPosition()).isSameAs(backend);
+        assertThat(proposalPosition.getTitle()).isEqualTo("백엔드 개발자");
+        assertThat(proposalPosition.getWorkType()).isEqualTo(ProposalWorkType.REMOTE);
+        assertThat(proposalPosition.getHeadCount()).isEqualTo(1L);
+        assertThat(proposalPosition.getWorkPlace()).isNull();
     }
 
     @Test
@@ -213,6 +379,13 @@ class AiBriefProposalMapperTest {
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill()).isSameAs(java);
         then(positionRepository).should(never()).save(any(Position.class));
         then(skillRepository).should(never()).save(any(Skill.class));
+    }
+
+    private ProposalPosition findProposalPosition(Proposal proposal, String positionName) {
+        return proposal.getPositions().stream()
+                .filter(proposalPosition -> proposalPosition.getPosition().getName().equals(positionName))
+                .findFirst()
+                .orElseThrow();
     }
 
     private Proposal createProposal() {


### PR DESCRIPTION
## 🔎 What

- AI 인터뷰 위젯 입력값을 `rawInputText`에 반영
- AI 브리프 생성 API 호출 연결
- 생성 중 loading 상태 표시
- 실패 시 에러 메시지 표시
- `AiBriefResult`를 제안서 폼 상태에 반영
- 제목, 설명, 예상 기간 자동 채움
- 포지션 목록 자동 채움
- 포지션별 직무, 제목, 근무 형태, 근무지, 인원, 예산, 경력, 기술 스택 반영
- 자동 채움 이후 사용자가 직접 수정할 수 있도록 유지
- 신규 제안서 작성 화면에서 `proposalId`가 없을 때의 처리 방식 정리
- 수동 검증 또는 테스트 보강

## 🔗 Issue

- Closes: #66 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?