### PR TITLE
[Feat] RecommendationResult 생성 로직 구현

### DIFF
--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -28,7 +28,7 @@ public class RecommendationResultCreator {
     private static final int SCORE_SCALE = 4;
     private final ResumeRepository resumeRepository;
 
-    List<RecommendationResult> create(
+    public List<RecommendationResult> create(
             RecommendationRun run,
             List<ScoredCandidate> scoredCandidates,
             int topK,
@@ -144,7 +144,7 @@ public class RecommendationResultCreator {
         List<String> highlights = new ArrayList<>();
 
         if (!matchedSkills.isEmpty()) {
-            highlights.add("공토 스킬 " + matchedSkills.size() + "개 보유");
+            highlights.add("공통 스킬 " + matchedSkills.size() + "개 보유");
         }
 
         if (candidate.careerYears() > 0) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -1,0 +1,160 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationResultCreator {
+
+    private static final int SCORE_SCALE = 4;
+    private final ResumeRepository resumeRepository;
+
+    List<RecommendationResult> create(
+            RecommendationRun run,
+            List<ScoredCandidate> scoredCandidates,
+            int topK,
+            Set<String> requiredSkillNames
+    ) {
+        List<ScoredCandidate> topCandidates = selectTopCandidates(scoredCandidates, topK);
+        if (topCandidates.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Resume> resumeMap = loadResumeMap(topCandidates);
+
+        List<RecommendationResult> results = new ArrayList<>();
+        int rank = 1;
+
+        for (ScoredCandidate candidate : topCandidates) {
+            results.add(
+                    RecommendationResult.create(
+                            run,
+                            resumeMap.get(candidate.resumeId()),
+                            rank++,
+                            toBigDecimal(candidate.finalScore()),
+                            toBigDecimal(candidate.similarityScore()),
+                            createReasonFacts(candidate, requiredSkillNames)
+                    )
+            );
+        }
+
+        return results;
+    }
+
+    private List<ScoredCandidate> selectTopCandidates(List<ScoredCandidate> scoredCandidates, int topK) {
+        if (scoredCandidates == null || scoredCandidates.isEmpty()) {
+            return List.of();
+        }
+
+        List<ScoredCandidate> deduplicated = new ArrayList<>(
+                scoredCandidates.stream()
+                        .sorted(resultComparator())
+                        .collect(Collectors.toMap(
+                                ScoredCandidate::resumeId,
+                                Function.identity(),
+                                (first, second) -> first,
+                                LinkedHashMap::new
+                        ))
+                        .values()
+        );
+
+        return deduplicated.stream()
+                .limit(topK)
+                .toList();
+    }
+
+    private Comparator<ScoredCandidate> resultComparator() {
+        return Comparator.comparing(ScoredCandidate::finalScore).reversed()
+                .thenComparing(ScoredCandidate::candidateId);
+    }
+
+    private Map<Long, Resume> loadResumeMap(List<ScoredCandidate> topCandidates) {
+        List<Long> resumeIds = topCandidates.stream()
+                .map(ScoredCandidate::resumeId)
+                .toList();
+
+        Map<Long, Resume> resumeMap = resumeRepository.findAllById(resumeIds).stream()
+                .collect(Collectors.toMap(
+                        Resume::getId,
+                        Function.identity()
+                ));
+
+        if (resumeMap.size() != resumeIds.size()) {
+            throw new IllegalStateException("추천 결과 생성 대상 이력서 일부를 찾을 수 없습니다.");
+        }
+
+        return resumeMap;
+    }
+
+    private BigDecimal toBigDecimal(double value) {
+        return BigDecimal.valueOf(value)
+                .setScale(SCORE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private ReasonFacts createReasonFacts(
+            ScoredCandidate candidate,
+            Set<String> requiredSkillNames
+    ) {
+        List<String> matchedSkills = extractMatchedSkills(candidate, requiredSkillNames);
+
+        return new ReasonFacts(
+                matchedSkills,
+                List.of(), // matchedDomains (placeholder)
+                candidate.careerYears(),
+                createHighlights(candidate, matchedSkills)
+        );
+    }
+
+    private List<String> extractMatchedSkills(
+            ScoredCandidate candidate,
+            Set<String> requiredSkillNames
+    ) {
+        if (requiredSkillNames == null || requiredSkillNames.isEmpty()) {
+            return List.of();
+        }
+        return candidate.ownedSkillNames().stream()
+                .filter(requiredSkillNames::contains)
+                .sorted()
+                .toList();
+    }
+
+    private List<String> createHighlights(
+            ScoredCandidate candidate,
+            List<String> matchedSkills
+    ) {
+        List<String> highlights = new ArrayList<>();
+
+        if (!matchedSkills.isEmpty()) {
+            highlights.add("공토 스킬 " + matchedSkills.size() + "개 보유");
+        }
+
+        if (candidate.careerYears() > 0) {
+            highlights.add("관련 경력 " + candidate.careerYears() + "년");
+        }
+
+        if (candidate.similarityScore() >= 0.8) {
+            highlights.add("요구 조건과 높은 유사도");
+        }
+
+        return highlights;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -1,8 +1,45 @@
 package com.generic4.itda.service.recommend.scoring.model;
 
+import java.util.Set;
+
 public record ScoredCandidate(
         RecommendationScorableCandidate candidate,
         ScoreBreakdown scoreBreakdown
 ) {
 
+    public Long candidateId() {
+        return candidate.candidateId();
+    }
+
+    public Long memberId() {
+        return candidate.memberId();
+    }
+
+    public Long resumeId() {
+        return candidate.resumeId();
+    }
+
+    public int careerYears() {
+        return candidate.careerYears();
+    }
+
+    public Set<String> ownedSkillNames() {
+        return candidate.ownedSkillNames();
+    }
+
+    public double similarityScore() {
+        return scoreBreakdown.similarityScore();
+    }
+
+    public double skillAdjustmentScore() {
+        return scoreBreakdown.skillAdjustmentScore();
+    }
+
+    public double careerAdjustmentScore() {
+        return scoreBreakdown.careerAdjustmentScore();
+    }
+
+    public double finalScore() {
+        return scoreBreakdown.finalScore();
+    }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -229,7 +229,7 @@ class RecommendationResultCreatorTest {
 
             // then
             List<String> highlights = results.get(0).getReasonFacts().highlights();
-            assertThat(highlights).contains("공토 스킬 2개 보유");
+            assertThat(highlights).contains("공통 스킬 2개 보유");
             assertThat(highlights).contains("관련 경력 5년");
             assertThat(highlights).contains("요구 조건과 높은 유사도");
         }
@@ -257,7 +257,7 @@ class RecommendationResultCreatorTest {
             ReasonFacts facts = results.get(0).getReasonFacts();
             assertThat(facts.matchedSkills()).isEmpty();
             assertThat(facts.highlights()).doesNotContainAnyElementsOf(
-                    List.of("공토 스킬 2개 보유")
+                    List.of("공통 스킬 2개 보유")
             );
         }
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -1,0 +1,289 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationResultCreatorTest {
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @InjectMocks
+    private RecommendationResultCreator creator;
+
+    @Nested
+    @DisplayName("finalScore 기준 내림차순 정렬")
+    class SortByFinalScore {
+
+        @Test
+        @DisplayName("여러 후보가 finalScore 내림차순으로 정렬되고 rank는 1부터 순서대로 부여된다")
+        void finalScore_내림차순_정렬_및_rank_순서_검증() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate low = scoredCandidate(1L, 10L, 101L, 0.5, 3);
+            ScoredCandidate mid = scoredCandidate(2L, 20L, 102L, 0.7, 3);
+            ScoredCandidate high = scoredCandidate(3L, 30L, 103L, 0.9, 3);
+
+            Resume resume101 = resumeWithId(101L);
+            Resume resume102 = resumeWithId(102L);
+            Resume resume103 = resumeWithId(103L);
+
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume101, resume102, resume103));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(low, mid, high), 3, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).getRank()).isEqualTo(1);
+            assertThat(results.get(0).getResume()).isEqualTo(resume103); // 0.9
+            assertThat(results.get(1).getRank()).isEqualTo(2);
+            assertThat(results.get(1).getResume()).isEqualTo(resume102); // 0.7
+            assertThat(results.get(2).getRank()).isEqualTo(3);
+            assertThat(results.get(2).getResume()).isEqualTo(resume101); // 0.5
+        }
+    }
+
+    @Nested
+    @DisplayName("resumeId 기준 중복 제거")
+    class DeduplicateByResumeId {
+
+        @Test
+        @DisplayName("같은 resumeId를 가진 후보 중 finalScore가 높은 것만 결과에 포함된다")
+        void 같은_resumeId_중_높은_점수만_결과에_포함() {
+            // given
+            // 낮은 점수가 입력 리스트에 먼저 위치 → 정렬 후 dedup 시 올바르게 제거되는지 검증
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate lowerScore = scoredCandidate(1L, 10L, 100L, 0.4, 2);
+            ScoredCandidate higherScore = scoredCandidate(2L, 20L, 100L, 0.8, 2);
+
+            Resume resume = resumeWithId(100L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(lowerScore, higherScore), 3, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getFinalScore().doubleValue()).isEqualTo(0.8);
+        }
+    }
+
+    @Nested
+    @DisplayName("topK 제한")
+    class TopKLimit {
+
+        @Test
+        @DisplayName("후보가 topK보다 많으면 결과는 정확히 topK개다")
+        void 후보가_topK보다_많으면_결과는_topK개() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 101L, 0.9, 3);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 102L, 0.7, 3);
+            ScoredCandidate c3 = scoredCandidate(3L, 30L, 103L, 0.5, 3);
+
+            Resume resume101 = resumeWithId(101L);
+            Resume resume102 = resumeWithId(102L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume101, resume102));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(c1, c2, c3), 2, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Resume 일괄 조회")
+    class ResumeLoading {
+
+        @Test
+        @DisplayName("resumeRepository.findAllById() 결과가 RecommendationResult에 정확히 매핑된다")
+        void resume_일괄_조회_결과가_결과에_매핑된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 201L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 202L, 0.7, 2);
+
+            Resume resume201 = resumeWithId(201L);
+            Resume resume202 = resumeWithId(202L);
+
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume201, resume202));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(c1, c2), 2, Set.of()
+            );
+
+            // then
+            assertThat(results.get(0).getResume()).isEqualTo(resume201);
+            assertThat(results.get(1).getResume()).isEqualTo(resume202);
+        }
+
+        @Test
+        @DisplayName("일부 resumeId에 해당하는 Resume이 조회되지 않으면 IllegalStateException이 발생한다")
+        void 일부_resume_누락_시_예외_발생() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 301L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 302L, 0.7, 2);
+
+            // 302L에 해당하는 Resume 누락
+            Resume resume301 = resumeWithId(301L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume301));
+
+            // when & then
+            assertThatThrownBy(() -> creator.create(run, List.of(c1, c2), 2, Set.of()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("추천 결과 생성 대상 이력서 일부를 찾을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("ReasonFacts 생성")
+    class ReasonFactsCreation {
+
+        @Test
+        @DisplayName("후보 스킬과 requiredSkillNames의 교집합이 matchedSkills로 정렬되어 설정된다")
+        void matchedSkills가_교집합으로_정확히_계산된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 401L, 0.9, 3,
+                    Set.of("Java", "Spring", "Redis")
+            );
+
+            Resume resume = resumeWithId(401L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of("Spring", "Redis", "Docker")
+            );
+
+            // then
+            ReasonFacts facts = results.get(0).getReasonFacts();
+            assertThat(facts.matchedSkills())
+                    .containsExactly("Redis", "Spring"); // 알파벳 오름차순 정렬
+        }
+
+        @Test
+        @DisplayName("matchedSkills가 있으면 highlights에 스킬 개수가, careerYears > 0이면 경력이, similarityScore >= 0.8이면 유사도 메시지가 포함된다")
+        void highlights가_규칙대로_생성된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            // careerYears=5, similarityScore=0.9, matchedSkills=["Java","Spring"]
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 501L, 0.9, 5,
+                    Set.of("Java", "Spring")
+            );
+
+            Resume resume = resumeWithId(501L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of("Java", "Spring")
+            );
+
+            // then
+            List<String> highlights = results.get(0).getReasonFacts().highlights();
+            assertThat(highlights).contains("공토 스킬 2개 보유");
+            assertThat(highlights).contains("관련 경력 5년");
+            assertThat(highlights).contains("요구 조건과 높은 유사도");
+        }
+
+        @Test
+        @DisplayName("requiredSkillNames가 비어있으면 matchedSkills는 빈 리스트이고 스킬 highlight는 없다")
+        void requiredSkillNames가_비어있으면_matchedSkills_비어있음() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 601L, 0.5, 0,
+                    Set.of("Java", "Spring")
+            );
+
+            Resume resume = resumeWithId(601L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of()
+            );
+
+            // then
+            ReasonFacts facts = results.get(0).getReasonFacts();
+            assertThat(facts.matchedSkills()).isEmpty();
+            assertThat(facts.highlights()).doesNotContainAnyElementsOf(
+                    List.of("공토 스킬 2개 보유")
+            );
+        }
+    }
+
+    // --- fixture helpers ---
+
+    private ScoredCandidate scoredCandidate(
+            Long candidateId, Long memberId, Long resumeId, double finalScore, int careerYears
+    ) {
+        return scoredCandidateWithSkills(candidateId, memberId, resumeId, finalScore, careerYears, Set.of());
+    }
+
+    private ScoredCandidate scoredCandidateWithSkills(
+            Long candidateId, Long memberId, Long resumeId,
+            double finalScore, int careerYears, Set<String> skills
+    ) {
+        RecommendationScorableCandidate candidate = new RecommendationScorableCandidate(
+                candidateId, memberId, resumeId, careerYears, skills
+        );
+        ScoreBreakdown breakdown = new ScoreBreakdown(finalScore, 0.0, 0.0, finalScore);
+        return new ScoredCandidate(candidate, breakdown);
+    }
+
+    private Resume resumeWithId(Long id) {
+        Resume resume = mock(Resume.class);
+        given(resume.getId()).willReturn(id);
+        return resume;
+    }
+}


### PR DESCRIPTION
## 🔎 What

* `RecommendationResult` 생성 로직 구현
* `finalScore` 기준 정렬 및 `topK` 후보 선정
* `resumeId` 기준 중복 제거 로직 적용 (상위 점수 후보 유지)
* `Resume` 일괄 조회 후 결과 매핑 처리
* `ReasonFacts` 생성 로직 구현 (matchedSkills / highlights)
* 결과 생성 책임을 `RecommendationResultCreator`로 분리
> 하드 필터 및 스코어링 결과를 기반으로 추천 결과를 생성하는 파이프라인의 마지막 단계를 구현했습니다.

---

## 🔗 Issue

* Closes: #43 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?