### PR TITLE
[Feat] 클라이언트 대시보드 제안서 카드 액션 메뉴 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -93,6 +93,27 @@ public class ProposalController {
         }
     }
 
+    @GetMapping("/{proposalId}")
+    public String detail(
+            @PathVariable Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Proposal proposal = proposalService.findOwnedProposal(proposalId, principal.getEmail());
+            model.addAttribute("proposal", proposal);
+            addMemberAttributes(model, principal);
+            return "client/proposalDetail";
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+            return "redirect:/client/dashboard";
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 조회할 수 있습니다.");
+            return "redirect:/client/dashboard";
+        }
+    }
+
     @GetMapping("/{proposalId}/edit")
     public String editForm(
             @PathVariable Long proposalId,
@@ -137,6 +158,25 @@ public class ProposalController {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/client/dashboard";
         }
+    }
+
+    @PostMapping("/{proposalId}/delete")
+    public String delete(
+            @PathVariable Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            proposalService.delete(proposalId, principal.getEmail());
+            redirectAttributes.addFlashAttribute("noticeMessage", "프로젝트가 삭제되었습니다.");
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+        } catch (org.springframework.security.access.AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 삭제할 수 있습니다.");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/client/dashboard";
     }
 
     @PostMapping("/{proposalId}/edit-draft")

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -132,6 +132,14 @@ public class ProposalService {
         return proposal;
     }
 
+    public void delete(Long proposalId, String memberEmail) {
+        Proposal proposal = getOwnedProposal(proposalId, memberEmail);
+        if (proposal.getStatus() != ProposalStatus.WRITING) {
+            throw new IllegalStateException("작성 중인 제안서만 삭제할 수 있습니다.");
+        }
+        proposalRepository.delete(proposal);
+    }
+
     @Transactional(readOnly = true)
     public Proposal findOwnedProposal(Long proposalId, String memberEmail) {
         Proposal proposal = proposalRepository.findWithPositionsById(proposalId)

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -166,11 +166,34 @@
                                     매칭 시작 전
                                 </span>
                             </td>
-                            <td class="px-6 py-7 text-right">
+                            <td class="relative px-6 py-7 text-right">
                                 <button type="button"
-                                        class="inline-flex h-10 w-10 items-center justify-center rounded-full text-slate-300 transition hover:bg-slate-100 hover:text-slate-500">
+                                        class="menu-trigger inline-flex h-10 w-10 items-center justify-center rounded-full text-slate-300 transition hover:bg-slate-100 hover:text-slate-500">
                                     <i data-lucide="ellipsis" class="h-4 w-4"></i>
                                 </button>
+                                <div class="menu-dropdown hidden absolute right-6 top-14 z-20 w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
+                                    <a th:href="@{/proposals/{id}(id=${project.proposalId})}"
+                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+                                        <i data-lucide="file-text" class="h-4 w-4 text-slate-400"></i>제안서 상세 보기
+                                    </a>
+                                    <a th:if="${project.statusKey == 'WRITING' or project.statusKey == 'MATCHING'}"
+                                       th:href="@{/proposals/{id}/edit(id=${project.proposalId})}"
+                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+                                        <i data-lucide="pencil" class="h-4 w-4 text-slate-400"></i>제안서 수정
+                                    </a>
+                                    <a th:if="${project.statusKey == 'MATCHING' or project.statusKey == 'COMPLETE'}"
+                                       th:href="@{/proposals/{id}/recommendations(id=${project.proposalId})}"
+                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+                                        <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>추천 결과 보기
+                                    </a>
+                                    <div th:if="${project.statusKey == 'WRITING'}" class="my-1 border-t border-slate-100"></div>
+                                    <button th:if="${project.statusKey == 'WRITING'}"
+                                            type="button"
+                                            th:attr="data-proposal-id=${project.proposalId},data-proposal-title=${project.title}"
+                                            class="delete-btn flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-red-500 hover:bg-red-50">
+                                        <i data-lucide="trash-2" class="h-4 w-4"></i>프로젝트 삭제
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                         </tbody>
@@ -179,6 +202,33 @@
             </section>
         </div>
     </main>
+
+    <!-- 삭제 확인 모달 -->
+    <div id="deleteModal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
+        <div id="deleteModalBackdrop" class="absolute inset-0 bg-black/40"></div>
+        <div class="relative mx-4 w-full max-w-sm rounded-[28px] bg-white p-8 shadow-2xl">
+            <div class="flex h-14 w-14 items-center justify-center rounded-3xl bg-red-50">
+                <i data-lucide="trash-2" class="h-6 w-6 text-red-500"></i>
+            </div>
+            <h3 class="mt-6 text-xl font-black text-slate-900">프로젝트를 삭제할까요?</h3>
+            <p class="mt-2 text-sm leading-6 text-slate-500">
+                <span id="deleteModalTitle" class="font-bold text-slate-700"></span> 제안서가 영구적으로 삭제됩니다. <br>이 작업은 되돌릴 수 없습니다.
+            </p>
+            <div class="mt-8 flex gap-3">
+                <button type="button" id="deleteModalCancel"
+                        class="flex-1 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-bold text-slate-600 transition hover:bg-slate-50">
+                    취소
+                </button>
+                <form id="deleteForm" method="post" class="flex-1">
+                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                    <button type="submit"
+                            class="w-full rounded-2xl bg-red-500 px-4 py-3 text-sm font-bold text-white transition hover:bg-red-600">
+                        삭제
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
 
     <script th:fragment="dashboardScript">
     (function () {
@@ -262,13 +312,58 @@
                 });
         }
 
