### PR TITLE
[Feat] 클라이언트 대시보드 필터 탭 AJAX 전환으로 UX 개선

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ClientDashboardController.java
+++ b/src/main/java/com/generic4/itda/controller/ClientDashboardController.java
@@ -32,4 +32,19 @@ public class ClientDashboardController {
 
         return "client/dashboard";
     }
+
+    /** AJAX 탭 전환 — listSection fragment만 반환 */
+    @GetMapping("/client/dashboard/items")
+    public String dashboardItems(
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            @RequestParam(name = "filter", required = false) String filter,
+            Model model
+    ) {
+        ClientDashboardFilter selectedFilter = ClientDashboardFilter.from(filter);
+        ClientDashboardViewModel dashboard = clientDashboardService.getDashboard(principal.getEmail(), selectedFilter);
+
+        model.addAttribute("dashboard", dashboard);
+
+        return "client/dashboard :: #listSection";
+    }
 }

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -4,6 +4,9 @@
       layout:decorate="~{layout/base}">
 <head>
     <title>클라이언트 대시보드</title>
+    <style>
+        @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
 </head>
 <body>
 <div layout:fragment="content">
@@ -53,10 +56,11 @@
                      style="transition-delay: 80ms;">
                 <a th:each="summary : ${dashboard.summaries}"
                    th:href="@{/client/dashboard(filter=${summary.filterKey})}"
+                   th:attr="data-filter=${summary.filterKey}"
                    th:classappend="${summary.selected}
-                                   ? 'border-blue-200 bg-blue-50/50 shadow-lg shadow-blue-100/60'
+                                   ? 'border-blue-200 bg-blue-50/50 shadow-lg shadow-blue-100/60 tab-active'
                                    : 'border-slate-200 bg-white hover:-translate-y-0.5 hover:border-slate-300'"
-                   class="rounded-[28px] border p-6 transition-all">
+                   class="filter-tab rounded-[28px] border p-6 transition-all">
                     <div class="flex h-14 w-14 items-center justify-center rounded-3xl"
                          th:classappend="${summary.selected} ? 'bg-blue-600 text-white' : 'bg-slate-100 text-slate-400'">
                         <i th:attr="data-lucide=${
@@ -76,7 +80,8 @@
                 </a>
             </section>
 
-            <section class="fade-up overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70"
+            <section id="listSection"
+                     class="fade-up overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70"
                      x-show="loaded"
                      x-transition.enter
                      style="transition-delay: 140ms;">
@@ -174,6 +179,106 @@
             </section>
         </div>
     </main>
