### PR TITLE
[Feat] AI 인터뷰 다단계 질문 및 대화 히스토리 저장

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalAiInterviewController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalAiInterviewController.java
@@ -1,0 +1,35 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.dto.proposal.AiInterviewSendMessageRequest;
+import com.generic4.itda.dto.proposal.AiInterviewSendMessageResponse;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.ProposalAiInterviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/proposals")
+public class ProposalAiInterviewController {
+
+    private final ProposalAiInterviewService proposalAiInterviewService;
+
+    @PostMapping("/{proposalId}/ai-interview/messages")
+    public AiInterviewSendMessageResponse sendMessage(
+            @AuthenticationPrincipal ItDaPrincipal itDaPrincipal,
+            @PathVariable Long proposalId,
+            @Valid @RequestBody AiInterviewSendMessageRequest request
+    ) {
+        return proposalAiInterviewService.sendMessage(
+                proposalId,
+                itDaPrincipal.getEmail(),
+                request.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -3,11 +3,13 @@ package com.generic4.itda.controller;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiInterviewMessageResponse;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.ProposalService;
 import jakarta.validation.Valid;
 import java.util.HashSet;
@@ -38,6 +40,7 @@ public class ProposalController {
     private static final String REGISTER_ACTION = "register";
 
     private final ProposalService proposalService;
+    private final ProposalAiInterviewService proposalAiInterviewService;
     private final PositionRepository positionRepository;
 
     @GetMapping("/new")
@@ -50,6 +53,7 @@ public class ProposalController {
         model.addAttribute("proposalId", null);
         model.addAttribute("isNew", true);
         model.addAttribute("aiBriefRequested", false);
+        model.addAttribute("aiInterviewMessages", List.of());
 
         return "client/proposalForm";
     }
@@ -73,6 +77,7 @@ public class ProposalController {
             model.addAttribute("proposalId", null);
             model.addAttribute("isNew", true);
             model.addAttribute("aiBriefRequested", aiBriefRequested);
+            model.addAttribute("aiInterviewMessages", List.of());
             return "client/proposalForm";
         }
 
@@ -89,6 +94,7 @@ public class ProposalController {
             model.addAttribute("proposalId", null);
             model.addAttribute("isNew", true);
             model.addAttribute("aiBriefRequested", aiBriefRequested);
+            model.addAttribute("aiInterviewMessages", List.of());
             return "client/proposalForm";
         }
     }
@@ -139,6 +145,8 @@ public class ProposalController {
             }
 
             ProposalForm form = proposalService.findOwnedProposalForm(proposalId, principal.getEmail());
+            List<AiInterviewMessageResponse> aiInterviewMessages =
+                    proposalAiInterviewService.findMessageResponses(proposalId, principal.getEmail());
 
             addCommonAttributes(model);
             addMemberAttributes(model, principal);
@@ -146,6 +154,7 @@ public class ProposalController {
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
             model.addAttribute("aiBriefRequested", aiBriefRequested);
+            model.addAttribute("aiInterviewMessages", aiInterviewMessages);
 
             return "client/proposalForm";
         } catch (ProposalNotFoundException e) {
@@ -224,6 +233,7 @@ public class ProposalController {
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
             model.addAttribute("aiBriefRequested", aiBriefRequested);
+            model.addAttribute("aiInterviewMessages", findAiInterviewMessagesOrEmpty(proposalId, principal));
             return "client/proposalForm";
         }
 
@@ -246,6 +256,7 @@ public class ProposalController {
             model.addAttribute("proposalId", proposalId);
             model.addAttribute("isNew", false);
             model.addAttribute("aiBriefRequested", aiBriefRequested);
+            model.addAttribute("aiInterviewMessages", findAiInterviewMessagesOrEmpty(proposalId, principal));
             return "client/proposalForm";
         }
     }
@@ -258,6 +269,18 @@ public class ProposalController {
     private void addMemberAttributes(Model model, ItDaPrincipal principal) {
         model.addAttribute("memberName", principal.getName());
         model.addAttribute("memberEmail", principal.getEmail());
+    }
+
+    private List<AiInterviewMessageResponse> findAiInterviewMessagesOrEmpty(Long proposalId, ItDaPrincipal principal) {
+        if (proposalId == null || principal == null) {
+            return List.of();
+        }
+
+        try {
+            return proposalAiInterviewService.findMessageResponses(proposalId, principal.getEmail());
+        } catch (ProposalNotFoundException | AccessDeniedException e) {
+            return List.of();
+        }
     }
 
     private String redirectAfterSave(Proposal proposal, boolean registerAction, boolean aiBriefRequested) {

--- a/src/main/java/com/generic4/itda/domain/proposal/AiInterviewMessageRole.java
+++ b/src/main/java/com/generic4/itda/domain/proposal/AiInterviewMessageRole.java
@@ -1,0 +1,16 @@
+package com.generic4.itda.domain.proposal;
+
+import lombok.Getter;
+
+@Getter
+public enum AiInterviewMessageRole {
+
+    USER("사용자"),
+    ASSISTANT("AI");
+
+    private final String description;
+
+    AiInterviewMessageRole(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/generic4/itda/domain/proposal/ProposalAiInterviewMessage.java
+++ b/src/main/java/com/generic4/itda/domain/proposal/ProposalAiInterviewMessage.java
@@ -1,0 +1,127 @@
+package com.generic4.itda.domain.proposal;
+
+import com.generic4.itda.domain.shared.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.util.Assert;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = false)
+@Table(
+        name = "proposal_ai_interview_message",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_proposal_ai_interview_message_proposal_sequence",
+                        columnNames = {"proposal_id", "sequence"}
+                )
+        },
+        indexes = {
+                @Index(
+                        name = "idx_proposal_ai_interview_message_proposal_sequence",
+                        columnList = "proposal_id, sequence"
+                )
+        }
+)
+public class ProposalAiInterviewMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proposal_id", nullable = false, updatable = false)
+    private Proposal proposal;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AiInterviewMessageRole role;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ProposalAiInterviewMessage(
+            Proposal proposal,
+            AiInterviewMessageRole role,
+            String content,
+            Integer sequence
+    ) {
+        validateProposal(proposal);
+        validateRole(role);
+        validateContent(content);
+        validateSequence(sequence);
+
+        this.proposal = proposal;
+        this.role = role;
+        this.content = content.trim();
+        this.sequence = sequence;
+    }
+
+    public static ProposalAiInterviewMessage createUserMessage(
+            Proposal proposal,
+            String content,
+            Integer sequence
+    ) {
+        return ProposalAiInterviewMessage.builder()
+                .proposal(proposal)
+                .role(AiInterviewMessageRole.USER)
+                .content(content)
+                .sequence(sequence)
+                .build();
+    }
+
+    public static ProposalAiInterviewMessage createAssistantMessage(
+            Proposal proposal,
+            String content,
+            Integer sequence
+    ) {
+        return ProposalAiInterviewMessage.builder()
+                .proposal(proposal)
+                .role(AiInterviewMessageRole.ASSISTANT)
+                .content(content)
+                .sequence(sequence)
+                .build();
+    }
+
+    public String toRawInputLine() {
+        return "[" + role.name() + "] " + content;
+    }
+
+    private static void validateProposal(Proposal proposal) {
+        Assert.notNull(proposal, "제안서는 필수값입니다.");
+    }
+
+    private static void validateRole(AiInterviewMessageRole role) {
+        Assert.notNull(role, "AI 인터뷰 메시지 역할은 필수값입니다.");
+    }
+
+    private static void validateContent(String content) {
+        Assert.hasText(content, "AI 인터뷰 메시지 내용은 필수값입니다.");
+    }
+
+    private static void validateSequence(Integer sequence) {
+        Assert.notNull(sequence, "AI 인터뷰 메시지 순서는 필수값입니다.");
+        Assert.isTrue(sequence > 0, "AI 인터뷰 메시지 순서는 양수여야 합니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewGenerateRequest.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewGenerateRequest.java
@@ -1,0 +1,40 @@
+package com.generic4.itda.dto.proposal;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+@Getter
+public class AiInterviewGenerateRequest {
+
+    private final ProposalForm proposalForm;
+    private final String conversationText;
+    private final String userMessage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiInterviewGenerateRequest(
+            ProposalForm proposalForm,
+            String conversationText,
+            String userMessage
+    ) {
+        Assert.notNull(proposalForm, "AI 인터뷰 제안서 폼은 필수값입니다.");
+        Assert.hasText(userMessage, "AI 인터뷰 사용자 메시지는 필수값입니다.");
+
+        this.proposalForm = proposalForm;
+        this.conversationText = conversationText == null ? "" : conversationText;
+        this.userMessage = userMessage.trim();
+    }
+
+    public static AiInterviewGenerateRequest of(
+            ProposalForm proposalForm,
+            String conversationText,
+            String userMessage
+    ) {
+        return AiInterviewGenerateRequest.builder()
+                .proposalForm(proposalForm)
+                .conversationText(conversationText)
+                .userMessage(userMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewMessageResponse.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewMessageResponse.java
@@ -1,0 +1,32 @@
+package com.generic4.itda.dto.proposal;
+
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AiInterviewMessageResponse {
+
+    private final Long id;
+    private final String role;
+    private final String content;
+    private final Integer sequence;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiInterviewMessageResponse(Long id, String role, String content, Integer sequence) {
+        this.id = id;
+        this.role = role;
+        this.content = content;
+        this.sequence = sequence;
+    }
+
+    public static AiInterviewMessageResponse from(ProposalAiInterviewMessage message) {
+        return AiInterviewMessageResponse.builder()
+                .id(message.getId())
+                .role(message.getRole().name())
+                .content(message.getContent())
+                .sequence(message.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewResult.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewResult.java
@@ -1,0 +1,29 @@
+package com.generic4.itda.dto.proposal;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+@Getter
+public class AiInterviewResult {
+
+    private final AiBriefResult aiBriefResult;
+    private final String assistantMessage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiInterviewResult(AiBriefResult aiBriefResult, String assistantMessage) {
+        Assert.notNull(aiBriefResult, "AI 인터뷰 브리프 결과는 필수값입니다.");
+        Assert.hasText(assistantMessage, "AI 인터뷰 후속 질문은 필수값입니다.");
+
+        this.aiBriefResult = aiBriefResult;
+        this.assistantMessage = assistantMessage.trim();
+    }
+
+    public static AiInterviewResult of(AiBriefResult aiBriefResult, String assistantMessage) {
+        return AiInterviewResult.builder()
+                .aiBriefResult(aiBriefResult)
+                .assistantMessage(assistantMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewSendMessageRequest.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewSendMessageRequest.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.dto.proposal;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiInterviewSendMessageRequest {
+
+    @NotBlank(message = "AI 인터뷰 메시지는 필수값입니다.")
+    @Size(max = 5000, message = "AI 인터뷰 메시지는 5000자를 초과할 수 없습니다.")
+    private String message;
+}

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewSendMessageResponse.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewSendMessageResponse.java
@@ -1,0 +1,37 @@
+package com.generic4.itda.dto.proposal;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AiInterviewSendMessageResponse {
+
+    private final ProposalForm proposalForm;
+    private final List<AiInterviewMessageResponse> messages;
+    private final String assistantMessage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AiInterviewSendMessageResponse(
+            ProposalForm proposalForm,
+            List<AiInterviewMessageResponse> messages,
+            String assistantMessage
+    ) {
+        this.proposalForm = proposalForm;
+        this.messages = messages == null ? List.of() : List.copyOf(messages);
+        this.assistantMessage = assistantMessage;
+    }
+
+    public static AiInterviewSendMessageResponse of(
+            ProposalForm proposalForm,
+            List<AiInterviewMessageResponse> messages,
+            String assistantMessage
+    ) {
+        return AiInterviewSendMessageResponse.builder()
+                .proposalForm(proposalForm)
+                .messages(messages)
+                .assistantMessage(assistantMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/ProposalAiInterviewMessageRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ProposalAiInterviewMessageRepository.java
@@ -1,0 +1,15 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProposalAiInterviewMessageRepository extends JpaRepository<ProposalAiInterviewMessage, Long> {
+
+    List<ProposalAiInterviewMessage> findAllByProposalIdOrderBySequenceAsc(Long proposalId);
+
+    Optional<ProposalAiInterviewMessage> findTopByProposalIdOrderBySequenceDesc(Long proposalId);
+
+    void deleteAllByProposalId(Long proposalId);
+}

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -38,6 +38,20 @@ public class AiBriefProposalMapper {
         Assert.notNull(proposal, "제안서는 필수값입니다.");
         Assert.notNull(aiBriefResult, "AI 브리프 결과는 필수값입니다.");
 
+        applyProposalFields(proposal, aiBriefResult);
+        mergePositions(proposal, aiBriefResult.getPositions(), true, Set.of());
+    }
+
+    public void applyForInterview(Proposal proposal, AiBriefResult aiBriefResult, String userMessage) {
+        Assert.notNull(proposal, "제안서는 필수값입니다.");
+        Assert.notNull(aiBriefResult, "AI 브리프 결과는 필수값입니다.");
+
+        Set<String> deletedPositionKeys = removeExplicitlyDeletedPositions(proposal, userMessage);
+        applyProposalFields(proposal, aiBriefResult);
+        mergePositions(proposal, aiBriefResult.getPositions(), false, deletedPositionKeys);
+    }
+
+    private void applyProposalFields(Proposal proposal, AiBriefResult aiBriefResult) {
         proposal.update(
                 resolveTitle(proposal, aiBriefResult),
                 proposal.getRawInputText(),
@@ -46,11 +60,14 @@ public class AiBriefProposalMapper {
                 resolveTotalBudgetMax(proposal, aiBriefResult),
                 resolveExpectedPeriod(proposal, aiBriefResult)
         );
-
-        mergePositions(proposal, aiBriefResult.getPositions());
     }
 
-    private void mergePositions(Proposal proposal, List<AiBriefPositionResult> positionResults) {
+    private void mergePositions(
+            Proposal proposal,
+            List<AiBriefPositionResult> positionResults,
+            boolean removePositionsNotInAiResult,
+            Set<String> ignoredPositionKeys
+    ) {
         if (positionResults == null || positionResults.isEmpty()) {
             return;
         }
@@ -60,7 +77,12 @@ public class AiBriefProposalMapper {
         Set<ProposalPosition> appliedPositions = new HashSet<>();
 
         for (PositionApplication application : applications) {
-            ProposalPosition proposalPosition = existingByPositionName.get(normalizeKey(application.position().getName()));
+            String positionKey = normalizeKey(application.position().getName());
+            if (ignoredPositionKeys.contains(positionKey)) {
+                continue;
+            }
+
+            ProposalPosition proposalPosition = existingByPositionName.get(positionKey);
             AiBriefPositionResult result = application.result();
             ProposalWorkType workType = resolveWorkType(result);
             String workPlace = resolveWorkPlace(workType, result.getWorkPlace());
@@ -97,7 +119,91 @@ public class AiBriefProposalMapper {
             appliedPositions.add(proposalPosition);
         }
 
-        removePositionsNotInAiResult(proposal, appliedPositions);
+        if (removePositionsNotInAiResult) {
+            removePositionsNotInAiResult(proposal, appliedPositions);
+        }
+    }
+
+    private Set<String> removeExplicitlyDeletedPositions(Proposal proposal, String userMessage) {
+        Set<String> deletedPositionKeys = new HashSet<>();
+        if (!StringUtils.hasText(userMessage)) {
+            return deletedPositionKeys;
+        }
+
+        List<String> messageParts = splitMessageParts(userMessage);
+        List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
+
+        for (ProposalPosition existingPosition : existingPositions) {
+            if (isExplicitlyDeleted(existingPosition, messageParts)) {
+                if (existingPosition.getPosition() != null) {
+                    deletedPositionKeys.add(normalizeKey(existingPosition.getPosition().getName()));
+                }
+                proposal.removePosition(existingPosition);
+            }
+        }
+
+        return deletedPositionKeys;
+    }
+
+    private boolean isExplicitlyDeleted(ProposalPosition existingPosition, List<String> messageParts) {
+        String positionName = existingPosition.getPosition() == null ? "" : existingPosition.getPosition().getName();
+        String title = existingPosition.getTitle();
+
+        for (String messagePart : messageParts) {
+            if (!hasDeleteIntent(messagePart)) {
+                continue;
+            }
+
+            String normalizedMessagePart = normalizeForContains(messagePart);
+            boolean positionNameMatched = containsNormalized(normalizedMessagePart, positionName);
+            boolean titleMatched = containsNormalized(normalizedMessagePart, title);
+
+            if (positionNameMatched || titleMatched) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private List<String> splitMessageParts(String userMessage) {
+        return List.of(userMessage.split("[,，.。!?！？\\n]|그리고|또|및|\\s+하고\\s+|\\s+가고\\s+|\\s+으로\\s+가고\\s+"))
+                .stream()
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+    }
+
+    private boolean hasDeleteIntent(String messagePart) {
+        if (!StringUtils.hasText(messagePart)) {
+            return false;
+        }
+
+        String normalized = normalizeForContains(messagePart);
+        return normalized.contains("빼")
+                || normalized.contains("제외")
+                || normalized.contains("삭제")
+                || normalized.contains("제거")
+                || normalized.contains("필요없")
+                || normalized.contains("안뽑")
+                || normalized.contains("안구")
+                || normalized.contains("없애");
+    }
+
+    private boolean containsNormalized(String normalizedSource, String target) {
+        if (!StringUtils.hasText(normalizedSource) || !StringUtils.hasText(target)) {
+            return false;
+        }
+        return normalizedSource.contains(normalizeForContains(target));
+    }
+
+    private String normalizeForContains(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase()
+                .replaceAll("\\s+", "")
+                .trim();
     }
 
     private void removePositionsNotInAiResult(Proposal proposal, Set<ProposalPosition> appliedPositions) {

--- a/src/main/java/com/generic4/itda/service/AiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/AiInterviewGenerator.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.dto.proposal.AiInterviewGenerateRequest;
+import com.generic4.itda.dto.proposal.AiInterviewResult;
+
+public interface AiInterviewGenerator {
+
+    AiInterviewResult generate(AiInterviewGenerateRequest request);
+}

--- a/src/main/java/com/generic4/itda/service/DisabledAiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/DisabledAiInterviewGenerator.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.dto.proposal.AiInterviewGenerateRequest;
+import com.generic4.itda.dto.proposal.AiInterviewResult;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "ai.brief", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class DisabledAiInterviewGenerator implements AiInterviewGenerator {
+
+    @Override
+    public AiInterviewResult generate(AiInterviewGenerateRequest request) {
+        throw new AiBriefGenerationException("AI 인터뷰 생성 어댑터가 등록되지 않았습니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
@@ -1,0 +1,504 @@
+package com.generic4.itda.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.AiBriefProperties;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.proposal.AiBriefPositionResult;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiBriefSkillResult;
+import com.generic4.itda.dto.proposal.AiInterviewGenerateRequest;
+import com.generic4.itda.dto.proposal.AiInterviewResult;
+import com.generic4.itda.dto.proposal.ProposalForm;
+import com.generic4.itda.dto.proposal.ProposalPositionForm;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "ai.brief", name = "enabled", havingValue = "true")
+public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
+
+    private static final String INTERVIEW_GENERATION_INSTRUCTIONS = """
+            당신은 IT 외주/프로젝트 제안서를 완성하기 위한 AI 인터뷰 도우미다.
+            사용자의 현재 제안서 폼 상태, 이전 대화 히스토리, 방금 사용자 메시지를 바탕으로
+            제안서 폼을 점진적으로 갱신할 JSON과 다음에 물어볼 후속 질문을 생성한다.
+
+            반드시 지킬 규칙:
+            - 반드시 JSON만 반환한다.
+            - 마크다운 코드블록, 설명문, 주석, 추가 텍스트를 절대 포함하지 않는다.
+            - aiBriefResult에는 현재까지 확인된 정보를 반영한 제안서 초안을 반환한다.
+            - assistantMessage에는 사용자에게 보여줄 다음 AI 메시지를 한국어로 자연스럽게 작성한다.
+            - 근거가 부족한 값은 추측하지 말고 null로 반환한다.
+            - 기존 폼에 이미 있는 값은 사용자가 바꾸거나 삭제하라고 하지 않았다면 최대한 유지한다.
+            - 사용자가 정정한 값은 최신 사용자 메시지를 우선한다.
+            - 사용자가 제거/삭제/빼달라고 한 포지션은 positions에서 제외한다.
+            - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
+            - expectedPeriod는 주 단위 기준 정수로 반환한다.
+            - position별 workType은 SITE, REMOTE, HYBRID 중 하나만 사용한다.
+            - REMOTE인 경우 workPlace는 null로 둔다.
+            - SITE 또는 HYBRID인데 근무지를 알 수 없으면 workPlace는 "협의"로 둔다.
+            - headCount가 명확하지 않으면 1로 둔다.
+            - skills.importance는 ESSENTIAL 또는 PREFERENCE만 사용한다.
+            - importance를 확신할 수 없으면 PREFERENCE를 사용한다.
+            - skillName은 짧고 일반적인 명칭으로 정리한다.
+            - position별 skills는 최대 4개까지만 반환한다.
+            - 같은 positionCategoryName을 중복 생성하지 않는다.
+            - 같은 직무 안에서 역할이 나뉘는 경우 하나의 모집 단위 title/description에 통합해서 표현한다.
+            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 프론트엔드 개발자, 앱 개발자
+            - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Java Spring 백엔드 개발자, React 프론트엔드 개발자
+
+            질문 방식:
+            - 폼에 비어 있는 필드를 전부 한 번에 나열해서 묻지 않는다.
+            - 한 번에 1~2개의 주제만 묻는다.
+            - 포지션이 여러 개면 하나의 포지션을 먼저 구체화한 뒤 다음 포지션으로 넘어간다.
+            - 예: 백엔드 개발자 → 인원/근무형태 → 기간/예산 → 기술스택/경력 → 프론트엔드 개발자 순서
+            - assistantMessage에는 방금 반영한 내용이 있으면 짧게 요약하고, 다음 질문을 이어서 작성한다.
+            - 이미 충분히 구체화된 항목은 반복해서 묻지 않는다.
+            """;
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final AiBriefProperties properties;
+
+    public OpenAiAiInterviewGenerator(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            AiBriefProperties properties
+    ) {
+        Assert.hasText(properties.getApiKey(), "AI 브리프 API 키는 필수값입니다.");
+
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    @Override
+    public AiInterviewResult generate(AiInterviewGenerateRequest request) {
+        Assert.notNull(request, "AI 인터뷰 요청은 필수값입니다.");
+
+        try {
+            JsonNode responseBody = restClient.post()
+                    .uri(properties.getApiUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .headers(headers -> headers.setBearerAuth(properties.getApiKey()))
+                    .body(buildRequestBody(request))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            String responseText = extractResponseText(responseBody);
+            try {
+                return toAiInterviewResult(responseText);
+            } catch (JsonProcessingException exception) {
+                log.warn("AI 인터뷰 응답 JSON 파싱 실패. responseText={}", abbreviate(responseText, 2000), exception);
+                throw exception;
+            }
+        } catch (AiBriefGenerationException exception) {
+            throw exception;
+        } catch (RestClientException exception) {
+            throw new AiBriefGenerationException("OpenAI AI 인터뷰 호출에 실패했습니다.", exception);
+        } catch (JsonProcessingException exception) {
+            throw new AiBriefGenerationException("AI 인터뷰 응답 파싱에 실패했습니다.", exception);
+        } catch (RuntimeException exception) {
+            throw new AiBriefGenerationException("AI 인터뷰 생성에 실패했습니다.", exception);
+        }
+    }
+
+    private Map<String, Object> buildRequestBody(AiInterviewGenerateRequest request) {
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("model", properties.getModel());
+        requestBody.put("instructions", INTERVIEW_GENERATION_INSTRUCTIONS);
+        requestBody.put("input", buildInput(request));
+        requestBody.put("max_output_tokens", properties.getMaxOutputTokens());
+
+        Map<String, Object> text = new LinkedHashMap<>();
+        text.put("format", buildJsonSchemaFormat());
+        requestBody.put("text", text);
+
+        return requestBody;
+    }
+
+    private String buildInput(AiInterviewGenerateRequest request) {
+        return """
+                [현재 제안서 폼 상태]
+                %s
+
+                [이전 대화 히스토리]
+                %s
+
+                [방금 사용자 메시지]
+                %s
+                """.formatted(
+                toJson(request.getProposalForm()),
+                blankToNone(request.getConversationText()),
+                request.getUserMessage()
+        );
+    }
+
+    private String toJson(ProposalForm proposalForm) {
+        try {
+            return objectMapper.writeValueAsString(proposalForm);
+        } catch (JsonProcessingException exception) {
+            throw new AiBriefGenerationException("AI 인터뷰 제안서 폼 직렬화에 실패했습니다.", exception);
+        }
+    }
+
+    private String blankToNone(String value) {
+        return StringUtils.hasText(value) ? value : "(없음)";
+    }
+
+    private Map<String, Object> buildJsonSchemaFormat() {
+        Map<String, Object> format = new LinkedHashMap<>();
+        format.put("type", "json_schema");
+        format.put("name", "proposal_ai_interview");
+        format.put("strict", true);
+        format.put("schema", buildSchema());
+        return format;
+    }
+
+    private Map<String, Object> buildSchema() {
+        Map<String, Object> schema = objectSchema();
+        schema.put("required", List.of("aiBriefResult", "assistantMessage"));
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("aiBriefResult", buildAiBriefResultSchema());
+        properties.put("assistantMessage", Map.of("type", "string"));
+
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    private Map<String, Object> buildAiBriefResultSchema() {
+        Map<String, Object> schema = objectSchema();
+
+        schema.put("required", List.of(
+                "title",
+                "description",
+                "totalBudgetMin",
+                "totalBudgetMax",
+                "expectedPeriod",
+                "positions"
+        ));
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("title", nullableStringSchema());
+        properties.put("description", nullableStringSchema());
+        properties.put("totalBudgetMin", nullableIntegerSchema());
+        properties.put("totalBudgetMax", nullableIntegerSchema());
+        properties.put("expectedPeriod", nullableIntegerSchema());
+        properties.put("positions", Map.of(
+                "type", "array",
+                "items", buildPositionSchema()
+        ));
+
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    private Map<String, Object> buildPositionSchema() {
+        Map<String, Object> schema = objectSchema();
+
+        schema.put("required", List.of(
+                "positionCategoryName",
+                "title",
+                "workType",
+                "headCount",
+                "unitBudgetMin",
+                "unitBudgetMax",
+                "expectedPeriod",
+                "careerMinYears",
+                "careerMaxYears",
+                "workPlace",
+                "skills"
+        ));
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("positionCategoryName", Map.of("type", "string"));
+        properties.put("title", Map.of("type", "string"));
+        properties.put("workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"));
+        properties.put("headCount", nullableIntegerSchema());
+        properties.put("unitBudgetMin", nullableIntegerSchema());
+        properties.put("unitBudgetMax", nullableIntegerSchema());
+        properties.put("expectedPeriod", nullableIntegerSchema());
+        properties.put("careerMinYears", nullableIntegerSchema());
+        properties.put("careerMaxYears", nullableIntegerSchema());
+        properties.put("workPlace", nullableStringSchema());
+        properties.put("skills", Map.of(
+                "type", "array",
+                "items", buildSkillSchema()
+        ));
+
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    private Map<String, Object> buildSkillSchema() {
+        Map<String, Object> schema = objectSchema();
+        schema.put("required", List.of("skillName", "importance"));
+        schema.put("properties", Map.of(
+                "skillName", Map.of("type", "string"),
+                "importance", nullableEnumSchema("ESSENTIAL", "PREFERENCE")
+        ));
+        return schema;
+    }
+
+    private Map<String, Object> objectSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+        return schema;
+    }
+
+    private Map<String, Object> nullableStringSchema() {
+        return Map.of("type", List.of("string", "null"));
+    }
+
+    private Map<String, Object> nullableIntegerSchema() {
+        return Map.of("type", List.of("integer", "null"));
+    }
+
+    private Map<String, Object> nullableEnumSchema(String... values) {
+        List<Object> enumValues = new ArrayList<>(List.of(values));
+        enumValues.add(null);
+        return Map.of(
+                "type", List.of("string", "null"),
+                "enum", enumValues
+        );
+    }
+
+    private String extractResponseText(JsonNode responseBody) {
+        if (responseBody == null || responseBody.isNull()) {
+            throw new AiBriefGenerationException("AI 인터뷰 응답이 비어 있습니다.");
+        }
+
+        String directOutput = readText(responseBody.get("output_text"));
+        if (StringUtils.hasText(directOutput)) {
+            return directOutput;
+        }
+
+        String refusalMessage = null;
+        JsonNode output = responseBody.get("output");
+        if (output != null && output.isArray()) {
+            for (JsonNode item : output) {
+                JsonNode content = item.get("content");
+                if (content == null || !content.isArray()) {
+                    continue;
+                }
+                for (JsonNode contentItem : content) {
+                    String text = readText(contentItem.get("text"));
+                    if (StringUtils.hasText(text)) {
+                        return text;
+                    }
+                    String refusal = readText(contentItem.get("refusal"));
+                    if (StringUtils.hasText(refusal)) {
+                        refusalMessage = refusal;
+                    }
+                }
+            }
+        }
+
+        if (StringUtils.hasText(refusalMessage)) {
+            throw new AiBriefGenerationException("AI 인터뷰 생성을 거부했습니다. " + refusalMessage);
+        }
+        throw new AiBriefGenerationException("AI 인터뷰 응답에서 본문을 찾을 수 없습니다.");
+    }
+
+    private String readText(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        JsonNode valueNode = node.get("value");
+        if (valueNode != null && valueNode.isTextual()) {
+            return valueNode.asText();
+        }
+        return null;
+    }
+
+    private AiInterviewResult toAiInterviewResult(String responseText) throws JsonProcessingException {
+        JsonNode root = objectMapper.readTree(extractJsonObject(responseText));
+
+        return AiInterviewResult.of(
+                parseAiBriefResult(root.get("aiBriefResult")),
+                normalizeRequiredText(root.get("assistantMessage"), "AI 인터뷰 후속 질문은 필수값입니다.")
+        );
+    }
+
+    private AiBriefResult parseAiBriefResult(JsonNode node) {
+        if (node == null || node.isNull() || !node.isObject()) {
+            throw new AiBriefGenerationException("AI 인터뷰 브리프 결과가 비어 있습니다.");
+        }
+
+        return AiBriefResult.of(
+                normalizeText(node.get("title")),
+                normalizeText(node.get("description")),
+                asLong(node.get("totalBudgetMin")),
+                asLong(node.get("totalBudgetMax")),
+                asLong(node.get("expectedPeriod")),
+                parsePositions(node.get("positions"))
+        );
+    }
+
+    private String extractJsonObject(String responseText) throws JsonProcessingException {
+        if (!StringUtils.hasText(responseText)) {
+            throw new JsonProcessingException("AI 인터뷰 응답 본문이 비어 있습니다.") {
+            };
+        }
+
+        String text = stripCodeFence(responseText.trim());
+        int start = text.indexOf('{');
+        int end = text.lastIndexOf('}');
+
+        if (start < 0 || end < start) {
+            throw new JsonProcessingException("AI 인터뷰 응답에서 JSON 객체를 찾을 수 없습니다. responseText="
+                    + abbreviate(text, 500)) {
+            };
+        }
+
+        return text.substring(start, end + 1);
+    }
+
+    private String stripCodeFence(String responseText) {
+        String text = responseText.trim();
+
+        if (text.startsWith("```")) {
+            int firstLineEnd = text.indexOf('\n');
+            int lastFenceStart = text.lastIndexOf("```");
+
+            if (firstLineEnd >= 0 && lastFenceStart > firstLineEnd) {
+                return text.substring(firstLineEnd + 1, lastFenceStart).trim();
+            }
+        }
+
+        return text;
+    }
+
+    private String abbreviate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
+    }
+
+    private List<AiBriefPositionResult> parsePositions(JsonNode positionsNode) {
+        if (positionsNode == null || positionsNode.isNull() || !positionsNode.isArray()) {
+            return List.of();
+        }
+
+        List<AiBriefPositionResult> positions = new ArrayList<>();
+        for (JsonNode positionNode : positionsNode) {
+            positions.add(AiBriefPositionResult.of(
+                    normalizeRequiredText(positionNode.get("positionCategoryName"), "AI 인터뷰 포지션 카테고리는 필수값입니다."),
+                    normalizeRequiredText(positionNode.get("title"), "AI 인터뷰 포지션 제목은 필수값입니다."),
+                    parseWorkType(positionNode.get("workType")),
+                    asLong(positionNode.get("headCount")),
+                    asLong(positionNode.get("unitBudgetMin")),
+                    asLong(positionNode.get("unitBudgetMax")),
+                    asLong(positionNode.get("expectedPeriod")),
+                    asInteger(positionNode.get("careerMinYears")),
+                    asInteger(positionNode.get("careerMaxYears")),
+                    normalizeText(positionNode.get("workPlace")),
+                    parseSkills(positionNode.get("skills"))
+            ));
+        }
+        return positions;
+    }
+
+    private List<AiBriefSkillResult> parseSkills(JsonNode skillsNode) {
+        if (skillsNode == null || skillsNode.isNull() || !skillsNode.isArray()) {
+            return List.of();
+        }
+
+        List<AiBriefSkillResult> skills = new ArrayList<>();
+        for (JsonNode skillNode : skillsNode) {
+            skills.add(AiBriefSkillResult.of(
+                    normalizeRequiredText(skillNode.get("skillName"), "AI 인터뷰 스킬명은 필수값입니다."),
+                    parseImportance(skillNode.get("importance"))
+            ));
+        }
+        return skills;
+    }
+
+    private ProposalWorkType parseWorkType(JsonNode node) {
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return ProposalWorkType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new AiBriefGenerationException("지원하지 않는 근무 형태입니다. value=" + value, exception);
+        }
+    }
+
+    private ProposalPositionSkillImportance parseImportance(JsonNode node) {
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return ProposalPositionSkillImportance.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new AiBriefGenerationException("지원하지 않는 스킬 중요도입니다. value=" + value, exception);
+        }
+    }
+
+    private Long asLong(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isIntegralNumber()) {
+            return node.longValue();
+        }
+        String value = normalizeText(node);
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException exception) {
+            throw new AiBriefGenerationException("숫자 필드 파싱에 실패했습니다. value=" + value, exception);
+        }
+    }
+
+    private Integer asInteger(JsonNode node) {
+        Long value = asLong(node);
+        if (value == null) {
+            return null;
+        }
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new AiBriefGenerationException("정수 범위를 벗어났습니다. value=" + value);
+        }
+        return value.intValue();
+    }
+
+    private String normalizeRequiredText(JsonNode node, String message) {
+        String value = normalizeText(node);
+        Assert.hasText(value, message);
+        return value;
+    }
+
+    private String normalizeText(JsonNode node) {
+        String value = readText(node);
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiBriefService.java
@@ -1,17 +1,22 @@
 package com.generic4.itda.service;
 
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.exception.AiBriefGenerationException;
 import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
 import com.generic4.itda.repository.ProposalRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 @Service
 @Transactional
@@ -19,6 +24,7 @@ import org.springframework.util.Assert;
 public class ProposalAiBriefService {
 
     private final ProposalRepository proposalRepository;
+    private final ProposalAiInterviewMessageRepository messageRepository;
     private final AiBriefGenerator aiBriefGenerator;
     private final AiBriefProposalMapper aiBriefProposalMapper;
 
@@ -33,9 +39,46 @@ public class ProposalAiBriefService {
         Assert.state(proposal.getStatus() == ProposalStatus.WRITING,
                 "작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
 
-        AiBriefResult aiBriefResult = generateAiBrief(proposal.getRawInputText());
+        String aiBriefInput = resolveAiBriefInput(proposalId, proposal);
+        syncRawInputText(proposal, aiBriefInput);
+
+        AiBriefResult aiBriefResult = generateAiBrief(aiBriefInput);
         aiBriefProposalMapper.apply(proposal, aiBriefResult);
         return aiBriefResult;
+    }
+
+    private String resolveAiBriefInput(Long proposalId, Proposal proposal) {
+        String conversationText = findConversationText(proposalId);
+        if (StringUtils.hasText(conversationText)) {
+            return conversationText;
+        }
+        return proposal.getRawInputText();
+    }
+
+    private String findConversationText(Long proposalId) {
+        List<ProposalAiInterviewMessage> messages = messageRepository.findAllByProposalIdOrderBySequenceAsc(proposalId);
+        if (messages.isEmpty()) {
+            return "";
+        }
+
+        return messages.stream()
+                .map(ProposalAiInterviewMessage::toRawInputLine)
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private void syncRawInputText(Proposal proposal, String rawInputText) {
+        if (!StringUtils.hasText(rawInputText)) {
+            return;
+        }
+
+        proposal.update(
+                proposal.getTitle(),
+                rawInputText,
+                proposal.getDescription(),
+                proposal.getTotalBudgetMin(),
+                proposal.getTotalBudgetMax(),
+                proposal.getExpectedPeriod()
+        );
     }
 
     private AiBriefResult generateAiBrief(String rawInputText) {

--- a/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
@@ -1,0 +1,201 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.dto.proposal.AiInterviewGenerateRequest;
+import com.generic4.itda.dto.proposal.AiInterviewMessageResponse;
+import com.generic4.itda.dto.proposal.AiInterviewResult;
+import com.generic4.itda.dto.proposal.AiInterviewSendMessageResponse;
+import com.generic4.itda.dto.proposal.ProposalForm;
+import com.generic4.itda.exception.AiBriefGenerationException;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProposalAiInterviewService {
+
+    private final ProposalRepository proposalRepository;
+    private final ProposalAiInterviewMessageRepository messageRepository;
+    private final AiInterviewGenerator aiInterviewGenerator;
+    private final AiBriefProposalMapper aiBriefProposalMapper;
+
+    public AiInterviewSendMessageResponse sendMessage(Long proposalId, String memberEmail, String userMessage) {
+        Assert.notNull(proposalId, "제안서 id는 필수값입니다.");
+        Assert.hasText(memberEmail, "회원 이메일은 필수값입니다.");
+        Assert.hasText(userMessage, "AI 인터뷰 사용자 메시지는 필수값입니다.");
+
+        Proposal proposal = getWritableProposalWithPositions(proposalId, memberEmail);
+        List<ProposalAiInterviewMessage> previousMessages = findMessages(proposalId);
+        String previousConversationText = toConversationText(previousMessages);
+
+        ProposalAiInterviewMessage savedUserMessage = saveUserMessage(
+                proposal,
+                userMessage,
+                nextSequence(previousMessages)
+        );
+
+        ProposalForm proposalFormBeforeAi = ProposalForm.from(proposal);
+        AiInterviewResult aiInterviewResult = generateAiInterview(
+                proposalFormBeforeAi,
+                previousConversationText,
+                savedUserMessage.getContent()
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiInterviewResult.getAiBriefResult());
+
+        ProposalAiInterviewMessage savedAssistantMessage = saveAssistantMessage(
+                proposal,
+                aiInterviewResult.getAssistantMessage(),
+                savedUserMessage.getSequence() + 1
+        );
+
+        List<ProposalAiInterviewMessage> currentMessages = new ArrayList<>(previousMessages);
+        currentMessages.add(savedUserMessage);
+        currentMessages.add(savedAssistantMessage);
+
+        syncRawInputText(proposal, currentMessages);
+
+        ProposalForm proposalForm = ProposalForm.from(proposal);
+        List<AiInterviewMessageResponse> messageResponses = toMessageResponses(currentMessages);
+
+        return AiInterviewSendMessageResponse.of(
+                proposalForm,
+                messageResponses,
+                savedAssistantMessage.getContent()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<AiInterviewMessageResponse> findMessageResponses(Long proposalId, String memberEmail) {
+        Assert.notNull(proposalId, "제안서 id는 필수값입니다.");
+        Assert.hasText(memberEmail, "회원 이메일은 필수값입니다.");
+
+        Proposal proposal = proposalRepository.findById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+
+        validateOwnership(proposal, memberEmail);
+
+        return toMessageResponses(findMessages(proposalId));
+    }
+
+    private Proposal getWritableProposalWithPositions(Long proposalId, String memberEmail) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+
+        validateOwnership(proposal, memberEmail);
+        validateWritable(proposal);
+
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
+    }
+
+    private void validateOwnership(Proposal proposal, String memberEmail) {
+        if (!proposal.getMember().getEmail().getValue().equals(memberEmail)) {
+            throw new AccessDeniedException("본인 제안서에 대해서만 AI 인터뷰를 진행할 수 있습니다.");
+        }
+    }
+
+    private void validateWritable(Proposal proposal) {
+        if (proposal.getStatus() != ProposalStatus.WRITING) {
+            throw new IllegalStateException("작성 중인 제안서만 AI 인터뷰를 진행할 수 있습니다.");
+        }
+    }
+
+    private List<ProposalAiInterviewMessage> findMessages(Long proposalId) {
+        return messageRepository.findAllByProposalIdOrderBySequenceAsc(proposalId);
+    }
+
+    private Integer nextSequence(List<ProposalAiInterviewMessage> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return 1;
+        }
+        return messages.get(messages.size() - 1).getSequence() + 1;
+    }
+
+    private ProposalAiInterviewMessage saveUserMessage(Proposal proposal, String content, Integer sequence) {
+        ProposalAiInterviewMessage message = ProposalAiInterviewMessage.createUserMessage(
+                proposal,
+                content,
+                sequence
+        );
+        return messageRepository.save(message);
+    }
+
+    private ProposalAiInterviewMessage saveAssistantMessage(Proposal proposal, String content, Integer sequence) {
+        ProposalAiInterviewMessage message = ProposalAiInterviewMessage.createAssistantMessage(
+                proposal,
+                content,
+                sequence
+        );
+        return messageRepository.save(message);
+    }
+
+    private AiInterviewResult generateAiInterview(
+            ProposalForm proposalForm,
+            String previousConversationText,
+            String userMessage
+    ) {
+        try {
+            return aiInterviewGenerator.generate(
+                    AiInterviewGenerateRequest.of(
+                            proposalForm,
+                            previousConversationText,
+                            userMessage
+                    )
+            );
+        } catch (AiBriefGenerationException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw new AiBriefGenerationException("AI 인터뷰 생성에 실패했습니다.", exception);
+        }
+    }
+
+    private void syncRawInputText(Proposal proposal, List<ProposalAiInterviewMessage> messages) {
+        String conversationText = toConversationText(messages);
+        String rawInputText = StringUtils.hasText(conversationText) ? conversationText : proposal.getRawInputText();
+
+        proposal.update(
+                proposal.getTitle(),
+                rawInputText,
+                proposal.getDescription(),
+                proposal.getTotalBudgetMin(),
+                proposal.getTotalBudgetMax(),
+                proposal.getExpectedPeriod()
+        );
+    }
+
+    private String toConversationText(List<ProposalAiInterviewMessage> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return "";
+        }
+
+        return messages.stream()
+                .map(ProposalAiInterviewMessage::toRawInputLine)
+                .toList()
+                .stream()
+                .reduce((left, right) -> left + System.lineSeparator() + right)
+                .orElse("");
+    }
+
+    private List<AiInterviewMessageResponse> toMessageResponses(List<ProposalAiInterviewMessage> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return List.of();
+        }
+
+        return messages.stream()
+                .map(AiInterviewMessageResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
@@ -47,6 +47,8 @@ public class ProposalAiInterviewService {
         );
 
         ProposalForm proposalFormBeforeAi = ProposalForm.from(proposal);
+        proposalFormBeforeAi.setRawInputText("");
+
         AiInterviewResult aiInterviewResult = generateAiInterview(
                 proposalFormBeforeAi,
                 previousConversationText,

--- a/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalAiInterviewService.java
@@ -53,7 +53,11 @@ public class ProposalAiInterviewService {
                 savedUserMessage.getContent()
         );
 
-        aiBriefProposalMapper.apply(proposal, aiInterviewResult.getAiBriefResult());
+        aiBriefProposalMapper.applyForInterview(
+                proposal,
+                aiInterviewResult.getAiBriefResult(),
+                savedUserMessage.getContent()
+        );
 
         ProposalAiInterviewMessage savedAssistantMessage = saveAssistantMessage(
                 proposal,

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -3,7 +3,9 @@ package com.generic4.itda.service;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.AiInterviewMessageRole;
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
@@ -15,6 +17,7 @@ import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
 import java.util.ArrayList;
@@ -49,6 +52,7 @@ public class ProposalService {
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
     private final MatchingRepository matchingRepository;
+    private final ProposalAiInterviewMessageRepository aiInterviewMessageRepository;
 
     public Proposal saveDraft(String memberEmail, ProposalForm form) {
         Member member = getMemberByEmail(memberEmail);
@@ -392,7 +396,40 @@ public class ProposalService {
             );
         }
 
-        return proposalRepository.save(draftCopy);
+        Proposal savedDraft = proposalRepository.save(draftCopy);
+        copyAiInterviewMessages(proposalId, savedDraft);
+        return savedDraft;
+    }
+
+    private void copyAiInterviewMessages(Long sourceProposalId, Proposal draftCopy) {
+        List<ProposalAiInterviewMessage> sourceMessages =
+                aiInterviewMessageRepository.findAllByProposalIdOrderBySequenceAsc(sourceProposalId);
+
+        if (sourceMessages == null || sourceMessages.isEmpty()) {
+            return;
+        }
+
+        List<ProposalAiInterviewMessage> copiedMessages = sourceMessages.stream()
+                .map(message -> copyAiInterviewMessage(draftCopy, message))
+                .toList();
+
+        aiInterviewMessageRepository.saveAll(copiedMessages);
+    }
+
+    private ProposalAiInterviewMessage copyAiInterviewMessage(Proposal draftCopy, ProposalAiInterviewMessage sourceMessage) {
+        if (sourceMessage.getRole() == AiInterviewMessageRole.USER) {
+            return ProposalAiInterviewMessage.createUserMessage(
+                    draftCopy,
+                    sourceMessage.getContent(),
+                    sourceMessage.getSequence()
+            );
+        }
+
+        return ProposalAiInterviewMessage.createAssistantMessage(
+                draftCopy,
+                sourceMessage.getContent(),
+                sourceMessage.getSequence()
+        );
     }
 
     private Proposal findReusableDraft(Long proposalId) {

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -76,27 +76,41 @@
                                 </p>
                             </div>
 
-                            <div class="flex-1 overflow-y-auto px-6 py-6">
+                            <div class="flex-1 overflow-y-auto px-6 py-6" x-ref="chatScroll">
                                 <div class="space-y-5">
                                     <div class="max-w-[92%] rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-4 text-sm leading-7 text-slate-600">
                                         안녕하세요! 만들고 싶은 IT 서비스나 프로젝트를 자유롭게 적어주세요.
-                                        전송하면 입력 내용을 저장하고 AI 브리프 생성 흐름을 시작합니다.
+                                        전송하면 AI가 후속 질문을 이어가고, 오른쪽 제안서 폼을 자동으로 갱신합니다.
                                     </div>
 
-                                    <template x-if="rawInputText.trim().length > 0">
+                                    <template x-if="aiInterviewMessages.length > 0">
+                                        <div class="space-y-5">
+                                            <template x-for="message in aiInterviewMessages" :key="message.id || `${message.role}-${message.sequence}`">
+                                                <div class="flex" :class="message.role === 'USER' ? 'justify-end' : 'justify-start'">
+                                                    <div class="max-w-[88%] whitespace-pre-line rounded-[24px] px-5 py-4 text-sm leading-7 shadow-sm"
+                                                         :class="message.role === 'USER'
+                                                            ? 'bg-slate-950 text-white shadow-slate-900/10'
+                                                            : 'border border-blue-100 bg-blue-50 text-blue-700'"
+                                                         x-text="message.content"></div>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
+
+                                    <template x-if="aiInterviewMessages.length === 0 && rawInputText.trim().length > 0">
                                         <div class="space-y-5">
                                             <div class="ml-auto max-w-[88%] whitespace-pre-line rounded-[24px] bg-slate-950 px-5 py-4 text-sm leading-7 text-white shadow-sm shadow-slate-900/10"
                                                  x-text="rawInputText"></div>
 
                                             <div class="max-w-[92%] rounded-[24px] border border-blue-100 bg-blue-50 px-5 py-4 text-sm leading-7 text-blue-700">
-                                                프로젝트 원본 입력을 확인했습니다. AI 브리프를 생성하면 오른쪽 폼이 갱신될 수 있습니다.
+                                                첫 입력을 확인했습니다. 곧 AI가 후속 질문을 생성하고 대화 히스토리로 저장합니다.
                                             </div>
                                         </div>
                                     </template>
 
-                                    <template x-if="rawInputText.trim().length === 0">
+                                    <template x-if="aiInterviewMessages.length === 0 && rawInputText.trim().length === 0">
                                         <div class="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-6 py-8 text-sm leading-7 text-slate-500">
-                                            아직 입력된 프로젝트 아이디어가 없습니다. 아래 입력창에 원하는 서비스를 적어두면, AI가 제안서 초안을 만들기 위한 원본 입력으로 저장합니다.
+                                            아직 대화가 없습니다. 아래 입력창에 원하는 서비스를 적어주세요.
                                         </div>
                                     </template>
 
@@ -107,7 +121,7 @@
 
                                     <template x-if="aiBriefLoading">
                                         <div class="max-w-[92%] rounded-[24px] border border-blue-100 bg-blue-50 px-5 py-4 text-sm leading-7 text-blue-700">
-                                            AI가 프로젝트 내용을 분석하고 제안서 초안을 작성하고 있습니다. 잠시만 기다려주세요.
+                                            AI가 답변을 분석하고 제안서 초안을 갱신하고 있습니다. 잠시만 기다려주세요.
                                         </div>
                                     </template>
 
@@ -125,6 +139,8 @@
                                               x-model="draftInput"
                                               rows="2"
                                               :disabled="aiBriefLoading"
+                                              @keydown.enter.meta.prevent="sendPrompt()"
+                                              @keydown.enter.ctrl.prevent="sendPrompt()"
                                               placeholder="예: 온라인 쇼핑몰 앱을 만들고 싶어요. 결제와 관리자 화면이 필요합니다."
                                               class="min-h-[72px] flex-1 rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"></textarea>
                                     <button type="button"
@@ -621,6 +637,16 @@
             title: /*[[${proposalForm.title}]]*/ '',
             rawInputText: /*[[${proposalForm.rawInputText}]]*/ '',
             aiBriefRequested: /*[[${aiBriefRequested}]]*/ false,
+            aiInterviewMessages: [
+                /*[# th:each="message, stat : ${aiInterviewMessages}"]*/
+                {
+                    id: /*[[${message.id}]]*/ null,
+                    role: /*[[${message.role}]]*/ '',
+                    content: /*[[${message.content}]]*/ '',
+                    sequence: /*[[${message.sequence}]]*/ null
+                }/*[(${stat.last} ? '' : ',')]*/
+                /*[/]*/
+            ],
             description: /*[[${proposalForm.description}]]*/ '',
             expectedPeriod: /*[[${proposalForm.expectedPeriod}]]*/ null,
             workTypes: [
@@ -678,6 +704,7 @@
                 aiBriefNoticeMessage: '',
                 aiBriefLoading: false,
                 aiBriefErrorMessage: '',
+                aiInterviewMessages: [],
                 title: bootstrap.title || '',
                 rawInputText: bootstrap.rawInputText || '',
                 draftInput: '',
@@ -693,6 +720,7 @@
                 positionErrors: [],
 
                 init() {
+                    this.aiInterviewMessages = (bootstrap.aiInterviewMessages || []).map(message => this.normalizeMessage(message));
                     this.positions = (bootstrap.positions || []).map((position, index) => this.normalizePosition({
                         ...position,
                         clientKey: position.id ? `position-${position.id}` : `seed-${index}`
@@ -700,10 +728,11 @@
                     this.currentPosition = this.blankPosition();
                     this.loaded = true;
                     this.refreshIcons();
+                    this.scrollChatToBottom();
 
                     if (this.aiBriefRequested && bootstrap.proposalId) {
                         this.$nextTick(() => {
-                            this.generateAiBrief();
+                            this.startInitialInterviewIfNeeded();
                         });
                     }
                 },
@@ -713,25 +742,98 @@
                     this.refreshIcons();
                 },
 
-                sendPrompt() {
-                    if (!this.draftInput || !this.draftInput.trim()) {
+                async sendPrompt() {
+                    const message = (this.draftInput || '').trim();
+                    if (!message || this.aiBriefLoading) {
                         return;
                     }
 
-                    this.rawInputText = this.appendRawInput(this.rawInputText, this.draftInput);
-                    this.draftInput = '';
-                    this.aiBriefNoticeMessage = '프로젝트 원본 입력을 저장했습니다. 기존 입력값은 AI 결과로 갱신될 수 있습니다.';
                     this.aiBriefErrorMessage = '';
+                    this.aiBriefNoticeMessage = '';
 
                     if (!this.title || !this.title.trim()) {
                         this.title = 'AI 브리프 작성 중';
                     }
 
-                    this.aiBriefRequested = true;
-                    this.submitAction = 'save';
-                    this.$nextTick(() => {
-                        this.$root.requestSubmit();
-                    });
+                    if (!bootstrap.proposalId) {
+                        this.rawInputText = this.appendRawInput(this.rawInputText, message);
+                        this.draftInput = '';
+                        this.submitAction = 'save';
+                        this.aiBriefRequested = true;
+                        this.$nextTick(() => {
+                            this.$root.requestSubmit();
+                        });
+                        return;
+                    }
+
+                    this.draftInput = '';
+                    await this.sendInterviewMessage(message);
+                },
+
+                async startInitialInterviewIfNeeded() {
+                    if (this.aiInterviewMessages.length > 0) {
+                        return;
+                    }
+
+                    const message = this.extractInitialMessage(this.rawInputText);
+                    if (!message) {
+                        await this.generateAiBrief();
+                        return;
+                    }
+
+                    this.aiBriefNoticeMessage = '첫 입력을 AI 인터뷰 메시지로 저장하고 후속 질문을 생성하고 있습니다.';
+                    await this.sendInterviewMessage(message);
+                    this.aiBriefRequested = false;
+                },
+
+                extractInitialMessage(rawInputText) {
+                    const text = (rawInputText || '').trim();
+                    if (!text) {
+                        return '';
+                    }
+
+                    const lines = text.split('\n')
+                        .map(line => line.trim())
+                        .filter(line => line.length > 0)
+                        .map(line => line.startsWith('- ') ? line.slice(2).trim() : line);
+
+                    return lines.join('\n').trim();
+                },
+
+                async sendInterviewMessage(message) {
+                    if (!bootstrap.proposalId || this.aiBriefLoading) {
+                        return;
+                    }
+
+                    this.aiBriefLoading = true;
+                    this.aiBriefErrorMessage = '';
+                    this.refreshIcons();
+
+                    try {
+                        const response = await fetch(`/proposals/${bootstrap.proposalId}/ai-interview/messages`, {
+                            method: 'POST',
+                            headers: {
+                                ...this.csrfHeaders(),
+                                'Content-Type': 'application/json',
+                                'Accept': 'application/json'
+                            },
+                            body: JSON.stringify({ message })
+                        });
+
+                        if (!response.ok) {
+                            throw new Error(await this.extractErrorMessage(response));
+                        }
+
+                        const data = await response.json();
+                        this.applyInterviewResponse(data);
+                        this.aiBriefNoticeMessage = '';
+                        this.scrollChatToBottom();
+                    } catch (error) {
+                        this.aiBriefErrorMessage = error.message || 'AI 인터뷰 메시지 전송에 실패했습니다. 잠시 후 다시 시도해주세요.';
+                    } finally {
+                        this.aiBriefLoading = false;
+                        this.refreshIcons();
+                    }
                 },
 
                 appendRawInput(current, input) {
@@ -774,7 +876,7 @@
                         this.aiBriefNoticeMessage = 'AI 브리프가 제안서에 반영되었습니다. 자동 채움 결과를 불러옵니다.';
                         window.location.replace(`/proposals/${bootstrap.proposalId}/edit`);
                     } catch (error) {
-                        this.aiBriefErrorMessage = error.message || 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                        this.aiBriefErrorMessage = error.message || 'AI 요청 처리에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
                         this.aiBriefNoticeMessage = '';
                         this.aiBriefRequested = false;
                     } finally {
@@ -797,10 +899,45 @@
                 async extractErrorMessage(response) {
                     try {
                         const data = await response.json();
-                        return data.message || data.error || 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                        return data.message || data.error || 'AI 요청 처리에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
                     } catch (error) {
-                        return 'AI 브리프 생성에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
+                        return 'AI 요청 처리에 실패했습니다. 잠시 후 다시 시도하거나 오른쪽 폼을 직접 작성해주세요.';
                     }
+                },
+
+                applyInterviewResponse(data) {
+                    const proposalForm = data.proposalForm || {};
+                    this.applyProposalForm(proposalForm);
+                    this.aiInterviewMessages = (data.messages || []).map(message => this.normalizeMessage(message));
+                },
+
+                applyProposalForm(proposalForm) {
+                    this.title = proposalForm.title || '';
+                    this.rawInputText = proposalForm.rawInputText || '';
+                    this.description = proposalForm.description || '';
+                    this.expectedPeriod = proposalForm.expectedPeriod ?? '';
+                    this.status = proposalForm.status || this.status || 'WRITING';
+                    this.positions = (proposalForm.positions || []).map((position, index) => this.normalizePosition({
+                        ...position,
+                        clientKey: position.id ? `position-${position.id}` : `ai-${Date.now()}-${index}`
+                    }));
+                },
+
+                normalizeMessage(message) {
+                    return {
+                        id: message.id ?? null,
+                        role: message.role || 'ASSISTANT',
+                        content: message.content || '',
+                        sequence: message.sequence ?? null
+                    };
+                },
+
+                scrollChatToBottom() {
+                    this.$nextTick(() => {
+                        if (this.$refs.chatScroll) {
+                            this.$refs.chatScroll.scrollTop = this.$refs.chatScroll.scrollHeight;
+                        }
+                    });
                 },
 
                 openAddPosition() {

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -810,6 +810,8 @@
                     this.refreshIcons();
 
                     try {
+                        await this.saveCurrentDraftBeforeInterview();
+
                         const response = await fetch(`/proposals/${bootstrap.proposalId}/ai-interview/messages`, {
                             method: 'POST',
                             headers: {
@@ -833,6 +835,38 @@
                     } finally {
                         this.aiBriefLoading = false;
                         this.refreshIcons();
+                    }
+                },
+
+                async saveCurrentDraftBeforeInterview() {
+                    const formData = new FormData(this.$root);
+                    formData.set('submitAction', 'save');
+                    formData.set('aiBriefRequested', 'false');
+                    formData.set('title', this.title || '');
+                    formData.set('rawInputText', this.rawInputText || '');
+                    formData.set('description', this.description || '');
+                    formData.set('expectedPeriod', this.expectedPeriod || '');
+
+                    const response = await fetch(this.$root.getAttribute('action'), {
+                        method: 'POST',
+                        headers: {
+                            ...this.csrfHeaders(),
+                            'Accept': 'text/html'
+                        },
+                        body: formData,
+                        redirect: 'manual'
+                    });
+
+                    if (response.type === 'opaqueredirect' || response.status === 0) {
+                        return;
+                    }
+
+                    if (response.status >= 300 && response.status < 400) {
+                        return;
+                    }
+
+                    if (!response.ok) {
+                        throw new Error('AI 인터뷰 전 현재 제안서 내용을 임시저장하지 못했습니다. 입력값을 확인해주세요.');
                     }
                 },
 

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -843,7 +843,7 @@
                     formData.set('submitAction', 'save');
                     formData.set('aiBriefRequested', 'false');
                     formData.set('title', this.title || '');
-                    formData.set('rawInputText', this.rawInputText || '');
+                    formData.set('rawInputText', '');
                     formData.set('description', this.description || '');
                     formData.set('expectedPeriod', this.expectedPeriod || '');
 

--- a/src/test/java/com/generic4/itda/controller/ProposalAiInterviewControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiInterviewControllerTest.java
@@ -1,0 +1,161 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
+import com.generic4.itda.dto.proposal.AiInterviewMessageResponse;
+import com.generic4.itda.dto.proposal.AiInterviewSendMessageResponse;
+import com.generic4.itda.dto.proposal.ProposalForm;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.ProposalAiInterviewService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(ProposalAiInterviewController.class)
+class ProposalAiInterviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProposalAiInterviewService proposalAiInterviewService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("인증된 사용자가 AI 인터뷰 메시지를 전송하면 갱신된 폼과 메시지 목록을 반환한다")
+    void sendMessage() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678")
+        );
+        Proposal proposal = Proposal.create(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678"),
+                "제안서 제목",
+                "",
+                "제안서 본문",
+                null,
+                null,
+                null
+        );
+        ProposalAiInterviewMessage userMessage = ProposalAiInterviewMessage.createUserMessage(
+                proposal,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요.",
+                1
+        );
+        ProposalAiInterviewMessage assistantMessage = ProposalAiInterviewMessage.createAssistantMessage(
+                proposal,
+                "필요한 주요 기능을 알려주세요.",
+                2
+        );
+        ProposalForm proposalForm = ProposalForm.from(proposal);
+        proposalForm.setTitle("온라인 쇼핑몰 구축");
+
+        AiInterviewSendMessageResponse response = AiInterviewSendMessageResponse.of(
+                proposalForm,
+                List.of(
+                        AiInterviewMessageResponse.from(userMessage),
+                        AiInterviewMessageResponse.from(assistantMessage)
+                ),
+                "필요한 주요 기능을 알려주세요."
+        );
+
+        given(proposalAiInterviewService.sendMessage(
+                1L,
+                "user@example.com",
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+        )).willReturn(response);
+
+        mockMvc.perform(post("/proposals/{proposalId}/ai-interview/messages", 1L)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "message": "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.proposalForm.title").value("온라인 쇼핑몰 구축"))
+                .andExpect(jsonPath("$.messages[0].role").value("USER"))
+                .andExpect(jsonPath("$.messages[0].content").value("온라인 쇼핑몰 웹사이트를 만들고 싶어요."))
+                .andExpect(jsonPath("$.messages[0].sequence").value(1))
+                .andExpect(jsonPath("$.messages[1].role").value("ASSISTANT"))
+                .andExpect(jsonPath("$.messages[1].content").value("필요한 주요 기능을 알려주세요."))
+                .andExpect(jsonPath("$.messages[1].sequence").value(2))
+                .andExpect(jsonPath("$.assistantMessage").value("필요한 주요 기능을 알려주세요."));
+
+        then(proposalAiInterviewService).should().sendMessage(
+                1L,
+                "user@example.com",
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+        );
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 메시지가 비어 있으면 400을 반환한다")
+    void failWhenMessageIsBlank() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/{proposalId}/ai-interview/messages", 1L)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "message": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        then(proposalAiInterviewService).should(never()).sendMessage(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 로그인 페이지로 리다이렉트된다")
+    void redirectToLoginWhenUnauthenticated() throws Exception {
+        mockMvc.perform(post("/proposals/{proposalId}/ai-interview/messages", 1L)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "message": "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+                                }
+                                """))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+}

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -30,6 +30,7 @@ import com.generic4.itda.exception.ProposalNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.ProposalService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +50,9 @@ class ProposalControllerTest {
 
     @MockitoBean
     private ProposalService proposalService;
+
+    @MockitoBean
+    private ProposalAiInterviewService proposalAiInterviewService;
 
     @MockitoBean
     private PositionRepository positionRepository;
@@ -73,7 +77,7 @@ class ProposalControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
-                .andExpect(model().attributeExists("proposalForm", "positionOptions", "workTypes"))
+                .andExpect(model().attributeExists("proposalForm", "positionOptions", "workTypes", "aiInterviewMessages"))
                 .andExpect(model().attribute("isNew", true))
                 .andExpect(model().attribute("aiBriefRequested", false));
     }
@@ -199,6 +203,7 @@ class ProposalControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
                 .andExpect(model().attributeHasErrors("proposalForm"))
+                .andExpect(model().attributeExists("aiInterviewMessages"))
                 .andExpect(model().attribute("aiBriefRequested", true));
 
         then(proposalService).should(never()).register(anyString(), any(ProposalForm.class));
@@ -229,6 +234,8 @@ class ProposalControllerTest {
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
         given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
                 .willReturn(ProposalForm.from(proposal));
+        given(proposalAiInterviewService.findMessageResponses(1L, "client@example.com"))
+                .willReturn(List.of());
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
@@ -242,7 +249,7 @@ class ProposalControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
-                .andExpect(model().attributeExists("proposalForm"))
+                .andExpect(model().attributeExists("proposalForm", "aiInterviewMessages"))
                 .andExpect(model().attribute("isNew", false))
                 .andExpect(model().attribute("aiBriefRequested", false));
     }
@@ -264,6 +271,8 @@ class ProposalControllerTest {
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
         given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
                 .willReturn(ProposalForm.from(proposal));
+        given(proposalAiInterviewService.findMessageResponses(1L, "client@example.com"))
+                .willReturn(List.of());
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
@@ -278,7 +287,7 @@ class ProposalControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("client/proposalForm"))
-                .andExpect(model().attributeExists("proposalForm"))
+                .andExpect(model().attributeExists("proposalForm", "aiInterviewMessages"))
                 .andExpect(model().attribute("proposalId", 1L))
                 .andExpect(model().attribute("isNew", false))
                 .andExpect(model().attribute("aiBriefRequested", true));

--- a/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
@@ -32,7 +32,8 @@ class AiBriefGeneratorConfigurationTest {
                     assertThat(context).hasSingleBean(AiBriefGenerator.class);
                     assertThat(context).hasSingleBean(DisabledAiBriefGenerator.class);
                     assertThat(context).doesNotHaveBean(OpenAiAiBriefGenerator.class);
-                    assertThat(context).doesNotHaveBean(AiInterviewGenerator.class);
+                    assertThat(context).hasSingleBean(AiInterviewGenerator.class);
+                    assertThat(context).hasSingleBean(DisabledAiInterviewGenerator.class);
                     assertThat(context).doesNotHaveBean(OpenAiAiInterviewGenerator.class);
                     assertThat(context).hasSingleBean(ProposalAiBriefService.class);
                 });
@@ -53,6 +54,7 @@ class AiBriefGeneratorConfigurationTest {
                     assertThat(context).hasSingleBean(AiInterviewGenerator.class);
                     assertThat(context).hasSingleBean(OpenAiAiInterviewGenerator.class);
                     assertThat(context).doesNotHaveBean(DisabledAiBriefGenerator.class);
+                    assertThat(context).doesNotHaveBean(DisabledAiInterviewGenerator.class);
                     assertThat(context).hasSingleBean(ProposalAiBriefService.class);
                 });
     }
@@ -73,6 +75,7 @@ class AiBriefGeneratorConfigurationTest {
     @EnableConfigurationProperties(AiBriefProperties.class)
     @Import({
             DisabledAiBriefGenerator.class,
+            DisabledAiInterviewGenerator.class,
             OpenAiAiBriefGenerator.class,
             OpenAiAiInterviewGenerator.class,
             AiBriefProposalMapper.class,

--- a/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.generic4.itda.config.ai.AiBriefProperties;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,8 @@ class AiBriefGeneratorConfigurationTest {
                     assertThat(context).hasSingleBean(AiBriefGenerator.class);
                     assertThat(context).hasSingleBean(DisabledAiBriefGenerator.class);
                     assertThat(context).doesNotHaveBean(OpenAiAiBriefGenerator.class);
+                    assertThat(context).doesNotHaveBean(AiInterviewGenerator.class);
+                    assertThat(context).doesNotHaveBean(OpenAiAiInterviewGenerator.class);
                     assertThat(context).hasSingleBean(ProposalAiBriefService.class);
                 });
     }
@@ -47,6 +50,8 @@ class AiBriefGeneratorConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(AiBriefGenerator.class);
                     assertThat(context).hasSingleBean(OpenAiAiBriefGenerator.class);
+                    assertThat(context).hasSingleBean(AiInterviewGenerator.class);
+                    assertThat(context).hasSingleBean(OpenAiAiInterviewGenerator.class);
                     assertThat(context).doesNotHaveBean(DisabledAiBriefGenerator.class);
                     assertThat(context).hasSingleBean(ProposalAiBriefService.class);
                 });
@@ -69,6 +74,7 @@ class AiBriefGeneratorConfigurationTest {
     @Import({
             DisabledAiBriefGenerator.class,
             OpenAiAiBriefGenerator.class,
+            OpenAiAiInterviewGenerator.class,
             AiBriefProposalMapper.class,
             ProposalAiBriefService.class
     })
@@ -87,6 +93,11 @@ class AiBriefGeneratorConfigurationTest {
         @Bean
         ProposalRepository proposalRepository() {
             return mock(ProposalRepository.class);
+        }
+
+        @Bean
+        ProposalAiInterviewMessageRepository proposalAiInterviewMessageRepository() {
+            return mock(ProposalAiInterviewMessageRepository.class);
         }
 
         @Bean

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -381,6 +381,168 @@ class AiBriefProposalMapperTest {
         then(skillRepository).should(never()).save(any(Skill.class));
     }
 
+    @Test
+    @DisplayName("AI 인터뷰 적용은 응답에 없는 기존 모집 단위를 삭제하지 않는다")
+    void applyForInterview_preservesExistingPositionsMissingFromAiResult() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+        Position frontend = Position.create("프론트엔드 개발자");
+
+        ProposalPosition backendPosition = proposal.addPosition(
+                backend,
+                "기존 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        ProposalPosition frontendPosition = proposal.addPosition(
+                frontend,
+                "기존 프론트엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                null,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                2L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.applyForInterview(proposal, aiBriefResult, "백엔드 개발자는 2명으로 하자.");
+
+        assertThat(proposal.getPositions()).hasSize(2);
+        assertThat(findProposalPosition(proposal, "백엔드 개발자")).isSameAs(backendPosition);
+        assertThat(findProposalPosition(proposal, "백엔드 개발자").getHeadCount()).isEqualTo(2L);
+        assertThat(findProposalPosition(proposal, "프론트엔드 개발자")).isSameAs(frontendPosition);
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 적용은 사용자 메시지에 명시적으로 삭제 의도가 있는 모집 단위만 삭제한다")
+    void applyForInterview_removesExplicitlyDeletedPositionOnly() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+        Position frontend = Position.create("프론트엔드 개발자");
+        Position designer = Position.create("UI/UX 디자이너");
+
+        proposal.addPosition(
+                backend,
+                "기존 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        proposal.addPosition(
+                frontend,
+                "기존 프론트엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        proposal.addPosition(
+                designer,
+                "UI/UX 디자이너",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+
+        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionRepository.findByName("프론트엔드 개발자")).willReturn(Optional.of(frontend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "새 제목",
+                "새 설명",
+                null,
+                null,
+                null,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                2L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                List.of()
+                        ),
+                        AiBriefPositionResult.of(
+                                "프론트엔드 개발자",
+                                "프론트엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.applyForInterview(
+                proposal,
+                aiBriefResult,
+                "백엔드 개발자 2명, 프론트엔드 개발자 1명으로 가고 UI/UX 디자이너는 빼자."
+        );
+
+        assertThat(proposal.getPositions()).hasSize(2);
+        assertThat(findProposalPosition(proposal, "백엔드 개발자").getHeadCount()).isEqualTo(2L);
+        assertThat(findProposalPosition(proposal, "프론트엔드 개발자").getHeadCount()).isEqualTo(1L);
+        assertThat(proposal.getPositions())
+                .noneMatch(position -> position.getPosition().getName().equals("UI/UX 디자이너"));
+    }
+
     private ProposalPosition findProposalPosition(Proposal proposal, String positionName) {
         return proposal.getPositions().stream()
                 .filter(proposalPosition -> proposalPosition.getPosition().getName().equals(positionName))

--- a/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiBriefServiceTest.java
@@ -9,12 +9,15 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.AiBriefGenerateRequest;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.exception.AiBriefGenerationException;
 import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
 import com.generic4.itda.repository.ProposalRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,9 @@ class ProposalAiBriefServiceTest {
 
     @Mock
     private ProposalRepository proposalRepository;
+
+    @Mock
+    private ProposalAiInterviewMessageRepository messageRepository;
 
     @Mock
     private AiBriefGenerator aiBriefGenerator;
@@ -60,6 +66,7 @@ class ProposalAiBriefServiceTest {
         );
 
         given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L)).willReturn(List.of());
         given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class))).willReturn(aiBriefResult);
 
         AiBriefResult result = proposalAiBriefService.generate(1L, OWNER_EMAIL);
@@ -67,6 +74,49 @@ class ProposalAiBriefServiceTest {
         assertThat(result).isSameAs(aiBriefResult);
         then(aiBriefGenerator).should().generate(requestCaptor.capture());
         assertThat(requestCaptor.getValue().getRawInputText()).isEqualTo("AI 브리프용 원본 입력");
+        then(aiBriefProposalMapper).should().apply(proposal, aiBriefResult);
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 히스토리가 있으면 raw input text 대신 대화 히스토리로 AI 브리프를 생성한다")
+    void generateAiBriefWithInterviewHistoryWhenMessagesExist() {
+        Proposal proposal = createProposal("기존 raw input");
+        ProposalAiInterviewMessage userMessage = ProposalAiInterviewMessage.createUserMessage(
+                proposal,
+                "온라인 쇼핑몰을 만들고 싶어요.",
+                1
+        );
+        ProposalAiInterviewMessage assistantMessage = ProposalAiInterviewMessage.createAssistantMessage(
+                proposal,
+                "백엔드 개발자는 몇 명 필요하고 근무 형태는 어떻게 할까요?",
+                2
+        );
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "AI가 만든 제목",
+                "AI가 만든 설명",
+                3_000_000L,
+                5_000_000L,
+                6L,
+                null
+        );
+
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L))
+                .willReturn(List.of(userMessage, assistantMessage));
+        given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class))).willReturn(aiBriefResult);
+
+        AiBriefResult result = proposalAiBriefService.generate(1L, OWNER_EMAIL);
+
+        assertThat(result).isSameAs(aiBriefResult);
+        then(aiBriefGenerator).should().generate(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getRawInputText()).isEqualTo(
+                "[USER] 온라인 쇼핑몰을 만들고 싶어요." + System.lineSeparator()
+                        + "[ASSISTANT] 백엔드 개발자는 몇 명 필요하고 근무 형태는 어떻게 할까요?"
+        );
+        assertThat(proposal.getRawInputText()).isEqualTo(
+                "[USER] 온라인 쇼핑몰을 만들고 싶어요." + System.lineSeparator()
+                        + "[ASSISTANT] 백엔드 개발자는 몇 명 필요하고 근무 형태는 어떻게 할까요?"
+        );
         then(aiBriefProposalMapper).should().apply(proposal, aiBriefResult);
     }
 
@@ -79,6 +129,7 @@ class ProposalAiBriefServiceTest {
                 .isInstanceOf(ProposalNotFoundException.class)
                 .hasMessage("제안서를 찾을 수 없습니다. id=1");
 
+        then(messageRepository).should(never()).findAllByProposalIdOrderBySequenceAsc(any());
         then(aiBriefGenerator).should(never()).generate(any());
         then(aiBriefProposalMapper).should(never()).apply(any(), any());
     }
@@ -94,6 +145,7 @@ class ProposalAiBriefServiceTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("작성 중인 제안서만 AI 브리프를 생성할 수 있습니다.");
 
+        then(messageRepository).should(never()).findAllByProposalIdOrderBySequenceAsc(any());
         then(aiBriefGenerator).should(never()).generate(any());
         then(aiBriefProposalMapper).should(never()).apply(any(), any());
     }
@@ -103,6 +155,7 @@ class ProposalAiBriefServiceTest {
     void failWhenAiGeneratorThrowsException() {
         Proposal proposal = createProposal("실패용 원본 입력");
         given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L)).willReturn(List.of());
         given(aiBriefGenerator.generate(any(AiBriefGenerateRequest.class)))
                 .willThrow(new RuntimeException("llm failure"));
 
@@ -128,6 +181,7 @@ class ProposalAiBriefServiceTest {
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("본인 제안서에 대해서만 AI 브리프를 생성할 수 있습니다.");
 
+        then(messageRepository).should(never()).findAllByProposalIdOrderBySequenceAsc(any());
         then(aiBriefGenerator).should(never()).generate(any());
         then(aiBriefProposalMapper).should(never()).apply(any(), any());
     }

--- a/src/test/java/com/generic4/itda/service/ProposalAiInterviewServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiInterviewServiceTest.java
@@ -1,0 +1,260 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.dto.proposal.AiBriefResult;
+import com.generic4.itda.dto.proposal.AiInterviewGenerateRequest;
+import com.generic4.itda.dto.proposal.AiInterviewResult;
+import com.generic4.itda.dto.proposal.AiInterviewSendMessageResponse;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class ProposalAiInterviewServiceTest {
+
+    private static final String OWNER_EMAIL = "test@example.com";
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
+    private ProposalAiInterviewMessageRepository messageRepository;
+
+    @Mock
+    private AiInterviewGenerator aiInterviewGenerator;
+
+    @Mock
+    private AiBriefProposalMapper aiBriefProposalMapper;
+
+    @InjectMocks
+    private ProposalAiInterviewService proposalAiInterviewService;
+
+    @Captor
+    private ArgumentCaptor<AiInterviewGenerateRequest> generateRequestCaptor;
+
+    @Captor
+    private ArgumentCaptor<ProposalAiInterviewMessage> messageCaptor;
+
+    @Test
+    @DisplayName("사용자 메시지를 저장하고 AI 응답 메시지와 갱신된 제안서 폼을 반환한다")
+    void sendMessageSavesUserAndAssistantMessagesAndReturnsUpdatedForm() {
+        Proposal proposal = createProposal();
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "온라인 쇼핑몰 구축",
+                "온라인 쇼핑몰 웹사이트를 구축합니다.",
+                null,
+                null,
+                null,
+                null
+        );
+        AiInterviewResult aiInterviewResult = AiInterviewResult.of(
+                aiBriefResult,
+                "쇼핑몰에 필요한 주요 기능을 알려주세요. 결제, 회원가입, 관리자 페이지가 필요할까요?"
+        );
+
+        given(proposalRepository.findWithPositionsById(1L)).willReturn(Optional.of(proposal));
+        given(proposalRepository.findPositionsWithSkillsByProposalId(1L)).willReturn(List.of());
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L)).willReturn(List.of());
+        given(messageRepository.save(any(ProposalAiInterviewMessage.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(aiInterviewGenerator.generate(any(AiInterviewGenerateRequest.class))).willReturn(aiInterviewResult);
+
+        AiInterviewSendMessageResponse response = proposalAiInterviewService.sendMessage(
+                1L,
+                OWNER_EMAIL,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+        );
+
+        then(messageRepository).should(times(2)).save(messageCaptor.capture());
+        List<ProposalAiInterviewMessage> savedMessages = messageCaptor.getAllValues();
+
+        assertThat(savedMessages).hasSize(2);
+        assertThat(savedMessages.get(0).getRole().name()).isEqualTo("USER");
+        assertThat(savedMessages.get(0).getContent()).isEqualTo("온라인 쇼핑몰 웹사이트를 만들고 싶어요.");
+        assertThat(savedMessages.get(0).getSequence()).isEqualTo(1);
+        assertThat(savedMessages.get(1).getRole().name()).isEqualTo("ASSISTANT");
+        assertThat(savedMessages.get(1).getContent()).isEqualTo("쇼핑몰에 필요한 주요 기능을 알려주세요. 결제, 회원가입, 관리자 페이지가 필요할까요?");
+        assertThat(savedMessages.get(1).getSequence()).isEqualTo(2);
+
+        then(aiInterviewGenerator).should().generate(generateRequestCaptor.capture());
+        assertThat(generateRequestCaptor.getValue().getConversationText()).isEmpty();
+        assertThat(generateRequestCaptor.getValue().getUserMessage()).isEqualTo("온라인 쇼핑몰 웹사이트를 만들고 싶어요.");
+
+        then(aiBriefProposalMapper).should().apply(proposal, aiBriefResult);
+
+        assertThat(response.getProposalForm().getRawInputText()).isEqualTo(
+                "[USER] 온라인 쇼핑몰 웹사이트를 만들고 싶어요." + System.lineSeparator()
+                        + "[ASSISTANT] 쇼핑몰에 필요한 주요 기능을 알려주세요. 결제, 회원가입, 관리자 페이지가 필요할까요?"
+        );
+        assertThat(response.getMessages()).hasSize(2);
+        assertThat(response.getAssistantMessage()).isEqualTo("쇼핑몰에 필요한 주요 기능을 알려주세요. 결제, 회원가입, 관리자 페이지가 필요할까요?");
+    }
+
+    @Test
+    @DisplayName("기존 메시지가 있으면 다음 sequence로 사용자 메시지와 AI 메시지를 저장한다")
+    void sendMessageUsesNextSequenceWhenPreviousMessagesExist() {
+        Proposal proposal = createProposal();
+        ProposalAiInterviewMessage previousUserMessage = ProposalAiInterviewMessage.createUserMessage(
+                proposal,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요.",
+                1
+        );
+        ProposalAiInterviewMessage previousAssistantMessage = ProposalAiInterviewMessage.createAssistantMessage(
+                proposal,
+                "필요한 포지션을 알려주세요.",
+                2
+        );
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "온라인 쇼핑몰 구축",
+                "온라인 쇼핑몰 웹사이트를 구축합니다.",
+                null,
+                null,
+                null,
+                null
+        );
+        AiInterviewResult aiInterviewResult = AiInterviewResult.of(
+                aiBriefResult,
+                "백엔드 개발자 2명과 프론트엔드 개발자 1명으로 반영했습니다. 예상 기간은 몇 주인가요?"
+        );
+
+        given(proposalRepository.findWithPositionsById(1L)).willReturn(Optional.of(proposal));
+        given(proposalRepository.findPositionsWithSkillsByProposalId(1L)).willReturn(List.of());
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L))
+                .willReturn(List.of(previousUserMessage, previousAssistantMessage));
+        given(messageRepository.save(any(ProposalAiInterviewMessage.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(aiInterviewGenerator.generate(any(AiInterviewGenerateRequest.class))).willReturn(aiInterviewResult);
+
+        AiInterviewSendMessageResponse response = proposalAiInterviewService.sendMessage(
+                1L,
+                OWNER_EMAIL,
+                "백엔드 개발자 2명, 프론트엔드 개발자 1명으로 갈게요."
+        );
+
+        then(messageRepository).should(times(2)).save(messageCaptor.capture());
+        List<ProposalAiInterviewMessage> savedMessages = messageCaptor.getAllValues();
+
+        assertThat(savedMessages.get(0).getSequence()).isEqualTo(3);
+        assertThat(savedMessages.get(0).getRole().name()).isEqualTo("USER");
+        assertThat(savedMessages.get(1).getSequence()).isEqualTo(4);
+        assertThat(savedMessages.get(1).getRole().name()).isEqualTo("ASSISTANT");
+
+        then(aiInterviewGenerator).should().generate(generateRequestCaptor.capture());
+        assertThat(generateRequestCaptor.getValue().getConversationText()).isEqualTo(
+                "[USER] 온라인 쇼핑몰 웹사이트를 만들고 싶어요." + System.lineSeparator()
+                        + "[ASSISTANT] 필요한 포지션을 알려주세요."
+        );
+        assertThat(generateRequestCaptor.getValue().getUserMessage()).isEqualTo("백엔드 개발자 2명, 프론트엔드 개발자 1명으로 갈게요.");
+
+        assertThat(response.getMessages()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("저장된 메시지 히스토리를 조회한다")
+    void findMessageResponses() {
+        Proposal proposal = createProposal();
+        ProposalAiInterviewMessage userMessage = ProposalAiInterviewMessage.createUserMessage(
+                proposal,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요.",
+                1
+        );
+        ProposalAiInterviewMessage assistantMessage = ProposalAiInterviewMessage.createAssistantMessage(
+                proposal,
+                "필요한 포지션을 알려주세요.",
+                2
+        );
+
+        given(proposalRepository.findById(1L)).willReturn(Optional.of(proposal));
+        given(messageRepository.findAllByProposalIdOrderBySequenceAsc(1L))
+                .willReturn(List.of(userMessage, assistantMessage));
+
+        var responses = proposalAiInterviewService.findMessageResponses(1L, OWNER_EMAIL);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getRole()).isEqualTo("USER");
+        assertThat(responses.get(0).getContent()).isEqualTo("온라인 쇼핑몰 웹사이트를 만들고 싶어요.");
+        assertThat(responses.get(0).getSequence()).isEqualTo(1);
+        assertThat(responses.get(1).getRole()).isEqualTo("ASSISTANT");
+        assertThat(responses.get(1).getContent()).isEqualTo("필요한 포지션을 알려주세요.");
+        assertThat(responses.get(1).getSequence()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서이면 AI 인터뷰 메시지 전송을 중단한다")
+    void failWhenProposalDoesNotExist() {
+        given(proposalRepository.findWithPositionsById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalAiInterviewService.sendMessage(1L, OWNER_EMAIL, "메시지"))
+                .isInstanceOf(ProposalNotFoundException.class)
+                .hasMessage("제안서를 찾을 수 없습니다. id=1");
+
+        then(messageRepository).should(never()).save(any());
+        then(aiInterviewGenerator).should(never()).generate(any());
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 AI 인터뷰 메시지 전송을 거부한다")
+    void failWhenProposalOwnerDoesNotMatch() {
+        Proposal proposal = createProposal();
+        given(proposalRepository.findWithPositionsById(1L)).willReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalAiInterviewService.sendMessage(1L, "other@example.com", "메시지"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("본인 제안서에 대해서만 AI 인터뷰를 진행할 수 있습니다.");
+
+        then(messageRepository).should(never()).save(any());
+        then(aiInterviewGenerator).should(never()).generate(any());
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    @Test
+    @DisplayName("작성 중이 아닌 제안서는 AI 인터뷰 메시지를 전송할 수 없다")
+    void failWhenProposalStatusIsNotWriting() {
+        Proposal proposal = createProposal();
+        proposal.startMatching();
+        given(proposalRepository.findWithPositionsById(1L)).willReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalAiInterviewService.sendMessage(1L, OWNER_EMAIL, "메시지"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("작성 중인 제안서만 AI 인터뷰를 진행할 수 있습니다.");
+
+        then(messageRepository).should(never()).save(any());
+        then(aiInterviewGenerator).should(never()).generate(any());
+        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+    }
+
+    private Proposal createProposal() {
+        return Proposal.create(
+                createMember(OWNER_EMAIL, "hashed-password", "클라이언트", "010-1234-5678"),
+                "제안서 제목",
+                "",
+                "제안서 본문",
+                1_000_000L,
+                2_000_000L,
+                3L
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ProposalAiInterviewServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalAiInterviewServiceTest.java
@@ -102,7 +102,11 @@ class ProposalAiInterviewServiceTest {
         assertThat(generateRequestCaptor.getValue().getConversationText()).isEmpty();
         assertThat(generateRequestCaptor.getValue().getUserMessage()).isEqualTo("온라인 쇼핑몰 웹사이트를 만들고 싶어요.");
 
-        then(aiBriefProposalMapper).should().apply(proposal, aiBriefResult);
+        then(aiBriefProposalMapper).should().applyForInterview(
+                proposal,
+                aiBriefResult,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요."
+        );
 
         assertThat(response.getProposalForm().getRawInputText()).isEqualTo(
                 "[USER] 온라인 쇼핑몰 웹사이트를 만들고 싶어요." + System.lineSeparator()
@@ -168,6 +172,12 @@ class ProposalAiInterviewServiceTest {
         );
         assertThat(generateRequestCaptor.getValue().getUserMessage()).isEqualTo("백엔드 개발자 2명, 프론트엔드 개발자 1명으로 갈게요.");
 
+        then(aiBriefProposalMapper).should().applyForInterview(
+                proposal,
+                aiBriefResult,
+                "백엔드 개발자 2명, 프론트엔드 개발자 1명으로 갈게요."
+        );
+
         assertThat(response.getMessages()).hasSize(4);
     }
 
@@ -212,7 +222,7 @@ class ProposalAiInterviewServiceTest {
 
         then(messageRepository).should(never()).save(any());
         then(aiInterviewGenerator).should(never()).generate(any());
-        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+        then(aiBriefProposalMapper).should(never()).applyForInterview(any(), any(), any());
     }
 
     @Test
@@ -227,7 +237,7 @@ class ProposalAiInterviewServiceTest {
 
         then(messageRepository).should(never()).save(any());
         then(aiInterviewGenerator).should(never()).generate(any());
-        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+        then(aiBriefProposalMapper).should(never()).applyForInterview(any(), any(), any());
     }
 
     @Test
@@ -243,7 +253,7 @@ class ProposalAiInterviewServiceTest {
 
         then(messageRepository).should(never()).save(any());
         then(aiInterviewGenerator).should(never()).generate(any());
-        then(aiBriefProposalMapper).should(never()).apply(any(), any());
+        then(aiBriefProposalMapper).should(never()).applyForInterview(any(), any(), any());
     }
 
     private Proposal createProposal() {

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -5,36 +5,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
+import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalAiInterviewMessageRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.SkillRepository;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProposalServiceTest {
 
     private static final String EMAIL = "client@example.com";
+    private static final String OTHER_EMAIL = "other@example.com";
 
     @InjectMocks
     private ProposalService proposalService;
@@ -55,6 +65,9 @@ class ProposalServiceTest {
     private MatchingRepository matchingRepository;
 
     @Mock
+    private ProposalAiInterviewMessageRepository aiInterviewMessageRepository;
+
+    @Mock
     private EntityManager entityManager;
 
     private Member member;
@@ -69,6 +82,10 @@ class ProposalServiceTest {
                 .thenReturn(false);
         lenient().when(proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(any(Long.class), any()))
                 .thenReturn(Optional.empty());
+        lenient().when(aiInterviewMessageRepository.findAllByProposalIdOrderBySequenceAsc(any(Long.class)))
+                .thenReturn(List.of());
+        lenient().when(aiInterviewMessageRepository.saveAll(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -180,6 +197,49 @@ class ProposalServiceTest {
     }
 
     @Test
+    @DisplayName("MATCHING 제안서를 수정 초안으로 복제할 때 AI 인터뷰 메시지도 함께 복제한다")
+    void createEditDraft_copiesAiInterviewMessages() {
+        Proposal source = Proposal.create(member, "기존 프로젝트", "원본", "설명", 3_000_000L, 4_000_000L, 8L);
+        ReflectionTestUtils.setField(source, "id", 1L);
+        source.startMatching();
+
+        ProposalAiInterviewMessage userMessage = ProposalAiInterviewMessage.createUserMessage(
+                source,
+                "온라인 쇼핑몰 웹사이트를 만들고 싶어요.",
+                1
+        );
+        ProposalAiInterviewMessage assistantMessage = ProposalAiInterviewMessage.createAssistantMessage(
+                source,
+                "필요한 포지션을 알려주세요.",
+                2
+        );
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(source));
+        when(matchingRepository.existsByProposalPosition_Proposal_IdAndStatusIn(eq(1L), any()))
+                .thenReturn(false);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(source));
+        when(proposalRepository.findPositionsWithSkillsByProposalId(1L)).thenReturn(source.getPositions());
+        when(aiInterviewMessageRepository.findAllByProposalIdOrderBySequenceAsc(1L))
+                .thenReturn(List.of(userMessage, assistantMessage));
+
+        Proposal copied = proposalService.createEditDraft(1L, EMAIL);
+
+        ArgumentCaptor<List<ProposalAiInterviewMessage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(aiInterviewMessageRepository).saveAll(captor.capture());
+
+        List<ProposalAiInterviewMessage> copiedMessages = captor.getValue();
+        assertThat(copiedMessages).hasSize(2);
+        assertThat(copiedMessages.get(0).getProposal()).isSameAs(copied);
+        assertThat(copiedMessages.get(0).getRole()).isEqualTo(userMessage.getRole());
+        assertThat(copiedMessages.get(0).getContent()).isEqualTo(userMessage.getContent());
+        assertThat(copiedMessages.get(0).getSequence()).isEqualTo(userMessage.getSequence());
+        assertThat(copiedMessages.get(1).getProposal()).isSameAs(copied);
+        assertThat(copiedMessages.get(1).getRole()).isEqualTo(assistantMessage.getRole());
+        assertThat(copiedMessages.get(1).getContent()).isEqualTo(assistantMessage.getContent());
+        assertThat(copiedMessages.get(1).getSequence()).isEqualTo(assistantMessage.getSequence());
+    }
+
+    @Test
     @DisplayName("같은 원본에서 이미 열린 WRITING draft가 있으면 그 draft를 재사용한다")
     void createEditDraft_reusesExistingWritingDraft() {
         Proposal source = Proposal.create(member, "기존 프로젝트", "원본", "설명", 3_000_000L, 4_000_000L, 8L);
@@ -221,5 +281,92 @@ class ProposalServiceTest {
         assertThatThrownBy(() -> proposalService.createEditDraft(1L, EMAIL))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("진행 중이거나 완료된 매칭이 있는 제안서는 수정할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("WRITING 상태 제안서는 정상적으로 삭제된다")
+    void delete_writingProposal_succeeds() {
+        Proposal proposal = Proposal.create(member, "삭제할 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        proposalService.delete(1L, EMAIL);
+
+        then(proposalRepository).should().delete(proposal);
+    }
+
+    @Test
+    @DisplayName("WRITING 상태가 아닌 제안서는 삭제할 수 없다")
+    void delete_nonWritingProposal_throws() {
+        Proposal proposal = Proposal.create(member, "매칭 중 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        proposal.startMatching();
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.delete(1L, EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("작성 중인 제안서만 삭제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 삭제할 수 없다")
+    void delete_othersProposal_throws() {
+        Proposal proposal = Proposal.create(member, "다른 사람 프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.delete(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+        then(proposalRepository).should().findById(1L);
+        then(proposalRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서는 삭제할 수 없다")
+    void delete_throws_whenNotFound() {
+        when(proposalRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.delete(99L, EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
+        then(proposalRepository).should().findById(99L);
+        then(proposalRepository).should(never()).delete(any(Proposal.class));
+    }
+
+    @Test
+    @DisplayName("소유자는 findOwnedProposal로 제안서를 조회할 수 있다")
+    void findOwnedProposal_returnsProposal_whenOwner() {
+        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        Proposal result = proposalService.findOwnedProposal(1L, EMAIL);
+
+        assertThat(result).isSameAs(proposal);
+        then(proposalRepository).should().findWithPositionsById(1L);
+        then(proposalRepository).should().findPositionsWithSkillsByProposalId(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서는 findOwnedProposal에서 예외가 발생한다")
+    void findOwnedProposal_throws_whenNotFound() {
+        when(proposalRepository.findWithPositionsById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.findOwnedProposal(99L, EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
+        then(proposalRepository).should().findWithPositionsById(99L);
+        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(99L);
+    }
+
+    @Test
+    @DisplayName("타인 제안서는 findOwnedProposal에서 접근 거부 예외가 발생한다")
+    void findOwnedProposal_throws_whenNotOwner() {
+        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.findOwnedProposal(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+        then(proposalRepository).should().findWithPositionsById(1L);
+        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(1L);
     }
 }

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -5,9 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import com.generic4.itda.domain.member.Member;
@@ -17,8 +15,6 @@ import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
-import com.generic4.itda.exception.ProposalNotFoundException;
-import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
@@ -39,7 +35,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 class ProposalServiceTest {
 
     private static final String EMAIL = "client@example.com";
-    private static final String OTHER_EMAIL = "other@example.com";
 
     @InjectMocks
     private ProposalService proposalService;
@@ -226,92 +221,5 @@ class ProposalServiceTest {
         assertThatThrownBy(() -> proposalService.createEditDraft(1L, EMAIL))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("진행 중이거나 완료된 매칭이 있는 제안서는 수정할 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("WRITING 상태 제안서는 정상적으로 삭제된다")
-    void delete_writingProposal_succeeds() {
-        Proposal proposal = Proposal.create(member, "삭제할 프로젝트", "", "설명", null, null, 6L);
-        ReflectionTestUtils.setField(proposal, "id", 1L);
-        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
-
-        proposalService.delete(1L, EMAIL);
-
-        then(proposalRepository).should().delete(proposal);
-    }
-
-    @Test
-    @DisplayName("WRITING 상태가 아닌 제안서는 삭제할 수 없다")
-    void delete_nonWritingProposal_throws() {
-        Proposal proposal = Proposal.create(member, "매칭 중 프로젝트", "", "설명", null, null, 6L);
-        ReflectionTestUtils.setField(proposal, "id", 1L);
-        proposal.startMatching();
-        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
-
-        assertThatThrownBy(() -> proposalService.delete(1L, EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("작성 중인 제안서만 삭제할 수 있습니다.");
-    }
-
-    @Test
-    @DisplayName("본인 제안서가 아니면 삭제할 수 없다")
-    void delete_othersProposal_throws() {
-        Proposal proposal = Proposal.create(member, "다른 사람 프로젝트", "", "설명", null, null, 6L);
-        ReflectionTestUtils.setField(proposal, "id", 1L);
-        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
-
-        assertThatThrownBy(() -> proposalService.delete(1L, OTHER_EMAIL))
-                .isInstanceOf(AccessDeniedException.class);
-        then(proposalRepository).should().findById(1L);
-        then(proposalRepository).shouldHaveNoMoreInteractions();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 제안서는 삭제할 수 없다")
-    void delete_throws_whenNotFound() {
-        when(proposalRepository.findById(99L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> proposalService.delete(99L, EMAIL))
-                .isInstanceOf(ProposalNotFoundException.class);
-        then(proposalRepository).should().findById(99L);
-        then(proposalRepository).should(never()).delete(any(Proposal.class));
-    }
-
-    @Test
-    @DisplayName("소유자는 findOwnedProposal로 제안서를 조회할 수 있다")
-    void findOwnedProposal_returnsProposal_whenOwner() {
-        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
-        ReflectionTestUtils.setField(proposal, "id", 1L);
-        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
-
-        Proposal result = proposalService.findOwnedProposal(1L, EMAIL);
-
-        assertThat(result).isSameAs(proposal);
-        then(proposalRepository).should().findWithPositionsById(1L);
-        then(proposalRepository).should().findPositionsWithSkillsByProposalId(1L);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 제안서는 findOwnedProposal에서 예외가 발생한다")
-    void findOwnedProposal_throws_whenNotFound() {
-        when(proposalRepository.findWithPositionsById(99L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> proposalService.findOwnedProposal(99L, EMAIL))
-                .isInstanceOf(ProposalNotFoundException.class);
-        then(proposalRepository).should().findWithPositionsById(99L);
-        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(99L);
-    }
-
-    @Test
-    @DisplayName("타인 제안서는 findOwnedProposal에서 접근 거부 예외가 발생한다")
-    void findOwnedProposal_throws_whenNotOwner() {
-        Proposal proposal = Proposal.create(member, "내 프로젝트", "원본", "설명", null, null, 6L);
-        ReflectionTestUtils.setField(proposal, "id", 1L);
-        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
-
-        assertThatThrownBy(() -> proposalService.findOwnedProposal(1L, OTHER_EMAIL))
-                .isInstanceOf(AccessDeniedException.class);
-        then(proposalRepository).should().findWithPositionsById(1L);
-        then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(1L);
     }
 }


### PR DESCRIPTION
## 🔎 What

- 제안서별 AI 인터뷰 메시지 저장 구조 추가
- USER / ASSISTANT 메시지 역할 구분
- 메시지 내용 저장
- 메시지 순서 저장
- 사용자 메시지 전송 API 구현
- 사용자 메시지 저장 후 AI 후속 질문 생성
- AI 응답 메시지 저장
- 제안서 수정 화면 진입 시 기존 대화 히스토리 조회
- AI 위젯을 rawInputText 단일 블럭이 아닌 말풍선 리스트 UI로 변경
- 화면 재진입 시 기존 대화 히스토리 복원
- AI 브리프 생성 시 저장된 대화 히스토리를 입력으로 사용
- 사용자 메시지 전송 시 현재 Proposal 상태 + 대화 히스토리를 AI에 전달
- AI가 후속 질문과 함께 갱신용 AiBriefResult를 반환하도록 구현
- 매 턴마다 AiBriefResult를 Proposal에 즉시 반영
- 메시지 전송 응답에 갱신된 ProposalForm과 메시지 목록 반환
- 폼 영역이 매 턴마다 갱신되도록 프론트 반영
- 기존 rawInputText와의 호환 처리
- 서비스/컨트롤러 테스트 보강
- 수동 검증

## 🔗 Issue

- Closes: #75 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?