-        // 탭 클릭 이벤트
+        // 탭 클릭 / 드롭다운 / 삭제 버튼 이벤트
+        var activeMenu = null;
+
+        function closeActiveMenu() {
+            if (activeMenu) {
+                activeMenu.classList.add('hidden');
+                activeMenu = null;
+            }
+        }
+
         document.addEventListener('click', function (e) {
+            // 필터 탭
             var tab = e.target.closest('.filter-tab');
-            if (!tab) return;
-            e.preventDefault();
-            if (tab.classList.contains('tab-active')) return; // 이미 선택된 탭은 재요청 안 함
-            loadItems(tab.dataset.filter, true);
+            if (tab) {
+                e.preventDefault();
+                if (tab.classList.contains('tab-active')) return;
+                closeActiveMenu();
+                loadItems(tab.dataset.filter, true);
+                return;
+            }
+
+            // ... 메뉴 트리거
+            var trigger = e.target.closest('.menu-trigger');
+            if (trigger) {
+                e.stopPropagation();
+                var dropdown = trigger.parentElement.querySelector('.menu-dropdown');
+                if (activeMenu && activeMenu !== dropdown) closeActiveMenu();
+                dropdown.classList.toggle('hidden');
+                activeMenu = dropdown.classList.contains('hidden') ? null : dropdown;
+                return;
+            }
+
+            // 삭제 버튼
+            var deleteBtn = e.target.closest('.delete-btn');
+            if (deleteBtn) {
+                closeActiveMenu();
+                document.getElementById('deleteModalTitle').textContent = deleteBtn.dataset.proposalTitle;
+                document.getElementById('deleteForm').action = '/proposals/' + deleteBtn.dataset.proposalId + '/delete';
+                document.getElementById('deleteModal').classList.remove('hidden');
+                return;
+            }
+
+            // 외부 클릭 시 메뉴 닫기
+            closeActiveMenu();
+        });
+
+        // 모달 닫기
+        document.getElementById('deleteModalCancel').addEventListener('click', function () {
+            document.getElementById('deleteModal').classList.add('hidden');
+        });
+        document.getElementById('deleteModalBackdrop').addEventListener('click', function () {
+            document.getElementById('deleteModal').classList.add('hidden');
         });
 
         // 브라우저 뒤로가기/앞으로가기

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -396,10 +396,7 @@
                 return;
             }
 
-            // 액션 메뉴 내부 클릭은 닫기 처리하지 않음 (링크/버튼이 직접 처리)
-            if (actionMenu.contains(e.target)) return;
-
-            // 삭제 버튼 (공유 메뉴 안의 #menuDelete)
+            // 삭제 버튼 (공유 메뉴 안의 #menuDelete) — actionMenu.contains 체크보다 먼저
             if (e.target.closest('#menuDelete')) {
                 closeActionMenu();
                 document.getElementById('deleteModalTitle').textContent = menuDelete.dataset.proposalTitle;
@@ -407,6 +404,9 @@
                 document.getElementById('deleteModal').classList.remove('hidden');
                 return;
             }