+
+    <script th:fragment="dashboardScript">
+    (function () {
+        var isLoading = false;
+
+        function setTabActive(filterKey) {
+            document.querySelectorAll('.filter-tab').forEach(function (tab) {
+                var isActive = tab.dataset.filter === filterKey;
+                tab.classList.toggle('border-blue-200', isActive);
+                tab.classList.toggle('bg-blue-50/50', isActive);
+                tab.classList.toggle('shadow-lg', isActive);
+                tab.classList.toggle('shadow-blue-100/60', isActive);
+                tab.classList.toggle('tab-active', isActive);
+                tab.classList.toggle('border-slate-200', !isActive);
+                tab.classList.toggle('bg-white', !isActive);
+                tab.classList.toggle('hover:-translate-y-0.5', !isActive);
+                tab.classList.toggle('hover:border-slate-300', !isActive);
+
+                var icon = tab.querySelector('div:first-child');
+                if (icon) {
+                    icon.classList.toggle('bg-blue-600', isActive);
+                    icon.classList.toggle('text-white', isActive);
+                    icon.classList.toggle('bg-slate-100', !isActive);
+                    icon.classList.toggle('text-slate-400', !isActive);
+                }
+            });
+        }
+
+        function showSpinner(listSection) {
+            listSection.style.pointerEvents = 'none';
+            listSection.style.position = 'relative';
+
+            var overlay = document.createElement('div');
+            overlay.id = 'listSectionSpinner';
+            overlay.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:10;background:rgba(255,255,255,0.6);border-radius:inherit;';
+            overlay.innerHTML = '<div style="width:40px;height:40px;border-radius:50%;border:4px solid #e2e8f0;border-top-color:#2563eb;animation:spin 0.7s linear infinite;"></div>';
+            listSection.appendChild(overlay);
+        }
+
+        function loadItems(filterKey, pushState) {
+            if (isLoading) return;
+            var listSection = document.getElementById('listSection');
+            if (!listSection) return;
+
+            isLoading = true;
+
+            // 200ms 안에 응답이 오면 스피너를 띄우지 않음
+            var spinnerTimer = setTimeout(function () {
+                var section = document.getElementById('listSection');
+                if (section) showSpinner(section);
+            }, 200);
+
+            var url = '/client/dashboard/items' + (filterKey && filterKey !== 'all' ? '?filter=' + filterKey : '');
+
+            fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                .then(function (r) { return r.text(); })
+                .then(function (html) {
+                    var tmp = document.createElement('div');
+                    tmp.innerHTML = html;
+                    var next = tmp.querySelector('#listSection') || tmp.firstElementChild;
+                    if (next) {
+                        listSection.replaceWith(next);
+                        if (window.lucide) lucide.createIcons();
+                    }
+                    setTabActive(filterKey || 'all');
+
+                    if (pushState) {
+                        var stateUrl = '/client/dashboard' + (filterKey && filterKey !== 'all' ? '?filter=' + filterKey : '');
+                        history.pushState({ filter: filterKey }, '', stateUrl);
+                    }
+                })
+                .catch(function (err) { console.error('대시보드 로드 오류', err); })
+                .finally(function () {
+                    clearTimeout(spinnerTimer);
+                    isLoading = false;
+                    var section = document.getElementById('listSection');
+                    if (section) {
+                        section.style.pointerEvents = '';
+                        section.style.position = '';
+                    }
+                });
+        }
+
+        // 탭 클릭 이벤트
+        document.addEventListener('click', function (e) {
+            var tab = e.target.closest('.filter-tab');
+            if (!tab) return;
+            e.preventDefault();
+            if (tab.classList.contains('tab-active')) return; // 이미 선택된 탭은 재요청 안 함
+            loadItems(tab.dataset.filter, true);
+        });
+
+        // 브라우저 뒤로가기/앞으로가기
+        window.addEventListener('popstate', function (e) {
+            var filter = (e.state && e.state.filter) || 'all';
+            loadItems(filter, false);
+            setTabActive(filter);
+        });
+    })();
+    </script>
 </div>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/ClientDashboardControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ClientDashboardControllerTest.java
@@ -85,6 +85,39 @@ class ClientDashboardControllerTest {
     }
 
     @Test
+    @DisplayName("AJAX 요청 시 listSection fragment만 반환한다")
+    void dashboardItems_returnsListSectionFragment() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+        ClientDashboardViewModel dashboard = new ClientDashboardViewModel(
+                "waiting",
+                "매칭 대기 중",
+                List.of(
+                        new ClientDashboardSummaryItem("all", "전체 프로젝트", 6L, "전체", false),
+                        new ClientDashboardSummaryItem("waiting", "매칭 대기 중", 2L, "대기 중", true)
+                ),
+                List.of()
+        );
+        given(clientDashboardService.getDashboard("client@example.com", com.generic4.itda.dto.client.ClientDashboardFilter.WAITING))
+                .willReturn(dashboard);
+
+        mockMvc.perform(get("/client/dashboard/items")
+                        .param("filter", "waiting")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/dashboard :: #listSection"))
+                .andExpect(model().attribute("dashboard", dashboard));
+
+        then(clientDashboardService).should()
+                .getDashboard("client@example.com", com.generic4.itda.dto.client.ClientDashboardFilter.WAITING);
+    }
+
+    @Test
     @DisplayName("인증되지 않은 사용자는 로그인 페이지로 리다이렉트된다")
     void redirectToLoginWhenUnauthenticated() throws Exception {
         mockMvc.perform(get("/client/dashboard"))


### PR DESCRIPTION
## 🔎 What

- 필터 탭 클릭 시 전체 페이지 리로드 대신 AJAX 요청으로 목록만 갱신
- 서버에서 목록 영역(listSection) fragment만 반환하는 엔드포인트 확인 또는 추가
- 탭 전환 시 URL은 ?filter=waiting 형태로 유지 (브라우저 뒤로가기 대응)
- 활성 탭 상태 UI 동기화 (선택된 탭 하이라이트)
- 로딩 중 UX 처리 (스피너 또는 스켈레톤)

## 🔗 Issue

- Closes: #71

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?