### PR TITLE
[Feat] HEURISTIC_V1 스코어링 구현

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
@@ -1,8 +1,10 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResumeEmbeddingRepository extends JpaRepository<ResumeEmbedding, Long> {
 
+    List<ResumeEmbedding> findAllByResume_IdInAndEmbeddingModel(List<Long> resumeIds, String embeddingModel);
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculator.java
@@ -1,0 +1,33 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CareerAdjustmentCalculator {
+
+    private static final double IN_RANGE_BONUS = 0.08;
+    private static final double MIN_SHORTAGE_UNIT_PENALTY = 0.04;
+    private static final double MAX_EXCESS_UNIT_PENALTY = 0.02;
+    private static final double MIN_SHORTAGE_MAX_PENALTY = -0.12;
+    private static final double MAX_EXCESS_MAX_PENALTY = -0.06;
+
+    public double calculate(int candidateCareerYears, Integer careerMinYears, Integer careerMaxYears) {
+        if (careerMinYears == null && careerMaxYears == null) {
+            return 0.0;
+        }
+
+        if (careerMinYears != null && candidateCareerYears < careerMinYears) {
+            int shortage = careerMinYears - candidateCareerYears;
+            double penalty = -(shortage * MIN_SHORTAGE_UNIT_PENALTY);
+            return Math.max(MIN_SHORTAGE_MAX_PENALTY, penalty);
+        }
+
+        if (careerMaxYears != null && candidateCareerYears > careerMaxYears) {
+            int excess = candidateCareerYears - careerMaxYears;
+            double penalty = -(excess * MAX_EXCESS_UNIT_PENALTY);
+            return Math.max(MAX_EXCESS_MAX_PENALTY, penalty);
+        }
+
+        return IN_RANGE_BONUS;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
@@ -31,7 +31,7 @@ public class CosineSimilarityCalculator {
 
     private void validate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
         if (queryEmbedding == null || targetEmbedding == null) {
-            throw new IllegalArgumentException("embedding 은 null 일 수 업습니다.");
+            throw new IllegalArgumentException("embedding 은 null 일 수 없습니다.");
         }
         if (queryEmbedding.isEmpty() || targetEmbedding.isEmpty()) {
             throw new IllegalArgumentException("embedding 은 비어 있을 수 없습니다.");

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
@@ -1,0 +1,43 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CosineSimilarityCalculator {
+
+    public double calculate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
+        validate(queryEmbedding, targetEmbedding);
+
+        double dotProduct = 0.0;
+        double queryNorm = 0.0;
+        double targetNorm = 0.0;
+
+        for (int i = 0; i < queryEmbedding.size(); i++) {
+            double q = queryEmbedding.get(i);
+            double t = targetEmbedding.get(i);
+
+            dotProduct += q * t;
+            queryNorm += q * q;
+            targetNorm += t * t;
+        }
+
+        if (queryNorm == 0.0 || targetNorm == 0.0) {
+            return 0.0;
+        }
+
+        return dotProduct / (Math.sqrt(queryNorm) * Math.sqrt(targetNorm));
+    }
+
+    private void validate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
+        if (queryEmbedding == null || targetEmbedding == null) {
+            throw new IllegalArgumentException("embedding 은 null 일 수 업습니다.");
+        }
+        if (queryEmbedding.isEmpty() || targetEmbedding.isEmpty()) {
+            throw new IllegalArgumentException("embedding 은 비어 있을 수 없습니다.");
+        }
+        if (queryEmbedding.size() != targetEmbedding.size()) {
+            throw new IllegalArgumentException("embedding 차원이 다릅니다.");
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -1,0 +1,125 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+@RequiredArgsConstructor
+public class HeuristicV1RecommendationScorer {
+
+    private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
+    private final QueryEmbeddingGenerator queryEmbeddingGenerator;
+    private final ResumeEmbeddingReader resumeEmbeddingReader;
+    private final CosineSimilarityCalculator cosineSimilarityCalculator;
+    private final SkillAdjustmentCalculator skillAdjustmentCalculator;
+    private final CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    public List<ScoredCandidate> score(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<RecommendationScorableCandidate> candidates,
+            String embeddingModel
+    ) {
+        Assert.notNull(proposal, "proposal은 필수입니다.");
+        Assert.notNull(proposalPosition, "proposalPosition은 필수입니다.");
+        Assert.notNull(candidates, "candidates는 null일 수 없습니다.");
+
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String queryText = recommendationQueryTextGenerator.generate(
+                proposal,
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames
+        );
+
+        List<Double> queryEmbedding = queryEmbeddingGenerator.generate(queryText);
+
+        List<Long> resumeIds = candidates.stream()
+                .map(RecommendationScorableCandidate::resumeId)
+                .toList();
+
+        Map<Long, List<Double>> resumeEmbeddings =
+                resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, embeddingModel);
+
+        return candidates.stream()
+                .filter(candidate -> resumeEmbeddings.containsKey(candidate.resumeId()))
+                .map(candidate -> scoredCandidate(
+                        candidate,
+                        proposalPosition,
+                        requiredSkillNames,
+                        preferredSkillNames,
+                        queryEmbedding,
+                        resumeEmbeddings.get(candidate.resumeId())
+                ))
+                .sorted(Comparator.comparingDouble(
+                        (ScoredCandidate scoredCandidate) -> scoredCandidate.scoreBreakdown().finalScore()
+                ).reversed())
+                .toList();
+    }
+
+    private ScoredCandidate scoredCandidate(
+            RecommendationScorableCandidate candidate,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<Double> queryEmbedding,
+            List<Double> resumeEmbedding
+    ) {
+        double rawCosineSimilarity = cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding);
+        double embeddingScore = normalizeCosineSimilarity(rawCosineSimilarity);
+
+        double skillAdjustmentScore = skillAdjustmentCalculator.calculate(
+                requiredSkillNames,
+                preferredSkillNames,
+                candidate.ownedSkillNames()
+        );
+
+        double careerAdjustmentScore = careerAdjustmentCalculator.calculate(
+                candidate.careerYears(),
+                proposalPosition.getCareerMinYears(),
+                proposalPosition.getCareerMaxYears()
+        );
+
+        double finalScore = clampScore(embeddingScore + skillAdjustmentScore + careerAdjustmentScore);
+
+        return new ScoredCandidate(
+                candidate,
+                new ScoreBreakdown(
+                        embeddingScore,
+                        skillAdjustmentScore,
+                        careerAdjustmentScore,
+                        finalScore
+                )
+        );
+    }
+
+    private double normalizeCosineSimilarity(double rawCosineSimilarity) {
+        return (rawCosineSimilarity + 1) / 2.0;
+    }
+
+    private double clampScore(double value) {
+        if (value < 0.0) {
+            return 0.0;
+        }
+        if (value > 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/QueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/QueryEmbeddingGenerator.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+
+public interface QueryEmbeddingGenerator {
+
+    List<Double> generate(String queryText);
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGenerator.java
@@ -1,0 +1,106 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * 임베딩용 문자열 생성기
+ */
+@Component
+public class RecommendationQueryTextGenerator {
+
+    public String generate(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames
+    ) {
+        Set<String> required = safeSet(requiredSkillNames);
+        Set<String> preferred = normalizePreferredSkills(required, preferredSkillNames);
+
+        String positionName = extractPositionName(proposalPosition.getPosition());
+        String workType = proposalPosition.getWorkType() == null ? "" : proposalPosition.getWorkType().name();
+        String careerRange = buildCareerRange(
+                proposalPosition.getCareerMinYears(),
+                proposalPosition.getCareerMaxYears()
+        );
+
+        String requiredSkillsText = joinSkills(required);
+        String preferredSkillsText = joinSkills(preferred);
+
+        String title = normalizeText(proposal.getTitle());
+        String description = normalizeText(proposal.getDescription());
+
+        return """
+                position: %s
+                workType: %s
+                career: %s
+                required skills: %s
+                preferred skills: %s
+                title: %s
+                description: %s
+                """.formatted(
+                positionName,
+                workType,
+                careerRange,
+                requiredSkillsText,
+                preferredSkillsText,
+                title,
+                description
+        ).trim();
+    }
+
+    private Set<String> safeSet(Set<String> skills) {
+        return skills == null ? Collections.emptySet() : skills;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> required, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(Predicate.not(required::contains))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private String extractPositionName(Position position) {
+        if (position == null || position.getName() == null) {
+            return "";
+        }
+        return position.getName();
+    }
+
+    private String buildCareerRange(Integer minYears, Integer maxYears) {
+        if (minYears == null && maxYears == null) {
+            return "";
+        }
+        if (minYears != null && maxYears != null) {
+            return minYears + "~" + maxYears + " years";
+        }
+        if (minYears != null) {
+            return minYears + "+ years";
+        }
+        return "up to " + maxYears + " years";
+    }
+
+    private String joinSkills(Set<String> skills) {
+        if (skills == null) {
+            return "";
+        }
+
+        return skills.stream()
+                .map(this::normalizeText)
+                .sorted(Comparator.naturalOrder())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String normalizeText(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReader.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReader.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ResumeEmbeddingReader {
+
+    Map<Long, List<Double>> readEmbeddingsByResumeIds(List<Long> resumeIds, String embeddingModel);
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.service.recommend.scoring;
 
-import com.generic4.itda.domain.recommendation.ResumeEmbedding;
 import com.generic4.itda.repository.ResumeEmbeddingRepository;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +23,10 @@ public class ResumeEmbeddingReaderImpl implements ResumeEmbeddingReader {
             return Collections.emptyMap();
         }
 
-        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, embeddingModel).stream()
+        String normalizedEmbeddingModel = embeddingModel.trim();
+
+        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, normalizedEmbeddingModel)
+                .stream()
                 .collect(Collectors.toMap(
                         embedding -> embedding.getResume().getId(),
                         embedding -> embedding.getEmbeddingVector().values()

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
@@ -1,0 +1,33 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+@RequiredArgsConstructor
+public class ResumeEmbeddingReaderImpl implements ResumeEmbeddingReader {
+
+    private final ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    @Override
+    public Map<Long, List<Double>> readEmbeddingsByResumeIds(List<Long> resumeIds, String embeddingModel) {
+        Assert.hasText(embeddingModel, "임베딩 모델명은 필수입니다.");
+
+        if (resumeIds == null || resumeIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, embeddingModel).stream()
+                .collect(Collectors.toMap(
+                        embedding -> embedding.getResume().getId(),
+                        embedding -> embedding.getEmbeddingVector().values()
+                ));
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
@@ -1,0 +1,75 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SkillAdjustmentCalculator {
+
+    private static final double REQUIRED_MAX_BONUS = 0.15;
+    private static final double REQUIRED_MIN_BONUS = -0.15;
+    private static final double PREFERRED_MAX_BONUS = 0.05;
+
+    public double calculate(
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            Set<String> ownedSkillNames
+    ) {
+        Set<String> required = safeSet(requiredSkillNames);
+        Set<String> preferred = normalizePreferredSkills(required, preferredSkillNames);
+        Set<String> owned = safeSet(ownedSkillNames);
+
+        double requiredAdjustment = calculateRequiredAdjustment(required, owned);
+        double preferredAdjustment = calculatePreferredAdjustment(preferred, owned);
+
+        return requiredAdjustment + preferredAdjustment;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(skillName -> !requiredSkillNames.contains(skillName))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private double calculateRequiredAdjustment(Set<String> requiredSkillNames, Set<String> ownedSkillNames) {
+        if (requiredSkillNames.isEmpty()) {
+            return 0.0;
+        }
+
+        long matchedCount = requiredSkillNames.stream()
+                .filter(ownedSkillNames::contains)
+                .count();
+
+        double matchRatio = (double) matchedCount / requiredSkillNames.size();
+        double adjustment = (matchRatio - 0.5) * 0.3;
+
+        if (adjustment > REQUIRED_MAX_BONUS) {
+            return REQUIRED_MIN_BONUS;
+        }
+        if (adjustment < REQUIRED_MIN_BONUS) {
+            return REQUIRED_MAX_BONUS;
+        }
+        return adjustment;
+    }
+
+    private double calculatePreferredAdjustment(Set<String> preferredSkillNames, Set<String> ownedSkillNames) {
+        if (preferredSkillNames.isEmpty()) {
+            return 0.0;
+        }
+
+        long matchCount = preferredSkillNames.stream()
+                .filter(ownedSkillNames::contains)
+                .count();
+
+        double matchRatio = (double) matchCount / preferredSkillNames.size();
+        return matchRatio * PREFERRED_MAX_BONUS;
+    }
+
+    private Set<String> safeSet(Set<String> skills) {
+        return skills == null ? Collections.emptySet() : skills;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class SkillAdjustmentCalculator {
 
+    private static final double REQUIRED_SKILL_NEUTRAL_MATCH_RATIO = 0.5;
+    private static final double REQUIRED_SKILL_ADJUSTMENT_WEIGHT = 0.3;
     private static final double REQUIRED_MAX_BONUS = 0.15;
-    private static final double REQUIRED_MIN_BONUS = -0.15;
+    private static final double REQUIRED_MIN_PENALTY = -0.15;
     private static final double PREFERRED_MAX_BONUS = 0.05;
 
     public double calculate(
@@ -27,14 +29,6 @@ public class SkillAdjustmentCalculator {
         return requiredAdjustment + preferredAdjustment;
     }
 
-    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
-        Set<String> preferred = safeSet(preferredSkillNames);
-
-        return preferred.stream()
-                .filter(skillName -> !requiredSkillNames.contains(skillName))
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
     private double calculateRequiredAdjustment(Set<String> requiredSkillNames, Set<String> ownedSkillNames) {
         if (requiredSkillNames.isEmpty()) {
             return 0.0;
@@ -45,13 +39,13 @@ public class SkillAdjustmentCalculator {
                 .count();
 
         double matchRatio = (double) matchedCount / requiredSkillNames.size();
-        double adjustment = (matchRatio - 0.5) * 0.3;
+        double adjustment = (matchRatio - REQUIRED_SKILL_NEUTRAL_MATCH_RATIO) * REQUIRED_SKILL_ADJUSTMENT_WEIGHT;
 
         if (adjustment > REQUIRED_MAX_BONUS) {
-            return REQUIRED_MIN_BONUS;
-        }
-        if (adjustment < REQUIRED_MIN_BONUS) {
             return REQUIRED_MAX_BONUS;
+        }
+        if (adjustment < REQUIRED_MIN_PENALTY) {
+            return REQUIRED_MIN_PENALTY;
         }
         return adjustment;
     }
@@ -71,5 +65,13 @@ public class SkillAdjustmentCalculator {
 
     private Set<String> safeSet(Set<String> skills) {
         return skills == null ? Collections.emptySet() : skills;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(skillName -> !requiredSkillNames.contains(skillName))
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StubQueryEmbeddingGenerator implements QueryEmbeddingGenerator {
+
+    @Override
+    public List<Double> generate(String queryText) {
+        throw new UnsupportedOperationException("쿼리 임베딩 생성은 별도 이슈에서 구현합니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+import java.util.Set;
+
+public record RecommendationScorableCandidate(
+        Long candidateId,
+        Long memberId,
+        Long resumeId,
+        int careerYears,
+        Set<String> ownedSkillNames
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoreBreakdown.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoreBreakdown.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+public record ScoreBreakdown(
+        double similarityScore,
+        double skillAdjustmentScore,
+        double careerAdjustmentScore,
+        double finalScore
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+public record ScoredCandidate(
+        RecommendationScorableCandidate candidate,
+        ScoreBreakdown scoreBreakdown
+) {
+
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
@@ -88,32 +88,32 @@ class ResumeEmbeddingRepositoryTest {
     }
 
     @Test
-    @DisplayName("같은 resume에서 다른 embeddingModel로 변경 후 flush하면 unique constraint 위반이 발생한다")
-    void 같은_resume에서_다른_embeddingModel로_변경_후_flush하면_unique_constraint_위반이_발생한다() {
+    @DisplayName("이력서 ID 목록과 모델명으로 임베딩을 조회한다")
+    void 이력서_ID_목록과_모델명으로_임베딩을_조회한다() {
         // given
-        ResumeEmbedding first = resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(
-                        resume, new SourceHash("hash001"), "text-embedding-3-small",
-                        new EmbeddingVector(List.of(0.1, 0.2))));
+        String model = "text-embedding-3-small";
         resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(
-                        resume, new SourceHash("hash002"), "text-embedding-3-large",
-                        new EmbeddingVector(List.of(0.3, 0.4))));
-        em.clear();
-
-        ResumeEmbedding found = resumeEmbeddingRepository.findById(first.getId()).orElseThrow();
+                ResumeEmbedding.create(resume, new SourceHash("hash1"), model, new EmbeddingVector(List.of(0.1, 0.2))));
+        
+        Member otherMember = memberRepository.save(createMember("other@test.com", "pass", "other", "010-1111-2222"));
+        Resume otherResume = resumeRepository.save(
+                Resume.create(otherMember, "자기소개입니다.", (byte) 5, new CareerPayload(),
+                        WorkType.SITE, ResumeWritingStatus.WRITING, null));
+        resumeEmbeddingRepository.saveAndFlush(
+                ResumeEmbedding.create(otherResume, new SourceHash("hash2"), model, new EmbeddingVector(List.of(0.3, 0.4))));
+        
+        resumeEmbeddingRepository.saveAndFlush(
+                ResumeEmbedding.create(resume, new SourceHash("hash3"), "other-model", new EmbeddingVector(List.of(0.5, 0.6))));
 
         // when
-        found.refresh(
-                new SourceHash("hash003"),
-                "text-embedding-3-large",
-                new EmbeddingVector(List.of(0.9, 0.8)));
+        List<ResumeEmbedding> results = resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(
+                List.of(resume.getId(), otherResume.getId()), model);
 
         // then
-        assertThatThrownBy(() -> {
-            resumeEmbeddingRepository.save(found);
-            resumeEmbeddingRepository.flush();
-        })
-                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(ResumeEmbedding::getEmbeddingModel)
+                .containsOnly(model);
+        assertThat(results).extracting(re -> re.getResume().getId())
+                .containsExactlyInAnyOrder(resume.getId(), otherResume.getId());
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculatorTest.java
@@ -1,0 +1,79 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("CareerAdjustmentCalculator 단위 테스트")
+class CareerAdjustmentCalculatorTest {
+
+    private final CareerAdjustmentCalculator calculator = new CareerAdjustmentCalculator();
+
+    @Test
+    @DisplayName("최소/최대 경력 요구사항이 모두 없을 경우 0.0을 반환한다.")
+    void calculate_WhenNoRequirements() {
+        // given
+        int candidateYears = 5;
+        Integer minYears = null;
+        Integer maxYears = null;
+
+        // when
+        double result = calculator.calculate(candidateYears, minYears, maxYears);
+
+        // then
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "5, 3, 7",  // 범위 중간
+            "3, 3, 7",  // 최소값 경계
+            "7, 3, 7",  // 최대값 경계
+            "5, 3, ",   // 최소값만 있고 충족
+            "5, , 7"    // 최대값만 있고 충족
+    })
+    @DisplayName("경력 요구사항 범위를 충족할 경우 보너스 점수(0.08)를 반환한다.")
+    void calculate_WhenInRange(int candidateYears, Integer minYears, Integer maxYears) {
+        // when
+        double result = calculator.calculate(candidateYears, minYears, maxYears);
+
+        // then
+        assertThat(result).isCloseTo(0.08, offset(1e-9));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "2, 3, -0.04", // 1년 부족
+            "1, 3, -0.08", // 2년 부족
+            "0, 3, -0.12", // 3년 부족 (최대 페널티)
+            "0, 5, -0.12"  // 5년 부족 (최대 페널티 캡핑)
+    })
+    @DisplayName("최소 경력보다 부족할 경우 연당 -0.04의 페널티를 부여하며 최대 -0.12까지 적용한다.")
+    void calculate_WhenBelowMin(int candidateYears, Integer minYears, double expected) {
+        // when
+        double result = calculator.calculate(candidateYears, minYears, 10);
+
+        // then
+        assertThat(result).isCloseTo(expected, offset(1e-9));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "6, 5, -0.02", // 1년 초과
+            "7, 5, -0.04", // 2년 초과
+            "8, 5, -0.06", // 3년 초과 (최대 페널티)
+            "10, 5, -0.06" // 5년 초과 (최대 페널티 캡핑)
+    })
+    @DisplayName("최대 경력보다 초과할 경우 연당 -0.02의 페널티를 부여하며 최대 -0.06까지 적용한다.")
+    void calculate_WhenAboveMax(int candidateYears, Integer maxYears, double expected) {
+        // when
+        double result = calculator.calculate(candidateYears, 0, maxYears);
+
+        // then
+        assertThat(result).isCloseTo(expected, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculatorTest.java
@@ -1,0 +1,119 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CosineSimilarityCalculatorTest {
+
+    private final CosineSimilarityCalculator calculator = new CosineSimilarityCalculator();
+
+    @DisplayName("동일한 두 벡터의 코사인 유사도는 1.0 이어야 한다")
+    @Test
+    void calculate_identicalVectors_returnsOne() {
+        // given
+        List<Double> query = List.of(1.0, 2.0, 3.0);
+        List<Double> target = List.of(1.0, 2.0, 3.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(1.0, offset(1e-9));
+    }
+
+    @DisplayName("서로 직교하는 두 벡터의 코사인 유사도는 0.0 이어야 한다")
+    @Test
+    void calculate_orthogonalVectors_returnsZero() {
+        // given
+        List<Double> query = List.of(1.0, 0.0);
+        List<Double> target = List.of(0.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(0.0, offset(1e-9));
+    }
+
+    @DisplayName("서로 다른 두 벡터의 코사인 유사도를 정확히 계산한다")
+    @Test
+    void calculate_differentVectors_returnsCorrectSimilarity() {
+        // given
+        // query: (1, 1), target: (0, 1)
+        // dotProduct: 1*0 + 1*1 = 1
+        // queryNorm: sqrt(1^2 + 1^2) = sqrt(2)
+        // targetNorm: sqrt(0^2 + 1^2) = 1
+        // similarity: 1 / (sqrt(2) * 1) = 1/sqrt(2) ≈ 0.707106781
+        List<Double> query = List.of(1.0, 1.0);
+        List<Double> target = List.of(0.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(1.0 / Math.sqrt(2.0), offset(1e-9));
+    }
+
+    @DisplayName("벡터 중 하나가 영벡터인 경우 유사도는 0.0 이어야 한다")
+    @Test
+    void calculate_withZeroVector_returnsZero() {
+        // given
+        List<Double> query = List.of(0.0, 0.0);
+        List<Double> target = List.of(1.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @DisplayName("입력 리스트가 null인 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_nullInput_throwsException() {
+        assertThatThrownBy(() -> calculator.calculate(null, List.of(1.0)))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> calculator.calculate(List.of(1.0), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("입력 리스트가 비어 있는 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_emptyInput_throwsException() {
+        assertThatThrownBy(() -> calculator.calculate(List.of(), List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("두 벡터의 차원이 다른 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_mismatchedDimensions_throwsException() {
+        // given
+        List<Double> query = List.of(1.0, 2.0);
+        List<Double> target = List.of(1.0, 2.0, 3.0);
+
+        // then
+        assertThatThrownBy(() -> calculator.calculate(query, target))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("코사인 유사도는 대칭성을 만족해야 한다")
+    @Test
+    void calculate_isSymmetric() {
+        // given
+        List<Double> a = List.of(1.0, 2.0, 3.0);
+        List<Double> b = List.of(4.0, 5.0, 6.0);
+
+        // when
+        double ab = calculator.calculate(a, b);
+        double ba = calculator.calculate(b, a);
+
+        // then
+        assertThat(ab).isCloseTo(ba, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -1,0 +1,280 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HeuristicV1RecommendationScorer 단위 테스트")
+class HeuristicV1RecommendationScorerTest {
+
+    @Mock
+    private RecommendationQueryTextGenerator recommendationQueryTextGenerator;
+
+    @Mock
+    private QueryEmbeddingGenerator queryEmbeddingGenerator;
+
+    @Mock
+    private ResumeEmbeddingReader resumeEmbeddingReader;
+
+    @Mock
+    private CosineSimilarityCalculator cosineSimilarityCalculator;
+
+    @Mock
+    private SkillAdjustmentCalculator skillAdjustmentCalculator;
+
+    @Mock
+    private CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    @Mock
+    private Proposal proposal;
+
+    @Mock
+    private ProposalPosition proposalPosition;
+
+    @InjectMocks
+    private HeuristicV1RecommendationScorer scorer;
+
+    private static final String EMBEDDING_MODEL = "text-embedding-3-small";
+
+    // -------------------------------------------------------------------------
+    // 공통 헬퍼
+    // -------------------------------------------------------------------------
+
+    private RecommendationScorableCandidate candidateWith(long candidateId, long memberId, long resumeId) {
+        return new RecommendationScorableCandidate(candidateId, memberId, resumeId, 3, Set.of("Java"));
+    }
+
+    private List<Double> dummyQueryEmbedding() {
+        return List.of(1.0, 0.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 1: 빈 후보 리스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("후보가 비어 있으면 빈 리스트를 반환한다")
+    void score_ReturnsEmptyList_WhenCandidatesIsEmpty() {
+        // given
+        List<RecommendationScorableCandidate> emptyCandidates = List.of();
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), emptyCandidates, EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).isEmpty();
+
+        verify(recommendationQueryTextGenerator, never()).generate(any(), any(), any(), any());
+        verify(queryEmbeddingGenerator, never()).generate(anyString());
+        verify(resumeEmbeddingReader, never()).readEmbeddingsByResumeIds(anyList(), anyString());
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 2: 이력서 임베딩이 없는 후보는 결과에서 제외
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("이력서 임베딩이 없는 후보는 결과에서 제외된다")
+    void score_ExcludesCandidate_WhenResumeEmbeddingIsMissing() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString()))
+                .willReturn(dummyQueryEmbedding());
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of()); // 임베딩 없음
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 3: finalScore 내림차순 정렬
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("최종 점수(finalScore) 내림차순으로 정렬한다")
+    void score_ReturnsCandidatesSortedByFinalScoreDescending() {
+        // given
+        RecommendationScorableCandidate candidateA = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidateB = candidateWith(2L, 20L, 200L);
+
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> embeddingA = List.of(1.0, 0.0);
+        List<Double> embeddingB = List.of(0.0, 1.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString()))
+                .willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, embeddingA, 200L, embeddingB));
+
+        // candidateA: rawCosine=0.6, skill=0.0, career=0.0 → finalScore=0.6
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, embeddingA)).willReturn(0.6);
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, embeddingB)).willReturn(0.3);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(),
+                List.of(candidateA, candidateB), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).scoreBreakdown().finalScore())
+                .isGreaterThan(result.get(1).scoreBreakdown().finalScore());
+        assertThat(result.get(0).candidate().resumeId()).isEqualTo(100L);
+        assertThat(result.get(1).candidate().resumeId()).isEqualTo(200L);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 4: raw cosine 정규화 → embeddingScore
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("raw cosine -1.0은 embeddingScore 0.0으로 정규화된다")
+    void score_NormalizesRawCosineMinusOne_ToZero() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.0, 1.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(-1.0);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().similarityScore()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("raw cosine 1.0은 embeddingScore 1.0으로 정규화된다")
+    void score_NormalizesRawCosinePlusOne_ToOne() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(1.0, 0.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(1.0);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().similarityScore()).isEqualTo(1.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 5: finalScore 상한 clamp → 1.0
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("embeddingScore와 보정치의 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
+    void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
+        // given — rawCosine(0.8) + skill(0.15) + career(0.08) = 1.03 → clamp 1.0
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.8, 0.2);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(0.8);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.15);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.08);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(1.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 6: finalScore 하한 clamp → 0.0
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("embeddingScore와 보정치의 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
+    void score_ClampsFinalScore_ToZeroWhenSumBelowZero() {
+        // given — rawCosine(-0.8) + skill(-0.15) + career(-0.12) = -1.07 → clamp 0.0
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(-0.8, 0.2);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(-0.8);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(-0.15);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(-0.12);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(0.0);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
@@ -1,0 +1,141 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.fixture.MemberFixture;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("RecommendationQueryTextGenerator 단위 테스트")
+class RecommendationQueryTextGeneratorTest {
+
+    private final RecommendationQueryTextGenerator generator = new RecommendationQueryTextGenerator();
+
+    @Test
+    @DisplayName("제안서 정보를 바탕으로 임베딩용 쿼리 텍스트를 생성한다.")
+    void generate_ReturnsFormattedText() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        ReflectionTestUtils.setField(position, "id", 1L);
+
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        Set<String> requiredSkills = Set.of("Java", "Spring");
+        Set<String> preferredSkills = Set.of("AWS", "Docker", "Java"); // Java is redundant
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, requiredSkills, preferredSkills);
+
+        // then
+        assertThat(result).contains("position: Backend Developer");
+        assertThat(result).contains("workType: REMOTE");
+        assertThat(result).contains("career: 3~5 years");
+        assertThat(result).contains("required skills: Java, Spring");
+        assertThat(result).contains("preferred skills: AWS, Docker"); // Java should be filtered out
+        assertThat(result).contains("title: Title");
+        assertThat(result).contains("description: Description");
+    }
+
+    @Test
+    @DisplayName("경력 요구사항이 null일 경우 빈 문자열로 처리한다.")
+    void generate_WithNullCareer_ReturnsEmptyCareer() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, null, null, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: ");
+        assertThat(result).doesNotContain("career: null");
+    }
+
+    @Test
+    @DisplayName("최소 경력만 있을 경우의 포맷을 확인한다.")
+    void generate_WithMinCareerOnly() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, null, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: 3+ years");
+    }
+
+    @Test
+    @DisplayName("최대 경력만 있을 경우의 포맷을 확인한다.")
+    void generate_WithMaxCareerOnly() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, null, 5, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: up to 5 years");
+    }
+
+    @Test
+    @DisplayName("required/preferred skill이 null이어도 null 문자열을 출력하지 않는다.")
+    void generate_WithNullSkills_DoesNotPrintNull() {
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        assertThat(result).contains("required skills: ");
+        assertThat(result).contains("preferred skills: ");
+        assertThat(result).doesNotContain("null");
+    }
+
+    @Test
+    @DisplayName("required skill이 비어 있으면 preferred skill을 그대로 포함한다.")
+    void generate_WithOnlyPreferredSkills_IncludesPreferredSkills() {
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        String result = generator.generate(
+                proposal,
+                proposalPosition,
+                null,
+                Set.of("AWS", "Docker")
+        );
+
+        assertThat(result).contains("preferred skills: AWS, Docker");
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
@@ -1,0 +1,129 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.domain.recommendation.vo.EmbeddingVector;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeEmbeddingReaderImplTest {
+
+    @Mock
+    private ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    private ResumeEmbeddingReaderImpl resumeEmbeddingReader;
+
+    @BeforeEach
+    void setUp() {
+        resumeEmbeddingReader = new ResumeEmbeddingReaderImpl(resumeEmbeddingRepository);
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록으로 임베딩을 조회하여 맵 형태로 반환한다")
+    void 이력서_ID_목록으로_임베딩을_조회하여_맵_형태로_반환한다() {
+        // given
+        List<Long> resumeIds = List.of(1L, 2L);
+        String model = "text-embedding-3-small";
+
+        Resume resume1 = mock(Resume.class);
+        given(resume1.getId()).willReturn(1L);
+        Resume resume2 = mock(Resume.class);
+        given(resume2.getId()).willReturn(2L);
+
+        ResumeEmbedding embedding1 = mock(ResumeEmbedding.class);
+        given(embedding1.getResume()).willReturn(resume1);
+        given(embedding1.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        ResumeEmbedding embedding2 = mock(ResumeEmbedding.class);
+        given(embedding2.getResume()).willReturn(resume2);
+        given(embedding2.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.3, 0.4)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, model))
+                .willReturn(List.of(embedding1, embedding2));
+
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, model);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(1L)).containsExactly(0.1, 0.2);
+        assertThat(result.get(2L)).containsExactly(0.3, 0.4);
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록이 비어있으면 빈 맵을 반환한다")
+    void 이력서_ID_목록이_비어있으면_빈_맵을_반환한다() {
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(Collections.emptyList(),
+                "model");
+
+        // then
+        assertThat(result).isEmpty();
+        then(resumeEmbeddingRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록이 null이면 빈 맵을 반환한다")
+    void 이력서_ID_목록이_null이면_빈_맵을_반환한다() {
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(null, "model");
+
+        // then
+        assertThat(result).isEmpty();
+        then(resumeEmbeddingRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("모델명이 없으면 예외가 발생한다")
+    void 모델명이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), null))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), ""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), "   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("조회되지 않은 이력서 ID는 결과 맵에 포함하지 않는다")
+    void 조회되지_않은_이력서_ID는_결과_맵에_포함하지_않는다() {
+        // given
+        List<Long> resumeIds = List.of(1L, 2L);
+        String model = "text-embedding-3-small";
+
+        Resume resume1 = mock(Resume.class);
+        given(resume1.getId()).willReturn(1L);
+
+        ResumeEmbedding embedding1 = mock(ResumeEmbedding.class);
+        given(embedding1.getResume()).willReturn(resume1);
+        given(embedding1.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, model))
+                .willReturn(List.of(embedding1));
+
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, model);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey(1L);
+        assertThat(result).doesNotContainKey(2L);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
@@ -126,4 +126,27 @@ class ResumeEmbeddingReaderImplTest {
         assertThat(result).containsKey(1L);
         assertThat(result).doesNotContainKey(2L);
     }
+
+    @Test
+    @DisplayName("모델명 앞뒤 공백은 제거한 뒤 조회한다")
+    void 모델명_앞뒤_공백은_제거한_뒤_조회한다() {
+        List<Long> resumeIds = List.of(1L);
+        String inputModel = " text-embedding-3-small ";
+        String normalizedModel = "text-embedding-3-small";
+
+        Resume resume = mock(Resume.class);
+        given(resume.getId()).willReturn(1L);
+
+        ResumeEmbedding embedding = mock(ResumeEmbedding.class);
+        given(embedding.getResume()).willReturn(resume);
+        given(embedding.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, normalizedModel))
+                .willReturn(List.of(embedding));
+
+        Map<Long, List<Double>> result =
+                resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, inputModel);
+
+        assertThat(result).containsEntry(1L, List.of(0.1, 0.2));
+    }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculatorTest.java
@@ -1,0 +1,126 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SkillAdjustmentCalculatorTest {
+
+    private final SkillAdjustmentCalculator calculator = new SkillAdjustmentCalculator();
+
+    @DisplayName("필수 기술과 선택 기술이 모두 일치할 때 가산점을 정확히 계산한다")
+    @Test
+    void calculate_allSkillsMatch_returnsMaxBonus() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker", "AWS");
+        Set<String> owned = Set.of("Java", "Spring", "Docker", "AWS", "Git");
+
+        // when
+        // requiredAdjustment: (1.0 - 0.5) * 0.3 = 0.15
+        // preferredAdjustment: 1.0 * 0.05 = 0.05
+        // total: 0.20
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.20, offset(1e-9));
+    }
+
+    @DisplayName("일치하는 기술이 하나도 없을 때 감점을 정확히 계산한다")
+    @Test
+    void calculate_noSkillsMatch_returnsMinPenalty() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker", "AWS");
+        Set<String> owned = Set.of("Python", "Django");
+
+        // when
+        // requiredAdjustment: (0.0 - 0.5) * 0.3 = -0.15
+        // preferredAdjustment: 0.0 * 0.05 = 0.0
+        // total: -0.15
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(-0.15, offset(1e-9));
+    }
+
+    @DisplayName("필수 기술이 절반만 일치할 때 필수 기술 보정치는 0이어야 한다")
+    @Test
+    void calculate_halfRequiredSkillsMatch_returnsZeroRequiredAdjustment() {
+        // given
+        Set<String> required = Set.of("Java", "Spring", "JPA", "Querydsl");
+        Set<String> preferred = Collections.emptySet();
+        Set<String> owned = Set.of("Java", "Spring");
+
+        // when
+        // requiredAdjustment: (2/4 - 0.5) * 0.3 = 0.0
+        // preferredAdjustment: 0.0
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.0, offset(1e-9));
+    }
+
+    @DisplayName("기술 목록이 null이거나 비어있을 때 0.0을 반환한다")
+    @Test
+    void calculate_emptyOrNullSkills_returnsZero() {
+        // when & then
+        assertThat(calculator.calculate(null, null, Set.of("Java"))).isEqualTo(0.0);
+        assertThat(calculator.calculate(Collections.emptySet(), Collections.emptySet(), Set.of("Java"))).isEqualTo(0.0);
+    }
+
+    @DisplayName("선택 기술만 일부 일치할 때 가산점을 정확히 계산한다")
+    @Test
+    void calculate_onlyPreferredSkillsMatch_returnsCorrectBonus() {
+        // given
+        Set<String> required = Collections.emptySet();
+        Set<String> preferred = Set.of("Docker", "AWS", "Kubernetes", "Terraform");
+        Set<String> owned = Set.of("Docker", "AWS");
+
+        // when
+        // requiredAdjustment: 0.0
+        // preferredAdjustment: (2/4) * 0.05 = 0.025
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.025, offset(1e-9));
+    }
+
+    @DisplayName("필수 기술과 중복된 우대 기술은 우대 가산점에 중복 반영되지 않는다")
+    @Test
+    void calculate_overlappingPreferredSkills_doesNotDoubleCount() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Spring", "AWS");
+        Set<String> owned = Set.of("Java", "Spring");
+
+        // when
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        // requiredAdjustment: (2/2 - 0.5) * 0.3 = 0.15
+        // preferredAdjustment: AWS만 유효 preferred로 남으면 0.0
+        assertThat(result).isCloseTo(0.15, offset(1e-9));
+    }
+
+    @DisplayName("보유 기술 수가 많아도 required/preferred 기준으로만 보정한다")
+    @Test
+    void calculate_extraOwnedSkills_doNotAffectAdjustment() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker");
+        Set<String> owned1 = Set.of("Java", "Spring", "Docker");
+        Set<String> owned2 = Set.of("Java", "Spring", "Docker", "Redis", "Kafka", "MySQL");
+
+        // when
+        double result1 = calculator.calculate(required, preferred, owned1);
+        double result2 = calculator.calculate(required, preferred, owned2);
+
+        // then
+        assertThat(result1).isCloseTo(result2, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGeneratorTest.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StubQueryEmbeddingGeneratorTest {
+
+    private final StubQueryEmbeddingGenerator generator = new StubQueryEmbeddingGenerator();
+
+    @Test
+    @DisplayName("생성 시 UnsupportedOperationException이 발생한다")
+    void 생성_시_UnsupportedOperationException이_발생한다() {
+        assertThatThrownBy(() -> generator.generate("any query"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("쿼리 임베딩 생성은 별도 이슈에서 구현합니다.");
+    }
+}


### PR DESCRIPTION
## 🔎 What

HEURISTIC_V1 기반 추천 스코어링 파이프라인을 구현하고, 초기 안정성 패치를 적용했습니다.

### 주요 내용

* 추천 점수 계산 로직 구현

  * cosine similarity 기반 유사도 계산
  * 스킬/경력 보정 점수 반영
  * 최종 점수(finalScore) 산출 및 정렬

* 스코어링 파이프라인 구성

  * `RecommendationQueryTextGenerator`를 통한 query text 생성
  * `QueryEmbeddingGenerator` 인터페이스 정의 (stub 기반)
  * `ResumeEmbeddingReader`를 통한 임베딩 조회

* 점수 범위 정규화

  * raw cosine [-1, 1] → embeddingScore [0, 1]로 변환
  * finalScore는 0~1 범위로 clamp 처리

* 안정성 개선 (1차 패치)

  * candidate가 비어 있을 경우 early return 처리
  * embeddingModel 조회 시 trim() 적용하여 miss 방지

* 테스트 코드 추가

  * `HeuristicV1RecommendationScorer` 단위 테스트 작성
  * 정렬, clamp, embedding 누락 케이스 등 핵심 시나리오 검증

### 제외 범위

* OpenAI 기반 query embedding 생성 구현 (stub으로 대체)
* Resume embedding 생성 및 저장 로직

---

## 🔗 Issue

* Closes: #42 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?