+
+            // 액션 메뉴 내부 링크 클릭은 그대로 동작하도록 통과
+            if (actionMenu.contains(e.target)) return;
 
             // 행 클릭 → 상세 페이지 이동
             var row = e.target.closest('.project-row');

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -135,7 +135,9 @@
                         </tr>
                         </thead>
                         <tbody class="divide-y divide-slate-200 bg-white">
-                        <tr th:each="project : ${dashboard.projects}" class="transition hover:bg-slate-50/70">
+                        <tr th:each="project : ${dashboard.projects}"
+                            th:attr="data-href=@{/proposals/{id}(id=${project.proposalId})}"
+                            class="project-row cursor-pointer transition hover:bg-slate-50/70">
                             <td class="px-8 py-7">
                                 <div class="max-w-[320px]">
                                     <p class="text-xl font-black tracking-tight text-slate-900" th:text="${project.title}">
@@ -166,34 +168,14 @@
                                     매칭 시작 전
                                 </span>
                             </td>
-                            <td class="relative px-6 py-7 text-right">
+                            <td class="px-6 py-7 text-right">
                                 <button type="button"
+                                        th:attr="data-proposal-id=${project.proposalId},
+                                                 data-status-key=${project.statusKey},
+                                                 data-proposal-title=${project.title}"
                                         class="menu-trigger inline-flex h-10 w-10 items-center justify-center rounded-full text-slate-300 transition hover:bg-slate-100 hover:text-slate-500">
                                     <i data-lucide="ellipsis" class="h-4 w-4"></i>
                                 </button>
-                                <div class="menu-dropdown hidden absolute right-6 top-14 z-20 w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
-                                    <a th:href="@{/proposals/{id}(id=${project.proposalId})}"
-                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
-                                        <i data-lucide="file-text" class="h-4 w-4 text-slate-400"></i>제안서 상세 보기
-                                    </a>
-                                    <a th:if="${project.statusKey == 'WRITING' or project.statusKey == 'MATCHING'}"
-                                       th:href="@{/proposals/{id}/edit(id=${project.proposalId})}"
-                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
-                                        <i data-lucide="pencil" class="h-4 w-4 text-slate-400"></i>제안서 수정
-                                    </a>
-                                    <a th:if="${project.statusKey == 'MATCHING' or project.statusKey == 'COMPLETE'}"
-                                       th:href="@{/proposals/{id}/recommendations(id=${project.proposalId})}"
-                                       class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
-                                        <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>추천 결과 보기
-                                    </a>
-                                    <div th:if="${project.statusKey == 'WRITING'}" class="my-1 border-t border-slate-100"></div>
-                                    <button th:if="${project.statusKey == 'WRITING'}"
-                                            type="button"
-                                            th:attr="data-proposal-id=${project.proposalId},data-proposal-title=${project.title}"
-                                            class="delete-btn flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-red-500 hover:bg-red-50">
-                                        <i data-lucide="trash-2" class="h-4 w-4"></i>프로젝트 삭제
-                                    </button>
-                                </div>
                             </td>
                         </tr>
                         </tbody>
@@ -202,6 +184,27 @@
             </section>
         </div>
     </main>
+
+    <!-- 공유 액션 메뉴 (position: fixed로 overflow-hidden 부모 탈출) -->
+    <div id="actionMenu" class="hidden fixed z-40 w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
+        <a id="menuDetail" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="file-text" class="h-4 w-4 text-slate-400"></i>제안서 상세 보기
+        </a>
+        <a id="menuEdit" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="pencil" class="h-4 w-4 text-slate-400"></i>제안서 수정
+        </a>
+        <a id="menuRecommend" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>추천 결과 보기
+        </a>
+        <div id="menuDeleteDivider" class="my-1 border-t border-slate-100"></div>
+        <button id="menuDelete" type="button"
+                class="flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-red-500 hover:bg-red-50">
+            <i data-lucide="trash-2" class="h-4 w-4"></i>프로젝트 삭제
+        </button>
+    </div>
 
     <!-- 삭제 확인 모달 -->
     <div id="deleteModal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
@@ -312,23 +315,74 @@
                 });
         }
 
