### PR TITLE
[Feat] RecommendationRunProcessor 연결 및 상태 전이 처리

### DIFF
--- a/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
@@ -112,7 +112,7 @@ public class RecommendationRun extends BaseEntity {
 
         this.status = RecommendationRunStatus.COMPUTED;
         this.hardFilterStats = stat;
-        this.candidateCount = stat.finalCount();
+        this.candidateCount = stat.finalCandidates();
         this.errorMessage = null;
     }
 

--- a/src/main/java/com/generic4/itda/domain/recommendation/vo/HardFilterStat.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/vo/HardFilterStat.java
@@ -2,12 +2,7 @@ package com.generic4.itda.domain.recommendation.vo;
 
 public record HardFilterStat(
         int totalCandidates,
-        int afterActiveFilter,
-        int afterVisibilityFilter,
-        int afterAiEnabledFilter
+        int finalCandidates
 ) {
 
-    public int finalCount() {
-        return afterAiEnabledFilter;
-    }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -84,7 +84,7 @@ public class RecommendationResultCreator {
 
     private Comparator<ScoredCandidate> resultComparator() {
         return Comparator.comparing(ScoredCandidate::finalScore).reversed()
-                .thenComparing(ScoredCandidate::candidateId);
+                .thenComparingLong(ScoredCandidate::resumeId);
     }
 
     private Map<Long, Resume> loadResumeMap(List<ScoredCandidate> topCandidates) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
@@ -1,17 +1,35 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.RecommendationCandidate.CandidateSkill;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class RecommendationRunProcessor {
 
     private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationResultRepository recommendationResultRepository;
+    private final RecommendationCandidateFinder recommendationCandidateFinder;
+    private final HeuristicV1RecommendationScorer recommendationScorer;
+    private final RecommendationResultCreator recommendationResultCreator;
 
     public void process(Long runId) {
         RecommendationRun run = recommendationRunRepository.findById(runId)
@@ -22,14 +40,47 @@ public class RecommendationRunProcessor {
         }
 
         try {
-            doProcess(run);
+            processRunningRun(run);
+            log.info("Recommendation run completed. runId={}", runId);
         } catch (Exception e) {
+            log.error("Recommendation run failed. runId={}", runId, e);
             run.markFailed(resolveErrorMessage(e));
         }
     }
 
-    void doProcess(RecommendationRun run) {
-        // TODO 실제 추천 계산 / 결과 저장 / 완료 처리
+    private void processRunningRun(RecommendationRun run) {
+        ProposalPosition proposalPosition = run.getProposalPosition();
+
+        List<RecommendationCandidate> candidates = recommendationCandidateFinder.findCandidates(
+                proposalPosition,
+                run.getTopK()
+        );
+
+        Set<String> requiredSkillNames = extractRequiredSkillNames(proposalPosition);
+        Set<String> preferredSkillNames = extractPreferredSkillNames(proposalPosition);
+
+        List<RecommendationScorableCandidate> scorableCandidates = candidates.stream()
+                .map(this::toScorableCandidate)
+                .toList();
+
+        List<ScoredCandidate> scoredCandidates = recommendationScorer.score(
+                proposalPosition.getProposal(),
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames,
+                scorableCandidates
+        );
+
+        List<RecommendationResult> results = recommendationResultCreator.create(
+                run,
+                scoredCandidates,
+                run.getTopK(),
+                requiredSkillNames
+        );
+
+        recommendationResultRepository.saveAll(results);
+        HardFilterStat hardFilterStat = new HardFilterStat(candidates.size(), results.size());
+        run.markCompleted(hardFilterStat);
     }
 
     private String resolveErrorMessage(Exception e) {
@@ -38,5 +89,29 @@ public class RecommendationRunProcessor {
             return "추천 실행 중 오류가 발생했습니다.";
         }
         return message;
+    }
+
+    private Set<String> extractRequiredSkillNames(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                .map(pps -> pps.getSkill().getName())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Set<String> extractPreferredSkillNames(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.PREFERENCE)
+                .map(pps -> pps.getSkill().getName())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private RecommendationScorableCandidate toScorableCandidate(RecommendationCandidate candidate) {
+        return new RecommendationScorableCandidate(
+                candidate.resumeId(),
+                candidate.careerYears(),
+                candidate.skills().stream()
+                        .map(CandidateSkill::skillName)
+                        .collect(Collectors.toSet())
+        );
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -18,12 +18,31 @@ import org.springframework.util.Assert;
 @RequiredArgsConstructor
 public class HeuristicV1RecommendationScorer {
 
+    private static final String DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+
     private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
     private final QueryEmbeddingGenerator queryEmbeddingGenerator;
     private final ResumeEmbeddingReader resumeEmbeddingReader;
     private final CosineSimilarityCalculator cosineSimilarityCalculator;
     private final SkillAdjustmentCalculator skillAdjustmentCalculator;
     private final CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    public List<ScoredCandidate> score(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<RecommendationScorableCandidate> candidates
+    ) {
+        return score(
+                proposal,
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames,
+                candidates,
+                DEFAULT_EMBEDDING_MODEL
+        );
+    }
 
     public List<ScoredCandidate> score(
             Proposal proposal,

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
@@ -3,8 +3,6 @@ package com.generic4.itda.service.recommend.scoring.model;
 import java.util.Set;
 
 public record RecommendationScorableCandidate(
-        Long candidateId,
-        Long memberId,
         Long resumeId,
         int careerYears,
         Set<String> ownedSkillNames

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -6,15 +6,7 @@ public record ScoredCandidate(
         RecommendationScorableCandidate candidate,
         ScoreBreakdown scoreBreakdown
 ) {
-
-    public Long candidateId() {
-        return candidate.candidateId();
-    }
-
-    public Long memberId() {
-        return candidate.memberId();
-    }
-
+    
     public Long resumeId() {
         return candidate.resumeId();
     }

--- a/src/test/java/com/generic4/itda/domain/recommendation/HardFilterStatConverterTest.java
+++ b/src/test/java/com/generic4/itda/domain/recommendation/HardFilterStatConverterTest.java
@@ -12,12 +12,12 @@ class HardFilterStatConverterTest {
 
     @Test
     void convert() {
-        HardFilterStat stat = new HardFilterStat(10, 8, 5, 3);
+        HardFilterStat stat = new HardFilterStat(10, 3);
 
         String json = converter.convertToDatabaseColumn(stat);
         HardFilterStat restored = converter.convertToEntityAttribute(json);
 
         assertThat(restored).isEqualTo(stat);
-        assertThat(restored.finalCount()).isEqualTo(3);
+        assertThat(restored.finalCandidates()).isEqualTo(3);
     }
 }

--- a/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
+++ b/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
@@ -21,7 +21,7 @@ class RecommendationRunTest {
     @BeforeEach
     void setUp() {
         mockPosition = mock(ProposalPosition.class);
-        stat = new HardFilterStat(10, 8, 5, 3); // finalCount() == 3
+        stat = new HardFilterStat(10, 3); // finalCandidates() == 3
     }
 
     private RecommendationRun createPendingRun() {
@@ -147,7 +147,7 @@ class RecommendationRunTest {
 
             run.markCompleted(stat);
 
-            assertThat(run.getCandidateCount()).isEqualTo(stat.finalCount());
+            assertThat(run.getCandidateCount()).isEqualTo(stat.finalCandidates());
         }
 
         @Test

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -72,7 +72,7 @@ class RecommendationRunRepositoryTest {
         RecommendationRun run = recommendationRunRepository.saveAndFlush(
                 RecommendationRun.create(proposalPosition, "fp-abc123", RecommendationAlgorithm.HEURISTIC_V1, 5));
         run.markRunning();
-        HardFilterStat stat = new HardFilterStat(10, 8, 6, 3);
+        HardFilterStat stat = new HardFilterStat(10, 3);
 
         // when
         run.markCompleted(stat);
@@ -386,7 +386,7 @@ class RecommendationRunRepositoryTest {
             run.markRunning();
         }
         if (targetStatus == RecommendationRunStatus.COMPUTED) {
-            run.markCompleted(new HardFilterStat(10, 8, 6, 3));
+            run.markCompleted(new HardFilterStat(10, 3));
         } else if (targetStatus == RecommendationRunStatus.FAILED) {
             run.markFailed("의도된 실패");
         }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -43,9 +43,9 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate low = scoredCandidate(1L, 10L, 101L, 0.5, 3);
-            ScoredCandidate mid = scoredCandidate(2L, 20L, 102L, 0.7, 3);
-            ScoredCandidate high = scoredCandidate(3L, 30L, 103L, 0.9, 3);
+            ScoredCandidate low = scoredCandidate(101L, 0.5, 3);
+            ScoredCandidate mid = scoredCandidate(102L, 0.7, 3);
+            ScoredCandidate high = scoredCandidate(103L, 0.9, 3);
 
             Resume resume101 = resumeWithId(101L);
             Resume resume102 = resumeWithId(102L);
@@ -81,8 +81,8 @@ class RecommendationResultCreatorTest {
             // 낮은 점수가 입력 리스트에 먼저 위치 → 정렬 후 dedup 시 올바르게 제거되는지 검증
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate lowerScore = scoredCandidate(1L, 10L, 100L, 0.4, 2);
-            ScoredCandidate higherScore = scoredCandidate(2L, 20L, 100L, 0.8, 2);
+            ScoredCandidate lowerScore = scoredCandidate(100L, 0.4, 2);
+            ScoredCandidate higherScore = scoredCandidate(100L, 0.8, 2);
 
             Resume resume = resumeWithId(100L);
             given(resumeRepository.findAllById(anyList()))
@@ -109,9 +109,9 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 101L, 0.9, 3);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 102L, 0.7, 3);
-            ScoredCandidate c3 = scoredCandidate(3L, 30L, 103L, 0.5, 3);
+            ScoredCandidate c1 = scoredCandidate(101L, 0.9, 3);
+            ScoredCandidate c2 = scoredCandidate(102L, 0.7, 3);
+            ScoredCandidate c3 = scoredCandidate(103L, 0.5, 3);
 
             Resume resume101 = resumeWithId(101L);
             Resume resume102 = resumeWithId(102L);
@@ -138,8 +138,8 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 201L, 0.9, 2);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 202L, 0.7, 2);
+            ScoredCandidate c1 = scoredCandidate(201L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(202L, 0.7, 2);
 
             Resume resume201 = resumeWithId(201L);
             Resume resume202 = resumeWithId(202L);
@@ -163,8 +163,8 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 301L, 0.9, 2);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 302L, 0.7, 2);
+            ScoredCandidate c1 = scoredCandidate(301L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(302L, 0.7, 2);
 
             // 302L에 해당하는 Resume 누락
             Resume resume301 = resumeWithId(301L);
@@ -188,10 +188,7 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 401L, 0.9, 3,
-                    Set.of("Java", "Spring", "Redis")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(401L, 0.9, 3, Set.of("Java", "Spring", "Redis"));
 
             Resume resume = resumeWithId(401L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -214,10 +211,7 @@ class RecommendationResultCreatorTest {
             RecommendationRun run = mock(RecommendationRun.class);
 
             // careerYears=5, similarityScore=0.9, matchedSkills=["Java","Spring"]
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 501L, 0.9, 5,
-                    Set.of("Java", "Spring")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(501L, 0.9, 5, Set.of("Java", "Spring"));
 
             Resume resume = resumeWithId(501L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -240,10 +234,7 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 601L, 0.5, 0,
-                    Set.of("Java", "Spring")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(601L, 0.5, 0, Set.of("Java", "Spring"));
 
             Resume resume = resumeWithId(601L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -264,18 +255,18 @@ class RecommendationResultCreatorTest {
 
     // --- fixture helpers ---
 
-    private ScoredCandidate scoredCandidate(
-            Long candidateId, Long memberId, Long resumeId, double finalScore, int careerYears
-    ) {
-        return scoredCandidateWithSkills(candidateId, memberId, resumeId, finalScore, careerYears, Set.of());
+    private ScoredCandidate scoredCandidate(Long resumeId, double finalScore, int careerYears) {
+        return scoredCandidateWithSkills(resumeId, finalScore, careerYears, Set.of());
     }
 
     private ScoredCandidate scoredCandidateWithSkills(
-            Long candidateId, Long memberId, Long resumeId,
-            double finalScore, int careerYears, Set<String> skills
+            Long resumeId,
+            double finalScore,
+            int careerYears,
+            Set<String> skills
     ) {
         RecommendationScorableCandidate candidate = new RecommendationScorableCandidate(
-                candidateId, memberId, resumeId, careerYears, skills
+                resumeId, careerYears, skills
         );
         ScoreBreakdown breakdown = new ScoreBreakdown(finalScore, 0.0, 0.0, finalScore);
         return new ScoredCandidate(candidate, breakdown);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -1,0 +1,182 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class RecommendationRunProcessorIntegrationTest {
+
+    private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
+    private static final int DEFAULT_TOP_K = 3;
+
+    @Autowired
+    private RecommendationRunProcessor recommendationRunProcessor;
+
+    @Autowired
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @Autowired
+    private RecommendationResultRepository recommendationResultRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProposalRepository proposalRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private RecommendationCandidateFinder recommendationCandidateFinder;
+
+    @MockitoBean
+    private HeuristicV1RecommendationScorer recommendationScorer;
+
+    @MockitoBean
+    private RecommendationResultCreator recommendationResultCreator;
+
+    @Test
+    @DisplayName("RUNNING 상태 run 처리 완료 후 RecommendationResult가 DB에 저장되고 status가 COMPUTED로 변경된다")
+    void process_happyPath_savesResultsAndMarksComputed() {
+        // given
+        RunFixture fixture = createRunningRunFixture("proc-happy@test.com", "fp-happy");
+
+        Member resumeOwner = memberRepository.save(createMember("resume-owner-happy@test.com", "pw", "이력서소유자", "010-1111-2222"));
+        Resume resume = persist(Resume.create(resumeOwner, "백엔드 개발 경험", (byte) 3, new CareerPayload(), null, ResumeWritingStatus.DONE, null));
+
+        RecommendationResult stubbedResult = RecommendationResult.create(
+                fixture.run(),
+                resume,
+                1,
+                BigDecimal.valueOf(0.8500),
+                BigDecimal.valueOf(0.7000),
+                new ReasonFacts(List.of("Java"), List.of(), 3, List.of())
+        );
+
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of());
+        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of());
+        given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(stubbedResult));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        assertThatCode(() -> recommendationRunProcessor.process(fixture.runId()))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: RecommendationRun 상태 검증
+        RecommendationRun persistedRun = recommendationRunRepository.findById(fixture.runId()).orElseThrow();
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(persistedRun.getErrorMessage()).isNull();
+
+        // then: HardFilterStat 반영 검증 (candidates=0개, results=1개)
+        HardFilterStat stat = persistedRun.getHardFilterStats();
+        assertThat(stat).isNotNull();
+        assertThat(stat.totalCandidates()).isZero();
+        assertThat(stat.finalCandidates()).isEqualTo(1);
+        assertThat(persistedRun.getCandidateCount()).isEqualTo(1);
+
+        // then: RecommendationResult DB 저장 검증
+        List<RecommendationResult> savedResults = recommendationResultRepository.findAll();
+        assertThat(savedResults).hasSize(1);
+        RecommendationResult savedResult = savedResults.get(0);
+        assertThat(savedResult.getRecommendationRun().getId()).isEqualTo(fixture.runId());
+        assertThat(savedResult.getResume().getId()).isEqualTo(resume.getId());
+        assertThat(savedResult.getRank()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("처리 중 예외 발생 시 process()가 예외를 전파하지 않고 status가 FAILED로 변경되며 errorMessage가 저장된다")
+    void process_exceptionDuringProcessing_doesNotPropagateAndMarksFailed() {
+        // given
+        RunFixture fixture = createRunningRunFixture("proc-fail@test.com", "fp-fail");
+
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt()))
+                .willThrow(new RuntimeException("후보 조회 중 오류 발생"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        assertThatCode(() -> recommendationRunProcessor.process(fixture.runId()))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: RecommendationRun 상태 검증
+        RecommendationRun persistedRun = recommendationRunRepository.findById(fixture.runId()).orElseThrow();
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(persistedRun.getErrorMessage()).isEqualTo("후보 조회 중 오류 발생");
+
+        // then: RecommendationResult가 저장되지 않았음을 검증
+        assertThat(recommendationResultRepository.count()).isZero();
+    }
+
+    private RunFixture createRunningRunFixture(String ownerEmail, String fingerprint) {
+        Member owner = memberRepository.save(createMember(ownerEmail, "pw", "제안자", "010-0000-0001"));
+        Position position = persist(Position.create("백엔드 개발자"));
+        Skill java = persist(Skill.create("Java", null));
+
+        Proposal proposal = Proposal.create(owner, "AI 추천 테스트 제안서", "원본 입력", "설명", 5_000_000L, 10_000_000L, 6L);
+        ProposalPosition proposalPosition = proposal.addPosition(position, "백엔드 개발자", null, 2L, 1_000_000L, 2_000_000L, null, null, null, null);
+        proposalPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+
+        RecommendationRun run = RecommendationRun.create(proposalPosition, fingerprint, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        run.markRunning();
+        persist(run);
+
+        return new RunFixture(run.getId(), run);
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+
+    private record RunFixture(Long runId, RecommendationRun run) {}
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -4,23 +4,39 @@ import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.spy;
+import static org.mockito.BDDMockito.then;
 
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +46,18 @@ class RecommendationRunProcessorTest {
 
     @Mock
     private RecommendationRunRepository recommendationRunRepository;
+
+    @Mock
+    private RecommendationResultRepository recommendationResultRepository;
+
+    @Mock
+    private RecommendationCandidateFinder recommendationCandidateFinder;
+
+    @Mock
+    private HeuristicV1RecommendationScorer recommendationScorer;
+
+    @Mock
+    private RecommendationResultCreator recommendationResultCreator;
 
     @InjectMocks
     private RecommendationRunProcessor recommendationRunProcessor;
@@ -63,62 +91,162 @@ class RecommendationRunProcessorTest {
         }
 
         @Test
-        @DisplayName("RUNNING 상태의 run이면 예외없이 처리한다")
+        @DisplayName("RUNNING 상태의 run이면 예외 없이 처리하고 COMPUTED 상태가 된다")
         void RUNNING_상태의_run이면_예외_없이_처리한다() {
-            RecommendationRun run = createRun(true);
+            ProposalPosition proposalPosition = createProposalPositionWithSkills();
+            RecommendationRun run = createRun(proposalPosition, true);
+
+            List<RecommendationCandidate> candidates = List.of(
+                    createCandidate(101L, 3,
+                            createCandidateSkill(1L, "Java", Proficiency.ADVANCED),
+                            createCandidateSkill(3L, "Kotlin", Proficiency.INTERMEDIATE)),
+                    createCandidate(202L, 1,
+                            createCandidateSkill(2L, "Spring", Proficiency.BEGINNER))
+            );
+            List<ScoredCandidate> scoredCandidates = List.of();
+            List<RecommendationResult> results = List.of(org.mockito.Mockito.mock(RecommendationResult.class));
 
             given(recommendationRunRepository.findById(1L))
                     .willReturn(Optional.of(run));
+            given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                    .willReturn(candidates);
+            given(recommendationScorer.score(
+                    any(),
+                    any(),
+                    anySet(),
+                    anySet(),
+                    anyList()
+            )).willReturn(scoredCandidates);
+            given(recommendationResultCreator.create(
+                    run,
+                    scoredCandidates,
+                    run.getTopK(),
+                    Set.of("Java")
+            )).willReturn(results);
 
             assertThatCode(() -> recommendationRunProcessor.process(1L))
                     .doesNotThrowAnyException();
+
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+            assertThat(run.getCandidateCount()).isEqualTo(1);
+            assertThat(run.getHardFilterStats()).isEqualTo(new HardFilterStat(2, 1));
+            then(recommendationScorer).should().score(
+                    proposalPosition.getProposal(),
+                    proposalPosition,
+                    Set.of("Java"),
+                    Set.of("Spring"),
+                    List.of(
+                            new RecommendationScorableCandidate(101L, 3, Set.of("Java", "Kotlin")),
+                            new RecommendationScorableCandidate(202L, 1, Set.of("Spring"))
+                    )
+            );
+            then(recommendationResultCreator).should().create(
+                    run,
+                    scoredCandidates,
+                    run.getTopK(),
+                    Set.of("Java")
+            );
+            then(recommendationResultRepository).should().saveAll(results);
         }
     }
 
     @Test
-    @DisplayName("처리 중 예외가 발생하면 FAILED 상태로 전이하고 예외 메시지를 저장한다")
+    @DisplayName("finder 처리 중 예외가 발생하면 FAILED 상태로 전이하고 예외 메시지를 저장한다")
     void 처리_중_예외가_발생하면_FAILED_상태로_전이하고_예외_메시지를_저장한다() {
         RecommendationRun run = createRun(true);
-        RecommendationRunProcessor spyProcessor = spy(
-                new RecommendationRunProcessor(recommendationRunRepository)
-        );
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        willThrow(new RuntimeException("하드 필터 계산 실패"))
-                .given(spyProcessor).doProcess(run);
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException("하드 필터 계산 실패"));
 
-        assertThatCode(() -> spyProcessor.process(1L))
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
                 .doesNotThrowAnyException();
 
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("하드 필터 계산 실패");
+        then(recommendationScorer).shouldHaveNoInteractions();
+        then(recommendationResultCreator).shouldHaveNoInteractions();
+        then(recommendationResultRepository).shouldHaveNoInteractions();
     }
 
     @Test
     @DisplayName("예외 메시지가 없으면 기본 실패 메시지로 FAILED 처리한다")
     void 예외_메시지가_없으면_기본_실패_메시지로_FAILED_처리한다() {
         RecommendationRun run = createRun(true);
-        RecommendationRunProcessor spyProcessor = org.mockito.Mockito.spy(
-                new RecommendationRunProcessor(recommendationRunRepository)
-        );
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        org.mockito.BDDMockito.willThrow(new RuntimeException())
-                .given(spyProcessor).doProcess(run);
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException());
 
-        assertThatCode(() -> spyProcessor.process(1L))
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
                 .doesNotThrowAnyException();
 
-        assertThat(run.getStatus()).isEqualTo(
-                com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.FAILED);
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
     }
 
+    @Test
+    @DisplayName("예외 메시지가 공백이면 기본 실패 메시지로 FAILED 처리한다")
+    void 예외_메시지가_공백이면_기본_실패_메시지로_FAILED_처리한다() {
+        RecommendationRun run = createRun(true);
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException("   "));
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("result 저장 중 예외가 발생하면 FAILED 상태로 전이한다")
+    void 결과_저장_중_예외가_발생하면_FAILED_상태로_전이한다() {
+        RecommendationRun run = createRun(true);
+
+        List<RecommendationCandidate> candidates = List.of();
+        List<ScoredCandidate> scoredCandidates = List.of();
+        List<RecommendationResult> results = List.of();
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                anyList()
+        )).willReturn(scoredCandidates);
+        given(recommendationResultCreator.create(
+                run,
+                scoredCandidates,
+                run.getTopK(),
+                Set.of()
+        )).willReturn(results);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("저장 실패"))
+                .given(recommendationResultRepository).saveAll(results);
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("저장 실패");
+    }
+
     private RecommendationRun createRun(boolean running) {
+        return createRun(createProposalPosition(), running);
+    }
+
+    private RecommendationRun createRun(ProposalPosition proposalPosition, boolean running) {
         RecommendationRun run = RecommendationRun.create(
-                createProposalPosition(),
+                proposalPosition,
                 running ? "fp-running" : "fp-pending",
                 RecommendationAlgorithm.HEURISTIC_V1,
                 5
@@ -133,7 +261,6 @@ class RecommendationRunProcessorTest {
 
     private ProposalPosition createProposalPosition() {
         Member member = createMember();
-
         Position position = Position.create("백엔드 개발자");
 
         Proposal proposal = Proposal.create(
@@ -158,5 +285,97 @@ class RecommendationRunProcessorTest {
                 null,
                 null
         );
+    }
+
+    @Test
+    @DisplayName("후보를 scoring 입력 모델로 변환해 scorer에 전달한다")
+    void 후보를_scoring_입력_모델로_변환해_scorer에_전달한다() {
+        RecommendationRun run = createRun(true);
+
+        RecommendationCandidate candidate = new RecommendationCandidate(
+                10L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of(
+                        new RecommendationCandidate.CandidateSkill(1L, "Java", Proficiency.ADVANCED),
+                        new RecommendationCandidate.CandidateSkill(2L, "Spring", Proficiency.INTERMEDIATE)
+                )
+        );
+
+        List<RecommendationCandidate> candidates = List.of(candidate);
+        List<ScoredCandidate> scoredCandidates = List.of();
+        List<RecommendationResult> results = List.of();
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                any(List.class)
+        )).willReturn(scoredCandidates);
+        given(recommendationResultCreator.create(
+                any(),
+                any(List.class),
+                anyInt(),
+                anySet()
+        )).willReturn(results);
+
+        recommendationRunProcessor.process(1L);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RecommendationScorableCandidate>> captor =
+                ArgumentCaptor.forClass(List.class);
+
+        then(recommendationScorer).should().score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                captor.capture()
+        );
+
+        List<RecommendationScorableCandidate> actual = captor.getValue();
+        assertThat(actual).hasSize(1);
+
+        RecommendationScorableCandidate scorable = actual.get(0);
+        assertThat(scorable.resumeId()).isEqualTo(10L);
+        assertThat(scorable.careerYears()).isEqualTo(3);
+        assertThat(scorable.ownedSkillNames()).containsExactlyInAnyOrder("Java", "Spring");
+    }
+
+    private ProposalPosition createProposalPositionWithSkills() {
+        ProposalPosition proposalPosition = createProposalPosition();
+        proposalPosition.addSkill(Skill.create("Java", null), ProposalPositionSkillImportance.ESSENTIAL);
+        proposalPosition.addSkill(Skill.create("Spring", null), ProposalPositionSkillImportance.PREFERENCE);
+        return proposalPosition;
+    }
+
+    private RecommendationCandidate createCandidate(
+            long resumeId,
+            int careerYears,
+            RecommendationCandidate.CandidateSkill... skills
+    ) {
+        return new RecommendationCandidate(
+                resumeId,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) careerYears,
+                List.of(skills)
+        );
+    }
+
+    private RecommendationCandidate.CandidateSkill createCandidateSkill(
+            long skillId,
+            String skillName,
+            Proficiency proficiency
+    ) {
+        return new RecommendationCandidate.CandidateSkill(skillId, skillName, proficiency);
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -27,12 +27,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * RecommendationRunQueryService 단위 테스트:
- * - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을 수행하는지 확인한다.
- *
- * 한계:
- * - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다.
- * - proposal/member/proposalPosition 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
+ * RecommendationRunQueryService 단위 테스트: - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을
+ * 수행하는지 확인한다.
+ * <p>
+ * 한계: - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다. - proposal/member/proposalPosition
+ * 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
  */
 @ExtendWith(MockitoExtension.class)
 class RecommendationRunQueryServiceTest {
@@ -240,7 +239,7 @@ class RecommendationRunQueryServiceTest {
             case RUNNING -> run.markRunning();
             case COMPUTED -> {
                 run.markRunning();
-                run.markCompleted(new HardFilterStat(12, 8, 5, 3));
+                run.markCompleted(new HardFilterStat(12, 3));
             }
             case FAILED -> {
                 run.markRunning();

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -59,8 +59,8 @@ class HeuristicV1RecommendationScorerTest {
     // 공통 헬퍼
     // -------------------------------------------------------------------------
 
-    private RecommendationScorableCandidate candidateWith(long candidateId, long memberId, long resumeId) {
-        return new RecommendationScorableCandidate(candidateId, memberId, resumeId, 3, Set.of("Java"));
+    private RecommendationScorableCandidate candidateWith(long resumeId) {
+        return new RecommendationScorableCandidate(resumeId, 3, Set.of("Java"));
     }
 
     private List<Double> dummyQueryEmbedding() {
@@ -98,7 +98,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("이력서 임베딩이 없는 후보는 결과에서 제외된다")
     void score_ExcludesCandidate_WhenResumeEmbeddingIsMissing() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
 
         given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
                 .willReturn("query text");
@@ -124,8 +124,8 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("최종 점수(finalScore) 내림차순으로 정렬한다")
     void score_ReturnsCandidatesSortedByFinalScoreDescending() {
         // given
-        RecommendationScorableCandidate candidateA = candidateWith(1L, 10L, 100L);
-        RecommendationScorableCandidate candidateB = candidateWith(2L, 20L, 200L);
+        RecommendationScorableCandidate candidateA = candidateWith(100L);
+        RecommendationScorableCandidate candidateB = candidateWith(200L);
 
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> embeddingA = List.of(1.0, 0.0);
@@ -166,7 +166,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("raw cosine -1.0은 embeddingScore 0.0으로 정규화된다")
     void score_NormalizesRawCosineMinusOne_ToZero() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.0, 1.0);
 
@@ -193,7 +193,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("raw cosine 1.0은 embeddingScore 1.0으로 정규화된다")
     void score_NormalizesRawCosinePlusOne_ToOne() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(1.0, 0.0);
 
@@ -224,7 +224,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("embeddingScore와 보정치의 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
     void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
         // given — rawCosine(0.8) + skill(0.15) + career(0.08) = 1.03 → clamp 1.0
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.8, 0.2);
 
@@ -255,7 +255,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("embeddingScore와 보정치의 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
     void score_ClampsFinalScore_ToZeroWhenSumBelowZero() {
         // given — rawCosine(-0.8) + skill(-0.15) + career(-0.12) = -1.07 → clamp 0.0
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(-0.8, 0.2);
 


### PR DESCRIPTION
## 🔎 What

추천 실행 흐름을 완성하고 `RecommendationRun`의 상태 전이를 관리하도록 `RecommendationRunProcessor`를 구현했습니다.

* `RecommendationCandidateFinder → Scorer → ResultCreator → 저장`으로 이어지는 실행 파이프라인을 연결했습니다.
* `RecommendationResultCreator`를 사용하도록 정리하여 결과 생성 책임을 processor 외부로 분리했습니다.
* `RecommendationCandidate → RecommendationScorableCandidate` 변환을 최소 입력 구조로 정리했습니다.
* `RecommendationScorableCandidate`에서 불필요한 식별자(`memberId`, `candidateId`)를 제거하고 `resumeId` 기준으로 단일화했습니다.
* 결과 정렬 시 `resumeId` 기반 tie-break를 추가하여 deterministic한 결과를 보장했습니다.
* `HardFilterStat`을 실제 파이프라인에 맞게 단순화했습니다.
  * 기존 단계별 필터 통계 → `totalCandidates`, `finalCandidates` 기준으로 재정의
* 예외 발생 시 `FAILED` 상태로 전이하고 에러 메시지를 저장하도록 처리했습니다.

또한, `PENDING → RUNNING` 상태 전이는 `RecommendationRunExecutor`로 분리하고,
`RecommendationRunProcessor`는 `RUNNING` 상태의 실행 처리 및 terminal 상태 전이에만 집중하도록 역할을 분리했습니다.

---

## 🔗 Issue

* Closes: #44 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?

---

## 💡 참고 사항

* `RecommendationRunPollingScheduler → RecommendationRunExecutor → RecommendationRunProcessor` 구조로
  실행/점유/처리 책임을 분리했습니다.
* 현재 `HardFilterStat`은 prefilter 이후 후보 기준으로 단순화된 상태이며,
  향후 query 단계에서 통계 수집이 필요할 경우 재설계 예정입니다.