-        // 탭 클릭 / 드롭다운 / 삭제 버튼 이벤트
-        var activeMenu = null;
+        // ── 공유 액션 메뉴 ──────────────────────────────────────
+        var actionMenu    = document.getElementById('actionMenu');
+        var menuDetail    = document.getElementById('menuDetail');
+        var menuEdit      = document.getElementById('menuEdit');
+        var menuRecommend = document.getElementById('menuRecommend');
+        var menuDeleteDiv = document.getElementById('menuDeleteDivider');
+        var menuDelete    = document.getElementById('menuDelete');
+        var menuOpen      = false;
 
-        function closeActiveMenu() {
-            if (activeMenu) {
-                activeMenu.classList.add('hidden');
-                activeMenu = null;
-            }
+        function closeActionMenu() {
+            if (!menuOpen) return;
+            actionMenu.classList.add('hidden');
+            menuOpen = false;
         }
 
+        function openActionMenu(trigger) {
+            var proposalId    = trigger.dataset.proposalId;
+            var statusKey     = trigger.dataset.statusKey;
+            var proposalTitle = trigger.dataset.proposalTitle;
+
+            // 링크 세팅
+            menuDetail.href    = '/proposals/' + proposalId;
+            menuEdit.href      = '/proposals/' + proposalId + '/edit';
+            menuRecommend.href = '/proposals/' + proposalId + '/recommendations';
+            menuDelete.dataset.proposalId    = proposalId;
+            menuDelete.dataset.proposalTitle = proposalTitle;
+
+            // 상태별 항목 표시/숨김
+            menuEdit.classList.toggle('hidden', statusKey === 'COMPLETE');
+            menuRecommend.classList.toggle('hidden', statusKey === 'WRITING');
+            var showDelete = statusKey === 'WRITING';
+            menuDeleteDiv.classList.toggle('hidden', !showDelete);
+            menuDelete.classList.toggle('hidden', !showDelete);
+
+            // 버튼 기준으로 위치 계산 (fixed)
+            actionMenu.classList.remove('hidden');
+            if (window.lucide) lucide.createIcons();
+
+            var rect       = trigger.getBoundingClientRect();
+            var menuHeight = actionMenu.offsetHeight;
+            var spaceBelow = window.innerHeight - rect.bottom;
+
+            actionMenu.style.left  = 'auto';
+            actionMenu.style.right = (window.innerWidth - rect.right) + 'px';
+
+            // 아래 공간이 부족하면 버튼 위로 열기
+            if (spaceBelow < menuHeight + 8) {
+                actionMenu.style.top    = 'auto';
+                actionMenu.style.bottom = (window.innerHeight - rect.top + 4) + 'px';
+            } else {
+                actionMenu.style.bottom = 'auto';
+                actionMenu.style.top    = (rect.bottom + 4) + 'px';
+            }
+
+            menuOpen = true;
+        }
+
+        // 스크롤 시 메뉴 닫기 (fixed 위치가 어긋나므로)
+        window.addEventListener('scroll', closeActionMenu, true);
+
+        // ── 이벤트 위임 ─────────────────────────────────────────
         document.addEventListener('click', function (e) {
             // 필터 탭
             var tab = e.target.closest('.filter-tab');
             if (tab) {
                 e.preventDefault();
                 if (tab.classList.contains('tab-active')) return;
-                closeActiveMenu();
+                closeActionMenu();
                 loadItems(tab.dataset.filter, true);
                 return;
             }
@@ -337,25 +391,33 @@
             var trigger = e.target.closest('.menu-trigger');
             if (trigger) {
                 e.stopPropagation();
-                var dropdown = trigger.parentElement.querySelector('.menu-dropdown');
-                if (activeMenu && activeMenu !== dropdown) closeActiveMenu();
-                dropdown.classList.toggle('hidden');
-                activeMenu = dropdown.classList.contains('hidden') ? null : dropdown;
+                if (menuOpen) { closeActionMenu(); return; }
+                openActionMenu(trigger);
                 return;
             }
 
-            // 삭제 버튼
-            var deleteBtn = e.target.closest('.delete-btn');
-            if (deleteBtn) {
-                closeActiveMenu();
-                document.getElementById('deleteModalTitle').textContent = deleteBtn.dataset.proposalTitle;
-                document.getElementById('deleteForm').action = '/proposals/' + deleteBtn.dataset.proposalId + '/delete';
+            // 액션 메뉴 내부 클릭은 닫기 처리하지 않음 (링크/버튼이 직접 처리)
+            if (actionMenu.contains(e.target)) return;
+
+            // 삭제 버튼 (공유 메뉴 안의 #menuDelete)
+            if (e.target.closest('#menuDelete')) {
+                closeActionMenu();
+                document.getElementById('deleteModalTitle').textContent = menuDelete.dataset.proposalTitle;
+                document.getElementById('deleteForm').action = '/proposals/' + menuDelete.dataset.proposalId + '/delete';
                 document.getElementById('deleteModal').classList.remove('hidden');
                 return;
             }
 
+            // 행 클릭 → 상세 페이지 이동
+            var row = e.target.closest('.project-row');
+            if (row && row.dataset.href) {
+                closeActionMenu();
+                window.location.href = row.dataset.href;
+                return;
+            }
+
             // 외부 클릭 시 메뉴 닫기
-            closeActiveMenu();
+            closeActionMenu();
         });
 
         // 모달 닫기

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -404,5 +405,86 @@ class ProposalControllerTest {
                         ))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/client/dashboard"));
+    }
+
+    @Test
+    @DisplayName("제안서 상세 조회 시 proposalDetail 뷰와 proposal 모델을 반환한다")
+    void renderProposalDetail() throws Exception {
+        Proposal proposal = Proposal.create(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678"),
+                "기존 프로젝트", "", "설명", null, null, 6L
+        );
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/1")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalDetail"))
+                .andExpect(model().attributeExists("proposal"));
+    }
+
+    @Test
+    @DisplayName("없는 제안서 상세 조회 시 대시보드로 리다이렉트한다")
+    void redirectDashboardWhenDetailNotFound() throws Exception {
+        given(proposalService.findOwnedProposal(999L, "client@example.com"))
+                .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/999")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"));
+    }
+
+    @Test
+    @DisplayName("WRITING 상태 제안서 삭제 요청 시 대시보드로 리다이렉트한다")
+    void deleteWritingProposalAndRedirectToDashboard() throws Exception {
+        willDoNothing().given(proposalService).delete(1L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/delete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"));
+
+        then(proposalService).should().delete(1L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("삭제 불가 상태의 제안서 삭제 시도 시 에러 메시지와 함께 대시보드로 리다이렉트한다")
+    void redirectDashboardWithErrorWhenDeleteFails() throws Exception {
+        willThrow(new IllegalStateException("작성 중인 제안서만 삭제할 수 있습니다."))
+                .given(proposalService).delete(1L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/delete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"));
+
+        then(proposalService).should().delete(1L, "client@example.com");
     }
 }

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -25,6 +25,7 @@ import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.service.ProposalService;
@@ -406,7 +407,7 @@ class ProposalControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/client/dashboard"));
     }
-    
+
     @Test
     @DisplayName("없는 제안서 상세 조회 시 대시보드로 리다이렉트한다")
     void redirectDashboardWhenDetailNotFound() throws Exception {
@@ -429,6 +430,27 @@ class ProposalControllerTest {
     @DisplayName("WRITING 상태 제안서 삭제 요청 시 대시보드로 리다이렉트한다")
     void deleteWritingProposalAndRedirectToDashboard() throws Exception {
         willDoNothing().given(proposalService).delete(1L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/delete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"));
+
+        then(proposalService).should().delete(1L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("타인의 제안서 삭제 시도 시 에러 메시지와 함께 대시보드로 리다이렉트한다")
+    void redirectDashboardWithErrorWhenDeleteAccessDenied() throws Exception {
+        willThrow(new AccessDeniedException("본인 제안서만 삭제할 수 있습니다."))
+                .given(proposalService).delete(1L, "client@example.com");
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -3,6 +3,7 @@ package com.generic4.itda.controller;
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -12,6 +13,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -140,6 +142,9 @@ class ProposalControllerTest {
         given(proposal.getId()).willReturn(3L);
         given(positionRepository.findAll(any(Sort.class)))
                 .willReturn(List.of(Position.create("백엔드 개발자")));
+        // register 검증 로직에서 총 예산 계산이 null 이면 실패로 처리되므로, 성공 흐름을 위해 stub 한다.
+        given(proposalService.calculateTotalBudgetMin(any(ProposalForm.class))).willReturn(3_000_000L);
+        given(proposalService.calculateTotalBudgetMax(any(ProposalForm.class))).willReturn(4_000_000L);
         given(proposalService.register(anyString(), any(ProposalForm.class))).willReturn(proposal);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -309,6 +314,178 @@ class ProposalControllerTest {
     }
 
     @Test
+    @DisplayName("수정 요청이 유효하면 saveDraft 후 edit 화면으로 이동한다")
+    void updateDraftAndRedirectToEdit() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(proposalService.saveDraft(any(Long.class), anyString(), any(ProposalForm.class))).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("title", "수정된 제목")
+                        .param("rawInputText", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1/edit"));
+
+        then(proposalService).should().saveDraft(any(Long.class), anyString(), any(ProposalForm.class));
+    }
+
+    @Test
+    @DisplayName("수정 요청에서 register 액션이 유효하면 추천 진입 화면으로 이동한다")
+    void registerAfterUpdateAndRedirectToRecommendationEntry() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(positionRepository.findAll(any(Sort.class)))
+                .willReturn(List.of(Position.create("백엔드 개발자")));
+        given(proposalService.calculateTotalBudgetMin(any(ProposalForm.class))).willReturn(3_000_000L);
+        given(proposalService.calculateTotalBudgetMax(any(ProposalForm.class))).willReturn(4_000_000L);
+        given(proposalService.register(any(Long.class), anyString(), any(ProposalForm.class))).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "register")
+                        .param("title", "쇼핑몰 앱 개발")
+                        .param("rawInputText", "")
+                        .param("expectedPeriod", "8")
+                        .param("positions[0].positionId", "1")
+                        .param("positions[0].title", "Node.js 백엔드 개발자")
+                        .param("positions[0].workType", "REMOTE")
+                        .param("positions[0].headCount", "1")
+                        .param("positions[0].unitBudgetMin", "3000000")
+                        .param("positions[0].unitBudgetMax", "4000000")
+                        .param("positions[0].expectedPeriod", "4")
+                        .param("positions[0].essentialSkillNames[0]", "Node.js"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1/recommendations"));
+
+        then(proposalService).should().register(any(Long.class), anyString(), any(ProposalForm.class));
+    }
+
+    @Test
+    @DisplayName("수정 요청에서 register 조건을 만족하지 못하면 편집기에 머무르며 이유를 보여준다")
+    void stayOnFormWhenUpdateRegisterValidationFails() throws Exception {
+        given(positionRepository.findAll(any(Sort.class)))
+                .willReturn(List.of(Position.create("백엔드 개발자")));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "register")
+                        .param("title", "쇼핑몰 앱 개발")
+                        .param("rawInputText", ""))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalForm"))
+                .andExpect(model().attributeHasErrors("proposalForm"));
+
+        then(proposalService).should(never()).register(any(Long.class), anyString(), any(ProposalForm.class));
+    }
+
+    @Test
+    @DisplayName("수정 요청 시 제안서가 없으면 대시보드로 리다이렉트한다")
+    void redirectDashboardWhenUpdateNotFound() throws Exception {
+        willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"))
+                .given(proposalService).saveDraft(eq(999L), eq("client@example.com"), any(ProposalForm.class));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/999/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("title", "수정된 제목")
+                        .param("rawInputText", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
+    @DisplayName("수정 요청 시 타인 제안서이면 대시보드로 리다이렉트한다")
+    void redirectDashboardWhenUpdateAccessDenied() throws Exception {
+        willThrow(new AccessDeniedException("본인 제안서만 조회하거나 수정할 수 있습니다."))
+                .given(proposalService).saveDraft(eq(1L), eq("client@example.com"), any(ProposalForm.class));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("title", "수정된 제목")
+                        .param("rawInputText", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
+    @DisplayName("수정 요청 처리 중 예외가 발생하면 편집기에 머무르며 이유를 보여준다")
+    void stayOnFormWhenUpdateFailsWithIllegalState() throws Exception {
+        given(positionRepository.findAll(any(Sort.class)))
+                .willReturn(List.of(Position.create("백엔드 개발자")));
+        willThrow(new IllegalStateException("저장 중 오류가 발생했습니다."))
+                .given(proposalService).saveDraft(eq(1L), eq("client@example.com"), any(ProposalForm.class));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .param("submitAction", "save")
+                        .param("title", "수정된 제목")
+                        .param("rawInputText", ""))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalForm"))
+                .andExpect(model().attributeHasErrors("proposalForm"));
+    }
+
+    @Test
     @DisplayName("MATCHING 제안서는 GET /edit 에서 수정 시작 안내 화면을 보여준다")
     void renderEditStartWhenMatchingProposalNeedsDraft() throws Exception {
         Proposal proposal = Proposal.create(
@@ -343,6 +520,38 @@ class ProposalControllerTest {
     }
 
     @Test
+    @DisplayName("COMPLETE 제안서는 GET /edit 에서 수정 불가 메시지와 함께 대시보드로 이동한다")
+    void redirectDashboardWhenProposalIsComplete() throws Exception {
+        Proposal proposal = Proposal.create(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678"),
+                "기존 프로젝트",
+                "",
+                "설명",
+                3_000_000L,
+                4_000_000L,
+                8L
+        );
+        proposal.startMatching();
+        proposal.complete();
+
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/1/edit")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
     @DisplayName("수정 시작 POST는 새 draft를 만든 뒤 그 draft의 edit 화면으로 이동한다")
     void redirectToClonedDraftAfterCreateEditDraft() throws Exception {
         Proposal copied = org.mockito.Mockito.mock(Proposal.class);
@@ -362,6 +571,29 @@ class ProposalControllerTest {
                         .with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/proposals/7/edit"));
+    }
+
+    @Test
+    @DisplayName("수정 시작 POST에서 새 draft로 이동하는 경우 noticeMessage 를 남긴다")
+    void keepNoticeMessageWhenRedirectedToNewDraftAfterCreateEditDraft() throws Exception {
+        Proposal copied = org.mockito.Mockito.mock(Proposal.class);
+        given(copied.getId()).willReturn(7L);
+        given(proposalService.createEditDraft(1L, "client@example.com")).willReturn(copied);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/edit-draft")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/7/edit"))
+                .andExpect(flash().attributeExists("noticeMessage"));
     }
 
     @Test
@@ -427,6 +659,25 @@ class ProposalControllerTest {
     }
 
     @Test
+    @DisplayName("제안서 상세 조회 시 타인 제안서이면 대시보드로 리다이렉트하고 오류 메시지를 남긴다")
+    void redirectDashboardWhenDetailAccessDenied() throws Exception {
+        given(proposalService.findOwnedProposal(1L, "client@example.com"))
+                .willThrow(new AccessDeniedException("본인 제안서만 조회할 수 있습니다."));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/1")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
     @DisplayName("WRITING 상태 제안서 삭제 요청 시 대시보드로 리다이렉트한다")
     void deleteWritingProposalAndRedirectToDashboard() throws Exception {
         willDoNothing().given(proposalService).delete(1L, "client@example.com");
@@ -444,6 +695,28 @@ class ProposalControllerTest {
                 .andExpect(redirectedUrl("/client/dashboard"));
 
         then(proposalService).should().delete(1L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("없는 제안서 삭제 시도 시 에러 메시지와 함께 대시보드로 리다이렉트한다")
+    void redirectDashboardWithErrorWhenDeleteNotFound() throws Exception {
+        willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"))
+                .given(proposalService).delete(999L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/999/delete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attributeExists("errorMessage"));
+
+        then(proposalService).should().delete(999L, "client@example.com");
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -406,29 +406,7 @@ class ProposalControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/client/dashboard"));
     }
-
-    @Test
-    @DisplayName("제안서 상세 조회 시 proposalDetail 뷰와 proposal 모델을 반환한다")
-    void renderProposalDetail() throws Exception {
-        Proposal proposal = Proposal.create(
-                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678"),
-                "기존 프로젝트", "", "설명", null, null, 6L
-        );
-        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
-
-        ItDaPrincipal principal = ItDaPrincipal.from(
-                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
-        );
-
-        mockMvc.perform(get("/proposals/1")
-                        .with(authentication(new UsernamePasswordAuthenticationToken(
-                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
-                        ))))
-                .andExpect(status().isOk())
-                .andExpect(view().name("client/proposalDetail"))
-                .andExpect(model().attributeExists("proposal"));
-    }
-
+    
     @Test
     @DisplayName("없는 제안서 상세 조회 시 대시보드로 리다이렉트한다")
     void redirectDashboardWhenDetailNotFound() throws Exception {

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -221,5 +222,30 @@ class ProposalServiceTest {
         assertThatThrownBy(() -> proposalService.createEditDraft(1L, EMAIL))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("진행 중이거나 완료된 매칭이 있는 제안서는 수정할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("WRITING 상태 제안서는 정상적으로 삭제된다")
+    void delete_writingProposal_succeeds() {
+        Proposal proposal = Proposal.create(member, "삭제할 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        proposalService.delete(1L, EMAIL);
+
+        then(proposalRepository).should().delete(proposal);
+    }
+
+    @Test
+    @DisplayName("WRITING 상태가 아닌 제안서는 삭제할 수 없다")
+    void delete_nonWritingProposal_throws() {
+        Proposal proposal = Proposal.create(member, "매칭 중 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        proposal.startMatching();
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.delete(1L, EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("작성 중인 제안서만 삭제할 수 있습니다.");
     }
 }

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import com.generic4.itda.domain.member.Member;

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -16,6 +16,8 @@ import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
@@ -36,6 +38,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class ProposalServiceTest {
 
     private static final String EMAIL = "client@example.com";
+    private static final String OTHER_EMAIL = "other@example.com";
 
     @InjectMocks
     private ProposalService proposalService;
@@ -247,5 +250,67 @@ class ProposalServiceTest {
         assertThatThrownBy(() -> proposalService.delete(1L, EMAIL))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("작성 중인 제안서만 삭제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 삭제할 수 없다")
+    void delete_othersProposal_throws() {
+        Proposal proposal = Proposal.create(member, "다른 사람 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.delete(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+        then(proposalRepository).should().findById(1L);
+        then(proposalRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서는 삭제할 수 없다")
+    void delete_throws_whenNotFound() {
+        when(proposalRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.delete(99L, EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
+        then(proposalRepository).should().findById(99L);
+        then(proposalRepository).should(never()).delete(any(Proposal.class));
+    }
+
+    @Test
+    @DisplayName("소유자는 findOwnedProposal로 제안서를 조회할 수 있다")
+    void findOwnedProposal_returnsProposal_whenOwner() {
+        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        Proposal result = proposalService.findOwnedProposal(1L, EMAIL);
+
+        assertThat(result).isSameAs(proposal);
+        then(proposalRepository).should().findWithPositionsById(1L);
+        then(proposalRepository).should().findPositionsWithSkillsByProposalId(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서는 findOwnedProposal에서 예외가 발생한다")
+    void findOwnedProposal_throws_whenNotFound() {
+        when(proposalRepository.findWithPositionsById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.findOwnedProposal(99L, EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
+        then(proposalRepository).should().findWithPositionsById(99L);
+        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(99L);
+    }
+
+    @Test
+    @DisplayName("타인 제안서는 findOwnedProposal에서 접근 거부 예외가 발생한다")
+    void findOwnedProposal_throws_whenNotOwner() {
+        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.findOwnedProposal(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+        then(proposalRepository).should().findWithPositionsById(1L);
+        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(1L);
     }
 }


### PR DESCRIPTION
## 🔎 What

- ... 버튼 클릭 시 드롭다운 메뉴 표시 (외부 클릭 시 닫힘 처리 포함)
- 제안서 수정 — 해당 제안서 편집 페이지(/proposals/{id}/edit)로 이동
- 제안서 상세 보기 ㅡ 제안서 상세 페이지 이동 (메뉴와 엔드 포인트 구현 까지만 진행)
- 추천 결과 보기 — AI 추천 결과 페이지로 이동 (MATCHING 상태인 경우에만 활성화)
- 매칭 상세 관리 — 매칭 상세 페이지로 이동 (MATCHING 상태인 경우에만 활성화)
- 프로젝트 삭제 — 삭제 확인 모달 표시 후 제안서 삭제 처리 ( WRITING 상태인 경우에만 활성화)
- 제안서 상태(WRITING / MATCHING / COMPLETE)에 따라 메뉴 항목 활성/비활성 처리

## 🔗 Issue

- Closes: #74

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?