### PR TITLE
[Feat] HEURISTIC_V1 추천 계산 구현

### DIFF
--- a/src/main/java/com/generic4/itda/ItDaApplication.java
+++ b/src/main/java/com/generic4/itda/ItDaApplication.java
@@ -3,9 +3,8 @@ package com.generic4.itda;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
+//@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ItDaApplication {

--- a/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/RecommendationRun.java
@@ -112,7 +112,7 @@ public class RecommendationRun extends BaseEntity {
 
         this.status = RecommendationRunStatus.COMPUTED;
         this.hardFilterStats = stat;
-        this.candidateCount = stat.finalCount();
+        this.candidateCount = stat.finalCandidates();
         this.errorMessage = null;
     }
 

--- a/src/main/java/com/generic4/itda/domain/recommendation/vo/HardFilterStat.java
+++ b/src/main/java/com/generic4/itda/domain/recommendation/vo/HardFilterStat.java
@@ -2,12 +2,7 @@ package com.generic4.itda.domain.recommendation.vo;
 
 public record HardFilterStat(
         int totalCandidates,
-        int afterActiveFilter,
-        int afterVisibilityFilter,
-        int afterAiEnabledFilter
+        int finalCandidates
 ) {
 
-    public int finalCount() {
-        return afterAiEnabledFilter;
-    }
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
@@ -1,8 +1,10 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResumeEmbeddingRepository extends JpaRepository<ResumeEmbedding, Long> {
 
+    List<ResumeEmbedding> findAllByResume_IdInAndEmbeddingModel(List<Long> resumeIds, String embeddingModel);
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
@@ -1,11 +1,19 @@
 package com.generic4.itda.repository;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import java.util.List;
 
 public interface ResumeQueryRepository {
 
-    List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize);
+    List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            int candidatePoolSize
+    );
 
-    List<Long> findRecommendableResumeIds(int candidatePoolSize);
+    List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            int candidatePoolSize
+    );
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
@@ -1,0 +1,11 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import java.util.List;
+
+public interface ResumeQueryRepository {
+
+    List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize);
+
+    List<Long> findRecommendableResumeIds(int candidatePoolSize);
+}

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.generic4.itda.repository;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.QResume;
+import com.generic4.itda.domain.resume.QResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QResume resume = QResume.resume;
+    private static final QResumeSkill resumeSkill = QResumeSkill.resumeSkill;
+
+    @Override
+    public List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize) {
+        NumberExpression<Integer> proficiencySquaredSum = new CaseBuilder()
+                .when(resumeSkill.proficiency.eq(Proficiency.BEGINNER)).then(1)
+                .when(resumeSkill.proficiency.eq(Proficiency.INTERMEDIATE)).then(4)
+                .when(resumeSkill.proficiency.eq(Proficiency.ADVANCED)).then(9)
+                .otherwise(0)
+                .sum();
+
+        NumberExpression<Long> matchedRequiredSkillCount = resumeSkill.skill.id.countDistinct();
+
+        return queryFactory
+                .select(Projections.constructor(
+                        CandidatePoolRow.class,
+                        resume.id,
+                        matchedRequiredSkillCount,
+                        proficiencySquaredSum,
+                        resume.careerYears
+                ))
+                .from(resume)
+                .join(resume.skills, resumeSkill)
+                .where(
+                        resume.status.eq(ResumeStatus.ACTIVE),
+                        resume.publiclyVisible.isTrue(),
+                        resume.aiMatchingEnabled.isTrue(),
+                        resumeSkill.skill.id.in(requiredSkillIds)
+                )
+                .groupBy(resume.id, resume.careerYears)
+                .orderBy(
+                        matchedRequiredSkillCount.desc(),
+                        proficiencySquaredSum.desc(),
+                        resume.careerYears.desc(),
+                        resume.id.asc()
+                )
+                .limit(candidatePoolSize)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findRecommendableResumeIds(int candidatePoolSize) {
+        return queryFactory
+                .select(resume.id)
+                .from(resume)
+                .where(
+                        resume.status.eq(ResumeStatus.ACTIVE),
+                        resume.publiclyVisible.isTrue(),
+                        resume.aiMatchingEnabled.isTrue()
+                )
+                .orderBy(
+                        resume.careerYears.desc(),
+                        resume.id.asc()
+                )
+                .limit(candidatePoolSize)
+                .fetch();
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.QResume;
 import com.generic4.itda.domain.resume.QResumeSkill;
 import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -47,6 +48,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                         resume.status.eq(ResumeStatus.ACTIVE),
                         resume.publiclyVisible.isTrue(),
                         resume.aiMatchingEnabled.isTrue(),
+                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -68,6 +70,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .where(
                         resume.status.eq(ResumeStatus.ACTIVE),
                         resume.publiclyVisible.isTrue(),
+                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
                         resume.aiMatchingEnabled.isTrue()
                 )
                 .orderBy(

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.generic4.itda.repository;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.QResume;
 import com.generic4.itda.domain.resume.QResumeSkill;
 import com.generic4.itda.domain.resume.ResumeStatus;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,7 +28,11 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     private static final QResumeSkill resumeSkill = QResumeSkill.resumeSkill;
 
     @Override
-    public List<CandidatePoolRow> findCandidatePool(List<Long> requiredSkillIds, int candidatePoolSize) {
+    public List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            int candidatePoolSize
+    ) {
         NumberExpression<Integer> proficiencySquaredSum = new CaseBuilder()
                 .when(resumeSkill.proficiency.eq(Proficiency.BEGINNER)).then(1)
                 .when(resumeSkill.proficiency.eq(Proficiency.INTERMEDIATE)).then(4)
@@ -45,10 +53,8 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .from(resume)
                 .join(resume.skills, resumeSkill)
                 .where(
-                        resume.status.eq(ResumeStatus.ACTIVE),
-                        resume.publiclyVisible.isTrue(),
-                        resume.aiMatchingEnabled.isTrue(),
-                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
+                        recommendable(),
+                        workTypeMatches(proposalPosition),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -63,15 +69,16 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     }
 
     @Override
-    public List<Long> findRecommendableResumeIds(int candidatePoolSize) {
+    public List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            int candidatePoolSize
+    ) {
         return queryFactory
                 .select(resume.id)
                 .from(resume)
                 .where(
-                        resume.status.eq(ResumeStatus.ACTIVE),
-                        resume.publiclyVisible.isTrue(),
-                        resume.writingStatus.eq(ResumeWritingStatus.DONE),
-                        resume.aiMatchingEnabled.isTrue()
+                        recommendable(),
+                        workTypeMatches(proposalPosition)
                 )
                 .orderBy(
                         resume.careerYears.desc(),
@@ -79,5 +86,26 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 )
                 .limit(candidatePoolSize)
                 .fetch();
+    }
+
+    private BooleanExpression recommendable() {
+        return resume.status.eq(ResumeStatus.ACTIVE)
+                .and(resume.publiclyVisible.isTrue())
+                .and(resume.aiMatchingEnabled.isTrue())
+                .and(resume.writingStatus.eq(ResumeWritingStatus.DONE));
+    }
+
+    private BooleanExpression workTypeMatches(ProposalPosition proposalPosition) {
+        ProposalWorkType workType = proposalPosition.getWorkType();
+
+        if (workType == null) {
+            return null;
+        }
+
+        return switch (workType) {
+            case SITE -> resume.preferredWorkType.in(WorkType.SITE, WorkType.HYBRID);
+            case REMOTE -> resume.preferredWorkType.in(WorkType.REMOTE, WorkType.HYBRID);
+            case HYBRID -> resume.preferredWorkType.eq(WorkType.HYBRID);
+        };
     }
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeRepository.java
@@ -1,14 +1,15 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.resume.Resume;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
     Optional<Resume> findByMemberId(Long memberId);
 
     boolean existsByMemberEmailValue(String email);
@@ -18,6 +19,15 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
             "left join fetch r.attachments " +
             "where r.member.email.value = :email")
     Optional<Resume> findByMemberEmailWithDetails(@Param("email") String email);
+
+    @Query("""
+            select distinct r
+            from Resume r
+            left join fetch r.skills rs
+            left join fetch rs.skill
+            where r.id in :resumeIds
+            """)
+    List<Resume> findAllWithSkillsByIds(List<Long> resumeIds);
 
     @Modifying
     @Query(value = "UPDATE resume SET career = :career WHERE id = :id", nativeQuery = true)

--- a/src/main/java/com/generic4/itda/service/recommend/CandidatePoolRow.java
+++ b/src/main/java/com/generic4/itda/service/recommend/CandidatePoolRow.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.service.recommend;
+
+public record CandidatePoolRow(
+        Long resumeId,
+        long matchedRequiredSkillCount,
+        int weightedProficiencySum,
+        byte careerYears
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidate.java
@@ -1,0 +1,52 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import java.util.List;
+import java.util.Objects;
+
+public record RecommendationCandidate(
+        Long resumeId,
+        ResumeStatus resumeStatus,
+        boolean publiclyVisible,
+        boolean aiMatchingEnabled,
+        byte careerYears,
+        List<CandidateSkill> skills
+) {
+
+    public RecommendationCandidate {
+        Objects.requireNonNull(resumeId);
+        Objects.requireNonNull(resumeStatus);
+        Objects.requireNonNull(skills);
+        skills = List.copyOf(skills); //방어적 복사
+    }
+
+    public boolean isActive() {
+        return resumeStatus == ResumeStatus.ACTIVE;
+    }
+
+    public record CandidateSkill(
+            Long skillId,
+            String skillName,
+            Proficiency proficiency
+    ) {
+
+        public CandidateSkill {
+            Objects.requireNonNull(skillId);
+            Objects.requireNonNull(skillName);
+            Objects.requireNonNull(proficiency);
+        }
+
+        public static CandidateSkill of(ResumeSkill resumeSkill) {
+            Objects.requireNonNull(resumeSkill);
+            Objects.requireNonNull(resumeSkill.getSkill());
+
+            return new CandidateSkill(
+                    resumeSkill.getSkill().getId(),
+                    resumeSkill.getSkill().getName(),
+                    resumeSkill.getProficiency()
+            );
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -52,7 +52,7 @@ public class RecommendationCandidateFinder {
         return candidateResumeIds.stream()
                 .map(resumeMap::get)
                 .filter(Objects::nonNull)
-                .filter(resume -> passesCareerRage(resume, proposalPosition))
+                .filter(resume -> passesCareerRange(resume, proposalPosition))
                 .map(this::toCandidate)
                 .toList();
     }
@@ -68,7 +68,7 @@ public class RecommendationCandidateFinder {
         return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
     }
 
-    private boolean passesCareerRage(Resume resume, ProposalPosition proposalPosition) {
+    private boolean passesCareerRange(Resume resume, ProposalPosition proposalPosition) {
         Integer candidateCareerYears = Integer.valueOf(resume.getCareerYears());
         Integer careerMinYears = proposalPosition.getCareerMinYears();
         Integer careerMaxYears = proposalPosition.getCareerMaxYears();

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -1,7 +1,7 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
-import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.repository.ResumeQueryRepository;
 import com.generic4.itda.repository.ResumeRepository;
@@ -24,9 +24,9 @@ public class RecommendationCandidateFinder {
     private final ResumeQueryRepository resumeQueryRepository;
     private final ResumeRepository resumeRepository;
 
-    public List<RecommendationCandidate> findCandidates(RecommendationRun run) {
-        List<Long> requiredSkillIds = extractRequiredSkillIds(run);
-        int candidatePoolSize = resolveCandidatePoolSize(run.getTopK());
+    public List<RecommendationCandidate> findCandidates(ProposalPosition proposalPosition, int topK) {
+        List<Long> requiredSkillIds = extractRequiredSkillIds(proposalPosition);
+        int candidatePoolSize = resolveCandidatePoolSize(topK);
 
         List<Long> candidateResumeIds;
         if (requiredSkillIds.isEmpty()) {
@@ -52,8 +52,8 @@ public class RecommendationCandidateFinder {
                 .toList();
     }
 
-    private List<Long> extractRequiredSkillIds(RecommendationRun run) {
-        return run.getProposalPosition().getSkills().stream()
+    private List<Long> extractRequiredSkillIds(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
                 .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
                 .map(pps -> pps.getSkill().getId())
                 .toList();

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -1,0 +1,79 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeQueryRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendationCandidateFinder {
+
+    private static final int MINIMUM_CANDIDATE_POOL_SIZE = 100;
+
+    private final ResumeQueryRepository resumeQueryRepository;
+    private final ResumeRepository resumeRepository;
+
+    public List<RecommendationCandidate> findCandidates(RecommendationRun run) {
+        List<Long> requiredSkillIds = extractRequiredSkillIds(run);
+        int candidatePoolSize = resolveCandidatePoolSize(run.getTopK());
+
+        List<Long> candidateResumeIds;
+        if (requiredSkillIds.isEmpty()) {
+            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(candidatePoolSize);
+        } else {
+            candidateResumeIds = resumeQueryRepository.findCandidatePool(requiredSkillIds, candidatePoolSize).stream()
+                    .map(CandidatePoolRow::resumeId)
+                    .toList();
+        }
+
+        if (candidateResumeIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Resume> resumes = resumeRepository.findAllWithSkillsByIds(candidateResumeIds);
+        Map<Long, Resume> resumeMap = resumes.stream()
+                .collect(Collectors.toMap(Resume::getId, Function.identity()));
+
+        return candidateResumeIds.stream()
+                .map(resumeMap::get)
+                .filter(Objects::nonNull)
+                .map(this::toCandidate)
+                .toList();
+    }
+
+    private List<Long> extractRequiredSkillIds(RecommendationRun run) {
+        return run.getProposalPosition().getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                .map(pps -> pps.getSkill().getId())
+                .toList();
+    }
+
+    private int resolveCandidatePoolSize(int topK) {
+        return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
+    }
+
+    private RecommendationCandidate toCandidate(Resume resume) {
+        return new RecommendationCandidate(
+                resume.getId(),
+                resume.getStatus(),
+                resume.isPubliclyVisible(),
+                resume.isAiMatchingEnabled(),
+                resume.getCareerYears(),
+                resume.getSkills().stream()
+                        .map(RecommendationCandidate.CandidateSkill::of)
+                        .toList()
+        );
+    }
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -30,9 +30,13 @@ public class RecommendationCandidateFinder {
 
         List<Long> candidateResumeIds;
         if (requiredSkillIds.isEmpty()) {
-            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(candidatePoolSize);
+            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(proposalPosition, candidatePoolSize);
         } else {
-            candidateResumeIds = resumeQueryRepository.findCandidatePool(requiredSkillIds, candidatePoolSize).stream()
+            candidateResumeIds = resumeQueryRepository.findCandidatePool(
+                            proposalPosition,
+                            requiredSkillIds,
+                            candidatePoolSize
+                    ).stream()
                     .map(CandidatePoolRow::resumeId)
                     .toList();
         }
@@ -48,6 +52,7 @@ public class RecommendationCandidateFinder {
         return candidateResumeIds.stream()
                 .map(resumeMap::get)
                 .filter(Objects::nonNull)
+                .filter(resume -> passesCareerRage(resume, proposalPosition))
                 .map(this::toCandidate)
                 .toList();
     }
@@ -61,6 +66,22 @@ public class RecommendationCandidateFinder {
 
     private int resolveCandidatePoolSize(int topK) {
         return Math.max(MINIMUM_CANDIDATE_POOL_SIZE, topK * 20);
+    }
+
+    private boolean passesCareerRage(Resume resume, ProposalPosition proposalPosition) {
+        Integer candidateCareerYears = Integer.valueOf(resume.getCareerYears());
+        Integer careerMinYears = proposalPosition.getCareerMinYears();
+        Integer careerMaxYears = proposalPosition.getCareerMaxYears();
+
+        if (careerMinYears != null && candidateCareerYears < careerMinYears) {
+            return false;
+        }
+
+        if (careerMaxYears != null && candidateCareerYears > careerMaxYears) {
+            return false;
+        }
+
+        return true;
     }
 
     private RecommendationCandidate toCandidate(Resume resume) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -28,7 +28,7 @@ public class RecommendationResultCreator {
     private static final int SCORE_SCALE = 4;
     private final ResumeRepository resumeRepository;
 
-    List<RecommendationResult> create(
+    public List<RecommendationResult> create(
             RecommendationRun run,
             List<ScoredCandidate> scoredCandidates,
             int topK,
@@ -144,7 +144,7 @@ public class RecommendationResultCreator {
         List<String> highlights = new ArrayList<>();
 
         if (!matchedSkills.isEmpty()) {
-            highlights.add("공토 스킬 " + matchedSkills.size() + "개 보유");
+            highlights.add("공통 스킬 " + matchedSkills.size() + "개 보유");
         }
 
         if (candidate.careerYears() > 0) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -84,7 +84,7 @@ public class RecommendationResultCreator {
 
     private Comparator<ScoredCandidate> resultComparator() {
         return Comparator.comparing(ScoredCandidate::finalScore).reversed()
-                .thenComparing(ScoredCandidate::candidateId);
+                .thenComparingLong(ScoredCandidate::resumeId);
     }
 
     private Map<Long, Resume> loadResumeMap(List<ScoredCandidate> topCandidates) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationResultCreator.java
@@ -1,0 +1,160 @@
+package com.generic4.itda.service.recommend;
+
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationResultCreator {
+
+    private static final int SCORE_SCALE = 4;
+    private final ResumeRepository resumeRepository;
+
+    List<RecommendationResult> create(
+            RecommendationRun run,
+            List<ScoredCandidate> scoredCandidates,
+            int topK,
+            Set<String> requiredSkillNames
+    ) {
+        List<ScoredCandidate> topCandidates = selectTopCandidates(scoredCandidates, topK);
+        if (topCandidates.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Resume> resumeMap = loadResumeMap(topCandidates);
+
+        List<RecommendationResult> results = new ArrayList<>();
+        int rank = 1;
+
+        for (ScoredCandidate candidate : topCandidates) {
+            results.add(
+                    RecommendationResult.create(
+                            run,
+                            resumeMap.get(candidate.resumeId()),
+                            rank++,
+                            toBigDecimal(candidate.finalScore()),
+                            toBigDecimal(candidate.similarityScore()),
+                            createReasonFacts(candidate, requiredSkillNames)
+                    )
+            );
+        }
+
+        return results;
+    }
+
+    private List<ScoredCandidate> selectTopCandidates(List<ScoredCandidate> scoredCandidates, int topK) {
+        if (scoredCandidates == null || scoredCandidates.isEmpty()) {
+            return List.of();
+        }
+
+        List<ScoredCandidate> deduplicated = new ArrayList<>(
+                scoredCandidates.stream()
+                        .sorted(resultComparator())
+                        .collect(Collectors.toMap(
+                                ScoredCandidate::resumeId,
+                                Function.identity(),
+                                (first, second) -> first,
+                                LinkedHashMap::new
+                        ))
+                        .values()
+        );
+
+        return deduplicated.stream()
+                .limit(topK)
+                .toList();
+    }
+
+    private Comparator<ScoredCandidate> resultComparator() {
+        return Comparator.comparing(ScoredCandidate::finalScore).reversed()
+                .thenComparing(ScoredCandidate::candidateId);
+    }
+
+    private Map<Long, Resume> loadResumeMap(List<ScoredCandidate> topCandidates) {
+        List<Long> resumeIds = topCandidates.stream()
+                .map(ScoredCandidate::resumeId)
+                .toList();
+
+        Map<Long, Resume> resumeMap = resumeRepository.findAllById(resumeIds).stream()
+                .collect(Collectors.toMap(
+                        Resume::getId,
+                        Function.identity()
+                ));
+
+        if (resumeMap.size() != resumeIds.size()) {
+            throw new IllegalStateException("추천 결과 생성 대상 이력서 일부를 찾을 수 없습니다.");
+        }
+
+        return resumeMap;
+    }
+
+    private BigDecimal toBigDecimal(double value) {
+        return BigDecimal.valueOf(value)
+                .setScale(SCORE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private ReasonFacts createReasonFacts(
+            ScoredCandidate candidate,
+            Set<String> requiredSkillNames
+    ) {
+        List<String> matchedSkills = extractMatchedSkills(candidate, requiredSkillNames);
+
+        return new ReasonFacts(
+                matchedSkills,
+                List.of(), // matchedDomains (placeholder)
+                candidate.careerYears(),
+                createHighlights(candidate, matchedSkills)
+        );
+    }
+
+    private List<String> extractMatchedSkills(
+            ScoredCandidate candidate,
+            Set<String> requiredSkillNames
+    ) {
+        if (requiredSkillNames == null || requiredSkillNames.isEmpty()) {
+            return List.of();
+        }
+        return candidate.ownedSkillNames().stream()
+                .filter(requiredSkillNames::contains)
+                .sorted()
+                .toList();
+    }
+
+    private List<String> createHighlights(
+            ScoredCandidate candidate,
+            List<String> matchedSkills
+    ) {
+        List<String> highlights = new ArrayList<>();
+
+        if (!matchedSkills.isEmpty()) {
+            highlights.add("공토 스킬 " + matchedSkills.size() + "개 보유");
+        }
+
+        if (candidate.careerYears() > 0) {
+            highlights.add("관련 경력 " + candidate.careerYears() + "년");
+        }
+
+        if (candidate.similarityScore() >= 0.8) {
+            highlights.add("요구 조건과 높은 유사도");
+        }
+
+        return highlights;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunExecutor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunExecutor.java
@@ -13,22 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RecommendationRunExecutor {
 
-    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 1);
+    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 10);
     private final RecommendationRunRepository recommendationRunRepository;
 
     public Optional<Long> claimNextPendingRun() {
         List<Long> pendingRunIds = recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN);
-        if (pendingRunIds.isEmpty()) {
-            return Optional.empty();
+
+        for (Long runId : pendingRunIds) {
+            int updated = recommendationRunRepository.claimAsRunning(runId);
+            if (updated > 0) {
+                return Optional.of(runId);
+            }
         }
 
-        Long runId = pendingRunIds.get(0);
-        int updated = recommendationRunRepository.claimAsRunning(runId);
-
-        if (updated == 0) {
-            return Optional.empty();
-        }
-
-        return Optional.of(runId);
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
@@ -1,17 +1,35 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.RecommendationCandidate.CandidateSkill;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class RecommendationRunProcessor {
 
     private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationResultRepository recommendationResultRepository;
+    private final RecommendationCandidateFinder recommendationCandidateFinder;
+    private final HeuristicV1RecommendationScorer recommendationScorer;
+    private final RecommendationResultCreator recommendationResultCreator;
 
     public void process(Long runId) {
         RecommendationRun run = recommendationRunRepository.findById(runId)
@@ -22,14 +40,47 @@ public class RecommendationRunProcessor {
         }
 
         try {
-            doProcess(run);
+            processRunningRun(run);
+            log.info("Recommendation run completed. runId={}", runId);
         } catch (Exception e) {
+            log.error("Recommendation run failed. runId={}", runId, e);
             run.markFailed(resolveErrorMessage(e));
         }
     }
 
-    void doProcess(RecommendationRun run) {
-        // TODO 실제 추천 계산 / 결과 저장 / 완료 처리
+    private void processRunningRun(RecommendationRun run) {
+        ProposalPosition proposalPosition = run.getProposalPosition();
+
+        List<RecommendationCandidate> candidates = recommendationCandidateFinder.findCandidates(
+                proposalPosition,
+                run.getTopK()
+        );
+
+        Set<String> requiredSkillNames = extractRequiredSkillNames(proposalPosition);
+        Set<String> preferredSkillNames = extractPreferredSkillNames(proposalPosition);
+
+        List<RecommendationScorableCandidate> scorableCandidates = candidates.stream()
+                .map(this::toScorableCandidate)
+                .toList();
+
+        List<ScoredCandidate> scoredCandidates = recommendationScorer.score(
+                proposalPosition.getProposal(),
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames,
+                scorableCandidates
+        );
+
+        List<RecommendationResult> results = recommendationResultCreator.create(
+                run,
+                scoredCandidates,
+                run.getTopK(),
+                requiredSkillNames
+        );
+
+        recommendationResultRepository.saveAll(results);
+        HardFilterStat hardFilterStat = new HardFilterStat(candidates.size(), results.size());
+        run.markCompleted(hardFilterStat);
     }
 
     private String resolveErrorMessage(Exception e) {
@@ -38,5 +89,29 @@ public class RecommendationRunProcessor {
             return "추천 실행 중 오류가 발생했습니다.";
         }
         return message;
+    }
+
+    private Set<String> extractRequiredSkillNames(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                .map(pps -> pps.getSkill().getName())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Set<String> extractPreferredSkillNames(ProposalPosition proposalPosition) {
+        return proposalPosition.getSkills().stream()
+                .filter(pps -> pps.getImportance() == ProposalPositionSkillImportance.PREFERENCE)
+                .map(pps -> pps.getSkill().getName())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private RecommendationScorableCandidate toScorableCandidate(RecommendationCandidate candidate) {
+        return new RecommendationScorableCandidate(
+                candidate.resumeId(),
+                candidate.careerYears(),
+                candidate.skills().stream()
+                        .map(CandidateSkill::skillName)
+                        .collect(Collectors.toSet())
+        );
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculator.java
@@ -1,0 +1,33 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CareerAdjustmentCalculator {
+
+    private static final double IN_RANGE_BONUS = 0.08;
+    private static final double MIN_SHORTAGE_UNIT_PENALTY = 0.04;
+    private static final double MAX_EXCESS_UNIT_PENALTY = 0.02;
+    private static final double MIN_SHORTAGE_MAX_PENALTY = -0.12;
+    private static final double MAX_EXCESS_MAX_PENALTY = -0.06;
+
+    public double calculate(int candidateCareerYears, Integer careerMinYears, Integer careerMaxYears) {
+        if (careerMinYears == null && careerMaxYears == null) {
+            return 0.0;
+        }
+
+        if (careerMinYears != null && candidateCareerYears < careerMinYears) {
+            int shortage = careerMinYears - candidateCareerYears;
+            double penalty = -(shortage * MIN_SHORTAGE_UNIT_PENALTY);
+            return Math.max(MIN_SHORTAGE_MAX_PENALTY, penalty);
+        }
+
+        if (careerMaxYears != null && candidateCareerYears > careerMaxYears) {
+            int excess = candidateCareerYears - careerMaxYears;
+            double penalty = -(excess * MAX_EXCESS_UNIT_PENALTY);
+            return Math.max(MAX_EXCESS_MAX_PENALTY, penalty);
+        }
+
+        return IN_RANGE_BONUS;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
@@ -31,7 +31,7 @@ public class CosineSimilarityCalculator {
 
     private void validate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
         if (queryEmbedding == null || targetEmbedding == null) {
-            throw new IllegalArgumentException("embedding 은 null 일 수 업습니다.");
+            throw new IllegalArgumentException("embedding 은 null 일 수 없습니다.");
         }
         if (queryEmbedding.isEmpty() || targetEmbedding.isEmpty()) {
             throw new IllegalArgumentException("embedding 은 비어 있을 수 없습니다.");

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculator.java
@@ -1,0 +1,43 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CosineSimilarityCalculator {
+
+    public double calculate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
+        validate(queryEmbedding, targetEmbedding);
+
+        double dotProduct = 0.0;
+        double queryNorm = 0.0;
+        double targetNorm = 0.0;
+
+        for (int i = 0; i < queryEmbedding.size(); i++) {
+            double q = queryEmbedding.get(i);
+            double t = targetEmbedding.get(i);
+
+            dotProduct += q * t;
+            queryNorm += q * q;
+            targetNorm += t * t;
+        }
+
+        if (queryNorm == 0.0 || targetNorm == 0.0) {
+            return 0.0;
+        }
+
+        return dotProduct / (Math.sqrt(queryNorm) * Math.sqrt(targetNorm));
+    }
+
+    private void validate(List<Double> queryEmbedding, List<Double> targetEmbedding) {
+        if (queryEmbedding == null || targetEmbedding == null) {
+            throw new IllegalArgumentException("embedding 은 null 일 수 업습니다.");
+        }
+        if (queryEmbedding.isEmpty() || targetEmbedding.isEmpty()) {
+            throw new IllegalArgumentException("embedding 은 비어 있을 수 없습니다.");
+        }
+        if (queryEmbedding.size() != targetEmbedding.size()) {
+            throw new IllegalArgumentException("embedding 차원이 다릅니다.");
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -1,0 +1,125 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+@RequiredArgsConstructor
+public class HeuristicV1RecommendationScorer {
+
+    private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
+    private final QueryEmbeddingGenerator queryEmbeddingGenerator;
+    private final ResumeEmbeddingReader resumeEmbeddingReader;
+    private final CosineSimilarityCalculator cosineSimilarityCalculator;
+    private final SkillAdjustmentCalculator skillAdjustmentCalculator;
+    private final CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    public List<ScoredCandidate> score(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<RecommendationScorableCandidate> candidates,
+            String embeddingModel
+    ) {
+        Assert.notNull(proposal, "proposal은 필수입니다.");
+        Assert.notNull(proposalPosition, "proposalPosition은 필수입니다.");
+        Assert.notNull(candidates, "candidates는 null일 수 없습니다.");
+
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String queryText = recommendationQueryTextGenerator.generate(
+                proposal,
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames
+        );
+
+        List<Double> queryEmbedding = queryEmbeddingGenerator.generate(queryText);
+
+        List<Long> resumeIds = candidates.stream()
+                .map(RecommendationScorableCandidate::resumeId)
+                .toList();
+
+        Map<Long, List<Double>> resumeEmbeddings =
+                resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, embeddingModel);
+
+        return candidates.stream()
+                .filter(candidate -> resumeEmbeddings.containsKey(candidate.resumeId()))
+                .map(candidate -> scoredCandidate(
+                        candidate,
+                        proposalPosition,
+                        requiredSkillNames,
+                        preferredSkillNames,
+                        queryEmbedding,
+                        resumeEmbeddings.get(candidate.resumeId())
+                ))
+                .sorted(Comparator.comparingDouble(
+                        (ScoredCandidate scoredCandidate) -> scoredCandidate.scoreBreakdown().finalScore()
+                ).reversed())
+                .toList();
+    }
+
+    private ScoredCandidate scoredCandidate(
+            RecommendationScorableCandidate candidate,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<Double> queryEmbedding,
+            List<Double> resumeEmbedding
+    ) {
+        double rawCosineSimilarity = cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding);
+        double embeddingScore = normalizeCosineSimilarity(rawCosineSimilarity);
+
+        double skillAdjustmentScore = skillAdjustmentCalculator.calculate(
+                requiredSkillNames,
+                preferredSkillNames,
+                candidate.ownedSkillNames()
+        );
+
+        double careerAdjustmentScore = careerAdjustmentCalculator.calculate(
+                candidate.careerYears(),
+                proposalPosition.getCareerMinYears(),
+                proposalPosition.getCareerMaxYears()
+        );
+
+        double finalScore = clampScore(embeddingScore + skillAdjustmentScore + careerAdjustmentScore);
+
+        return new ScoredCandidate(
+                candidate,
+                new ScoreBreakdown(
+                        embeddingScore,
+                        skillAdjustmentScore,
+                        careerAdjustmentScore,
+                        finalScore
+                )
+        );
+    }
+
+    private double normalizeCosineSimilarity(double rawCosineSimilarity) {
+        return (rawCosineSimilarity + 1) / 2.0;
+    }
+
+    private double clampScore(double value) {
+        if (value < 0.0) {
+            return 0.0;
+        }
+        if (value > 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -18,12 +18,31 @@ import org.springframework.util.Assert;
 @RequiredArgsConstructor
 public class HeuristicV1RecommendationScorer {
 
+    private static final String DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+
     private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
     private final QueryEmbeddingGenerator queryEmbeddingGenerator;
     private final ResumeEmbeddingReader resumeEmbeddingReader;
     private final CosineSimilarityCalculator cosineSimilarityCalculator;
     private final SkillAdjustmentCalculator skillAdjustmentCalculator;
     private final CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    public List<ScoredCandidate> score(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            List<RecommendationScorableCandidate> candidates
+    ) {
+        return score(
+                proposal,
+                proposalPosition,
+                requiredSkillNames,
+                preferredSkillNames,
+                candidates,
+                DEFAULT_EMBEDDING_MODEL
+        );
+    }
 
     public List<ScoredCandidate> score(
             Proposal proposal,

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/QueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/QueryEmbeddingGenerator.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+
+public interface QueryEmbeddingGenerator {
+
+    List<Double> generate(String queryText);
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGenerator.java
@@ -1,0 +1,106 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * 임베딩용 문자열 생성기
+ */
+@Component
+public class RecommendationQueryTextGenerator {
+
+    public String generate(
+            Proposal proposal,
+            ProposalPosition proposalPosition,
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames
+    ) {
+        Set<String> required = safeSet(requiredSkillNames);
+        Set<String> preferred = normalizePreferredSkills(required, preferredSkillNames);
+
+        String positionName = extractPositionName(proposalPosition.getPosition());
+        String workType = proposalPosition.getWorkType() == null ? "" : proposalPosition.getWorkType().name();
+        String careerRange = buildCareerRange(
+                proposalPosition.getCareerMinYears(),
+                proposalPosition.getCareerMaxYears()
+        );
+
+        String requiredSkillsText = joinSkills(required);
+        String preferredSkillsText = joinSkills(preferred);
+
+        String title = normalizeText(proposal.getTitle());
+        String description = normalizeText(proposal.getDescription());
+
+        return """
+                position: %s
+                workType: %s
+                career: %s
+                required skills: %s
+                preferred skills: %s
+                title: %s
+                description: %s
+                """.formatted(
+                positionName,
+                workType,
+                careerRange,
+                requiredSkillsText,
+                preferredSkillsText,
+                title,
+                description
+        ).trim();
+    }
+
+    private Set<String> safeSet(Set<String> skills) {
+        return skills == null ? Collections.emptySet() : skills;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> required, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(Predicate.not(required::contains))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private String extractPositionName(Position position) {
+        if (position == null || position.getName() == null) {
+            return "";
+        }
+        return position.getName();
+    }
+
+    private String buildCareerRange(Integer minYears, Integer maxYears) {
+        if (minYears == null && maxYears == null) {
+            return "";
+        }
+        if (minYears != null && maxYears != null) {
+            return minYears + "~" + maxYears + " years";
+        }
+        if (minYears != null) {
+            return minYears + "+ years";
+        }
+        return "up to " + maxYears + " years";
+    }
+
+    private String joinSkills(Set<String> skills) {
+        if (skills == null) {
+            return "";
+        }
+
+        return skills.stream()
+                .map(this::normalizeText)
+                .sorted(Comparator.naturalOrder())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String normalizeText(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReader.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReader.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ResumeEmbeddingReader {
+
+    Map<Long, List<Double>> readEmbeddingsByResumeIds(List<Long> resumeIds, String embeddingModel);
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.service.recommend.scoring;
 
-import com.generic4.itda.domain.recommendation.ResumeEmbedding;
 import com.generic4.itda.repository.ResumeEmbeddingRepository;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +23,10 @@ public class ResumeEmbeddingReaderImpl implements ResumeEmbeddingReader {
             return Collections.emptyMap();
         }
 
-        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, embeddingModel).stream()
+        String normalizedEmbeddingModel = embeddingModel.trim();
+
+        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, normalizedEmbeddingModel)
+                .stream()
                 .collect(Collectors.toMap(
                         embedding -> embedding.getResume().getId(),
                         embedding -> embedding.getEmbeddingVector().values()

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImpl.java
@@ -1,0 +1,33 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+@RequiredArgsConstructor
+public class ResumeEmbeddingReaderImpl implements ResumeEmbeddingReader {
+
+    private final ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    @Override
+    public Map<Long, List<Double>> readEmbeddingsByResumeIds(List<Long> resumeIds, String embeddingModel) {
+        Assert.hasText(embeddingModel, "임베딩 모델명은 필수입니다.");
+
+        if (resumeIds == null || resumeIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, embeddingModel).stream()
+                .collect(Collectors.toMap(
+                        embedding -> embedding.getResume().getId(),
+                        embedding -> embedding.getEmbeddingVector().values()
+                ));
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
@@ -1,0 +1,75 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SkillAdjustmentCalculator {
+
+    private static final double REQUIRED_MAX_BONUS = 0.15;
+    private static final double REQUIRED_MIN_BONUS = -0.15;
+    private static final double PREFERRED_MAX_BONUS = 0.05;
+
+    public double calculate(
+            Set<String> requiredSkillNames,
+            Set<String> preferredSkillNames,
+            Set<String> ownedSkillNames
+    ) {
+        Set<String> required = safeSet(requiredSkillNames);
+        Set<String> preferred = normalizePreferredSkills(required, preferredSkillNames);
+        Set<String> owned = safeSet(ownedSkillNames);
+
+        double requiredAdjustment = calculateRequiredAdjustment(required, owned);
+        double preferredAdjustment = calculatePreferredAdjustment(preferred, owned);
+
+        return requiredAdjustment + preferredAdjustment;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(skillName -> !requiredSkillNames.contains(skillName))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private double calculateRequiredAdjustment(Set<String> requiredSkillNames, Set<String> ownedSkillNames) {
+        if (requiredSkillNames.isEmpty()) {
+            return 0.0;
+        }
+
+        long matchedCount = requiredSkillNames.stream()
+                .filter(ownedSkillNames::contains)
+                .count();
+
+        double matchRatio = (double) matchedCount / requiredSkillNames.size();
+        double adjustment = (matchRatio - 0.5) * 0.3;
+
+        if (adjustment > REQUIRED_MAX_BONUS) {
+            return REQUIRED_MIN_BONUS;
+        }
+        if (adjustment < REQUIRED_MIN_BONUS) {
+            return REQUIRED_MAX_BONUS;
+        }
+        return adjustment;
+    }
+
+    private double calculatePreferredAdjustment(Set<String> preferredSkillNames, Set<String> ownedSkillNames) {
+        if (preferredSkillNames.isEmpty()) {
+            return 0.0;
+        }
+
+        long matchCount = preferredSkillNames.stream()
+                .filter(ownedSkillNames::contains)
+                .count();
+
+        double matchRatio = (double) matchCount / preferredSkillNames.size();
+        return matchRatio * PREFERRED_MAX_BONUS;
+    }
+
+    private Set<String> safeSet(Set<String> skills) {
+        return skills == null ? Collections.emptySet() : skills;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculator.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class SkillAdjustmentCalculator {
 
+    private static final double REQUIRED_SKILL_NEUTRAL_MATCH_RATIO = 0.5;
+    private static final double REQUIRED_SKILL_ADJUSTMENT_WEIGHT = 0.3;
     private static final double REQUIRED_MAX_BONUS = 0.15;
-    private static final double REQUIRED_MIN_BONUS = -0.15;
+    private static final double REQUIRED_MIN_PENALTY = -0.15;
     private static final double PREFERRED_MAX_BONUS = 0.05;
 
     public double calculate(
@@ -27,14 +29,6 @@ public class SkillAdjustmentCalculator {
         return requiredAdjustment + preferredAdjustment;
     }
 
-    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
-        Set<String> preferred = safeSet(preferredSkillNames);
-
-        return preferred.stream()
-                .filter(skillName -> !requiredSkillNames.contains(skillName))
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
     private double calculateRequiredAdjustment(Set<String> requiredSkillNames, Set<String> ownedSkillNames) {
         if (requiredSkillNames.isEmpty()) {
             return 0.0;
@@ -45,13 +39,13 @@ public class SkillAdjustmentCalculator {
                 .count();
 
         double matchRatio = (double) matchedCount / requiredSkillNames.size();
-        double adjustment = (matchRatio - 0.5) * 0.3;
+        double adjustment = (matchRatio - REQUIRED_SKILL_NEUTRAL_MATCH_RATIO) * REQUIRED_SKILL_ADJUSTMENT_WEIGHT;
 
         if (adjustment > REQUIRED_MAX_BONUS) {
-            return REQUIRED_MIN_BONUS;
-        }
-        if (adjustment < REQUIRED_MIN_BONUS) {
             return REQUIRED_MAX_BONUS;
+        }
+        if (adjustment < REQUIRED_MIN_PENALTY) {
+            return REQUIRED_MIN_PENALTY;
         }
         return adjustment;
     }
@@ -71,5 +65,13 @@ public class SkillAdjustmentCalculator {
 
     private Set<String> safeSet(Set<String> skills) {
         return skills == null ? Collections.emptySet() : skills;
+    }
+
+    private Set<String> normalizePreferredSkills(Set<String> requiredSkillNames, Set<String> preferredSkillNames) {
+        Set<String> preferred = safeSet(preferredSkillNames);
+
+        return preferred.stream()
+                .filter(skillName -> !requiredSkillNames.contains(skillName))
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StubQueryEmbeddingGenerator implements QueryEmbeddingGenerator {
+
+    @Override
+    public List<Double> generate(String queryText) {
+        throw new UnsupportedOperationException("쿼리 임베딩 생성은 별도 이슈에서 구현합니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+import java.util.Set;
+
+public record RecommendationScorableCandidate(
+        Long candidateId,
+        Long memberId,
+        Long resumeId,
+        int careerYears,
+        Set<String> ownedSkillNames
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/RecommendationScorableCandidate.java
@@ -3,8 +3,6 @@ package com.generic4.itda.service.recommend.scoring.model;
 import java.util.Set;
 
 public record RecommendationScorableCandidate(
-        Long candidateId,
-        Long memberId,
         Long resumeId,
         int careerYears,
         Set<String> ownedSkillNames

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoreBreakdown.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoreBreakdown.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+public record ScoreBreakdown(
+        double similarityScore,
+        double skillAdjustmentScore,
+        double careerAdjustmentScore,
+        double finalScore
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.service.recommend.scoring.model;
+
+public record ScoredCandidate(
+        RecommendationScorableCandidate candidate,
+        ScoreBreakdown scoreBreakdown
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -1,8 +1,45 @@
 package com.generic4.itda.service.recommend.scoring.model;
 
+import java.util.Set;
+
 public record ScoredCandidate(
         RecommendationScorableCandidate candidate,
         ScoreBreakdown scoreBreakdown
 ) {
 
+    public Long candidateId() {
+        return candidate.candidateId();
+    }
+
+    public Long memberId() {
+        return candidate.memberId();
+    }
+
+    public Long resumeId() {
+        return candidate.resumeId();
+    }
+
+    public int careerYears() {
+        return candidate.careerYears();
+    }
+
+    public Set<String> ownedSkillNames() {
+        return candidate.ownedSkillNames();
+    }
+
+    public double similarityScore() {
+        return scoreBreakdown.similarityScore();
+    }
+
+    public double skillAdjustmentScore() {
+        return scoreBreakdown.skillAdjustmentScore();
+    }
+
+    public double careerAdjustmentScore() {
+        return scoreBreakdown.careerAdjustmentScore();
+    }
+
+    public double finalScore() {
+        return scoreBreakdown.finalScore();
+    }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/model/ScoredCandidate.java
@@ -6,15 +6,7 @@ public record ScoredCandidate(
         RecommendationScorableCandidate candidate,
         ScoreBreakdown scoreBreakdown
 ) {
-
-    public Long candidateId() {
-        return candidate.candidateId();
-    }
-
-    public Long memberId() {
-        return candidate.memberId();
-    }
-
+    
     public Long resumeId() {
         return candidate.resumeId();
     }

--- a/src/test/java/com/generic4/itda/domain/recommendation/HardFilterStatConverterTest.java
+++ b/src/test/java/com/generic4/itda/domain/recommendation/HardFilterStatConverterTest.java
@@ -12,12 +12,12 @@ class HardFilterStatConverterTest {
 
     @Test
     void convert() {
-        HardFilterStat stat = new HardFilterStat(10, 8, 5, 3);
+        HardFilterStat stat = new HardFilterStat(10, 3);
 
         String json = converter.convertToDatabaseColumn(stat);
         HardFilterStat restored = converter.convertToEntityAttribute(json);
 
         assertThat(restored).isEqualTo(stat);
-        assertThat(restored.finalCount()).isEqualTo(3);
+        assertThat(restored.finalCandidates()).isEqualTo(3);
     }
 }

--- a/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
+++ b/src/test/java/com/generic4/itda/domain/recommendation/RecommendationRunTest.java
@@ -21,7 +21,7 @@ class RecommendationRunTest {
     @BeforeEach
     void setUp() {
         mockPosition = mock(ProposalPosition.class);
-        stat = new HardFilterStat(10, 8, 5, 3); // finalCount() == 3
+        stat = new HardFilterStat(10, 3); // finalCandidates() == 3
     }
 
     private RecommendationRun createPendingRun() {
@@ -147,7 +147,7 @@ class RecommendationRunTest {
 
             run.markCompleted(stat);
 
-            assertThat(run.getCandidateCount()).isEqualTo(stat.finalCount());
+            assertThat(run.getCandidateCount()).isEqualTo(stat.finalCandidates());
         }
 
         @Test

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -72,7 +72,7 @@ class RecommendationRunRepositoryTest {
         RecommendationRun run = recommendationRunRepository.saveAndFlush(
                 RecommendationRun.create(proposalPosition, "fp-abc123", RecommendationAlgorithm.HEURISTIC_V1, 5));
         run.markRunning();
-        HardFilterStat stat = new HardFilterStat(10, 8, 6, 3);
+        HardFilterStat stat = new HardFilterStat(10, 3);
 
         // when
         run.markCompleted(stat);
@@ -386,7 +386,7 @@ class RecommendationRunRepositoryTest {
             run.markRunning();
         }
         if (targetStatus == RecommendationRunStatus.COMPUTED) {
-            run.markCompleted(new HardFilterStat(10, 8, 6, 3));
+            run.markCompleted(new HardFilterStat(10, 3));
         } else if (targetStatus == RecommendationRunStatus.FAILED) {
             run.markFailed("의도된 실패");
         }

--- a/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
@@ -88,32 +88,32 @@ class ResumeEmbeddingRepositoryTest {
     }
 
     @Test
-    @DisplayName("같은 resume에서 다른 embeddingModel로 변경 후 flush하면 unique constraint 위반이 발생한다")
-    void 같은_resume에서_다른_embeddingModel로_변경_후_flush하면_unique_constraint_위반이_발생한다() {
+    @DisplayName("이력서 ID 목록과 모델명으로 임베딩을 조회한다")
+    void 이력서_ID_목록과_모델명으로_임베딩을_조회한다() {
         // given
-        ResumeEmbedding first = resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(
-                        resume, new SourceHash("hash001"), "text-embedding-3-small",
-                        new EmbeddingVector(List.of(0.1, 0.2))));
+        String model = "text-embedding-3-small";
         resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(
-                        resume, new SourceHash("hash002"), "text-embedding-3-large",
-                        new EmbeddingVector(List.of(0.3, 0.4))));
-        em.clear();
-
-        ResumeEmbedding found = resumeEmbeddingRepository.findById(first.getId()).orElseThrow();
+                ResumeEmbedding.create(resume, new SourceHash("hash1"), model, new EmbeddingVector(List.of(0.1, 0.2))));
+        
+        Member otherMember = memberRepository.save(createMember("other@test.com", "pass", "other", "010-1111-2222"));
+        Resume otherResume = resumeRepository.save(
+                Resume.create(otherMember, "자기소개입니다.", (byte) 5, new CareerPayload(),
+                        WorkType.SITE, ResumeWritingStatus.WRITING, null));
+        resumeEmbeddingRepository.saveAndFlush(
+                ResumeEmbedding.create(otherResume, new SourceHash("hash2"), model, new EmbeddingVector(List.of(0.3, 0.4))));
+        
+        resumeEmbeddingRepository.saveAndFlush(
+                ResumeEmbedding.create(resume, new SourceHash("hash3"), "other-model", new EmbeddingVector(List.of(0.5, 0.6))));
 
         // when
-        found.refresh(
-                new SourceHash("hash003"),
-                "text-embedding-3-large",
-                new EmbeddingVector(List.of(0.9, 0.8)));
+        List<ResumeEmbedding> results = resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(
+                List.of(resume.getId(), otherResume.getId()), model);
 
         // then
-        assertThatThrownBy(() -> {
-            resumeEmbeddingRepository.save(found);
-            resumeEmbeddingRepository.flush();
-        })
-                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(ResumeEmbedding::getEmbeddingModel)
+                .containsOnly(model);
+        assertThat(results).extracting(re -> re.getResume().getId())
+                .containsExactlyInAnyOrder(resume.getId(), otherResume.getId());
     }
 }

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -147,6 +147,45 @@ class ResumeQueryRepositoryTest {
         );
     }
 
+    @DisplayName("findCandidatePool은 작성중인 이력서를 후보 풀에서 제외한다")
+    @Test
+    void findCandidatePool_excludesWritingResumes() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-writing", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-writing", null));
+
+        Resume doneResume = saveResume(
+                "pool-done",
+                (byte) 8,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.DONE,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE)
+        );
+        saveResume(
+                "pool-writing",
+                (byte) 20,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.WRITING,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(doneResume.getId());
+    }
+
     @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
     @Test
     void findRecommendableResumeIds_appliesLimitAfterOrdering() {
@@ -167,12 +206,60 @@ class ResumeQueryRepositoryTest {
         );
     }
 
+    @DisplayName("findRecommendableResumeIds는 작성중인 이력서를 제외한다")
+    @Test
+    void findRecommendableResumeIds_excludesWritingResumes() {
+        // given
+        Resume doneResume = saveResume(
+                "recommend-done",
+                (byte) 7,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.DONE
+        );
+        saveResume(
+                "recommend-writing",
+                (byte) 30,
+                true,
+                true,
+                true,
+                ResumeWritingStatus.WRITING
+        );
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+
+        // then
+        assertThat(result).containsExactly(doneResume.getId());
+    }
+
     private Resume saveResume(
             String suffix,
             byte careerYears,
             boolean publiclyVisible,
             boolean aiMatchingEnabled,
             boolean active,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                ResumeWritingStatus.DONE,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            ResumeWritingStatus writingStatus,
             SkillAssignment... skills
     ) {
         String phone = "010-1111-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
@@ -190,7 +277,7 @@ class ResumeQueryRepositoryTest {
                 careerYears,
                 new CareerPayload(),
                 WorkType.REMOTE,
-                ResumeWritingStatus.DONE,
+                writingStatus,
                 null
         );
 
@@ -215,5 +302,6 @@ class ResumeQueryRepositoryTest {
     }
 
     private record SkillAssignment(Skill skill, Proficiency proficiency) {
+
     }
 }

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -1,0 +1,165 @@
+package com.generic4.itda.repository;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.H2RepositoryTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.service.recommend.CandidatePoolRow;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@H2RepositoryTest
+@Import(ResumeQueryRepositoryImpl.class)
+class ResumeQueryRepositoryTest {
+
+    @Autowired
+    private ResumeQueryRepository resumeQueryRepository;
+
+    @Autowired
+    private ResumeRepository resumeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SkillRepository skillRepository;
+
+    @DisplayName("findCandidatePool은 필터링 후 매칭 수, 숙련도 합, 경력, id 순으로 후보를 정렬한다")
+    @Test
+    void findCandidatePool_filtersAndOrdersCandidates() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool", null));
+        Skill aws = skillRepository.saveAndFlush(Skill.create("Aws-query-pool", null));
+
+        Resume strongest = saveResume("pool-1", (byte) 5, true, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreHighCareerLowId = saveResume("pool-2", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreLowCareer = saveResume("pool-3", (byte) 7, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume sameScoreHighCareerHighId = saveResume("pool-4", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume partialMatch = saveResume("pool-5", (byte) 20, true, true, true,
+                skill(java, Proficiency.ADVANCED));
+
+        saveResume("pool-hidden", (byte) 30, false, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-ai-off", (byte) 30, true, false, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-inactive", (byte) 30, true, true, false,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED));
+        saveResume("pool-other-skill", (byte) 30, true, true, true,
+                skill(aws, Proficiency.ADVANCED));
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(
+                        strongest.getId(),
+                        sameScoreHighCareerLowId.getId(),
+                        sameScoreHighCareerHighId.getId(),
+                        sameScoreLowCareer.getId(),
+                        partialMatch.getId()
+                );
+        assertThat(result).extracting(CandidatePoolRow::matchedRequiredSkillCount)
+                .containsExactly(2L, 2L, 2L, 2L, 1L);
+        assertThat(result).extracting(CandidatePoolRow::weightedProficiencySum)
+                .containsExactly(13, 8, 8, 8, 9);
+    }
+
+    @DisplayName("findRecommendableResumeIds는 추천 가능 이력서만 경력과 id 순으로 조회한다")
+    @Test
+    void findRecommendableResumeIds_filtersAndOrdersResumes() {
+        // given
+        Resume highestCareer = saveResume("recommend-1", (byte) 9, true, true, true);
+        Resume mediumCareerLowId = saveResume("recommend-2", (byte) 5, true, true, true);
+        Resume mediumCareerHighId = saveResume("recommend-3", (byte) 5, true, true, true);
+
+        saveResume("recommend-hidden", (byte) 99, false, true, true);
+        saveResume("recommend-ai-off", (byte) 99, true, false, true);
+        saveResume("recommend-inactive", (byte) 99, true, true, false);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+
+        // then
+        assertThat(result).containsExactly(
+                highestCareer.getId(),
+                mediumCareerLowId.getId(),
+                mediumCareerHighId.getId()
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            SkillAssignment... skills
+    ) {
+        String phone = "010-1111-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
+        Member member = memberRepository.save(createMember(
+                "resume-query-" + suffix + "@example.com",
+                "hashed-password",
+                "name-" + suffix,
+                "nickname-" + suffix,
+                phone
+        ));
+
+        Resume resume = Resume.create(
+                member,
+                "소개-" + suffix,
+                careerYears,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+
+        if (!publiclyVisible) {
+            resume.togglePubliclyVisible();
+        }
+        if (!aiMatchingEnabled) {
+            resume.toggleAiMatchingEnabled();
+        }
+        if (!active) {
+            resume.delete();
+        }
+        for (SkillAssignment skill : skills) {
+            resume.addSkill(skill.skill(), skill.proficiency());
+        }
+
+        return resumeRepository.saveAndFlush(resume);
+    }
+
+    private static SkillAssignment skill(Skill skill, Proficiency proficiency) {
+        return new SkillAssignment(skill, proficiency);
+    }
+
+    private record SkillAssignment(Skill skill, Proficiency proficiency) {
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -2,7 +2,12 @@ package com.generic4.itda.repository;
 
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.resume.CareerPayload;
@@ -13,8 +18,12 @@ import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -70,7 +79,9 @@ class ResumeQueryRepositoryTest {
                 skill(aws, Proficiency.ADVANCED));
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 10
         );
@@ -110,7 +121,9 @@ class ResumeQueryRepositoryTest {
                 skill(java, Proficiency.ADVANCED));
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 2
         );
@@ -137,7 +150,7 @@ class ResumeQueryRepositoryTest {
         saveResume("recommend-inactive", (byte) 99, true, true, false);
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 10);
 
         // then
         assertThat(result).containsExactly(
@@ -176,7 +189,9 @@ class ResumeQueryRepositoryTest {
         );
 
         // when
+        ProposalPosition proposalPosition = createProposalPosition(null);
         List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                proposalPosition,
                 List.of(java.getId(), spring.getId()),
                 10
         );
@@ -184,6 +199,56 @@ class ResumeQueryRepositoryTest {
         // then
         assertThat(result).extracting(CandidatePoolRow::resumeId)
                 .containsExactly(doneResume.getId());
+    }
+
+    @DisplayName("findCandidatePool은 근무 형태 정책 조합에 따라 후보를 필터링한다")
+    @ParameterizedTest(name = "proposalWorkType={0}")
+    @MethodSource("workTypePolicyCases")
+    void findCandidatePool_filtersByProposalWorkTypePolicies(
+            ProposalWorkType proposalWorkType,
+            List<WorkType> expectedWorkTypes
+    ) {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-work-type", null));
+
+        Resume remote = saveResume(
+                "pool-work-type-remote",
+                (byte) 4,
+                true,
+                true,
+                true,
+                WorkType.REMOTE,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+        Resume hybrid = saveResume(
+                "pool-work-type-hybrid",
+                (byte) 5,
+                true,
+                true,
+                true,
+                WorkType.HYBRID,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+        Resume site = saveResume(
+                "pool-work-type-site",
+                (byte) 20,
+                true,
+                true,
+                true,
+                WorkType.SITE,
+                skill(java, Proficiency.INTERMEDIATE)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                createProposalPosition(proposalWorkType),
+                List.of(java.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactlyElementsOf(expectedResumeIds(expectedWorkTypes, site, hybrid, remote));
     }
 
     @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
@@ -196,7 +261,7 @@ class ResumeQueryRepositoryTest {
         saveResume("recommend-limit-4", (byte) 1, true, true, true);
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(2);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 2);
 
         // then
         assertThat(result).hasSize(2);
@@ -228,10 +293,53 @@ class ResumeQueryRepositoryTest {
         );
 
         // when
-        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(10);
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(createProposalPosition(null), 10);
 
         // then
         assertThat(result).containsExactly(doneResume.getId());
+    }
+
+    @DisplayName("findRecommendableResumeIds는 fallback 조회 경로에서도 근무 형태 정책 조합을 적용한다")
+    @ParameterizedTest(name = "proposalWorkType={0}")
+    @MethodSource("workTypePolicyCases")
+    void findRecommendableResumeIds_filtersByProposalWorkTypePolicies(
+            ProposalWorkType proposalWorkType,
+            List<WorkType> expectedWorkTypes
+    ) {
+        // given
+        Resume remote = saveResume("recommend-remote", (byte) 4, true, true, true, WorkType.REMOTE);
+        Resume hybrid = saveResume("recommend-hybrid", (byte) 5, true, true, true, WorkType.HYBRID);
+        Resume site = saveResume("recommend-site", (byte) 6, true, true, true, WorkType.SITE);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(
+                createProposalPosition(proposalWorkType),
+                10
+        );
+
+        // then
+        assertThat(result).containsExactlyElementsOf(expectedResumeIds(expectedWorkTypes, site, hybrid, remote));
+    }
+
+    private static Stream<Arguments> workTypePolicyCases() {
+        return Stream.of(
+                arguments(null, List.of(WorkType.SITE, WorkType.HYBRID, WorkType.REMOTE)),
+                arguments(ProposalWorkType.SITE, List.of(WorkType.SITE, WorkType.HYBRID)),
+                arguments(ProposalWorkType.REMOTE, List.of(WorkType.HYBRID, WorkType.REMOTE)),
+                arguments(ProposalWorkType.HYBRID, List.of(WorkType.HYBRID))
+        );
+    }
+
+    private List<Long> expectedResumeIds(
+            List<WorkType> expectedWorkTypes,
+            Resume site,
+            Resume hybrid,
+            Resume remote
+    ) {
+        return Stream.of(site, hybrid, remote)
+                .filter(resume -> expectedWorkTypes.contains(resume.getPreferredWorkType()))
+                .map(Resume::getId)
+                .toList();
     }
 
     private Resume saveResume(
@@ -248,6 +356,7 @@ class ResumeQueryRepositoryTest {
                 publiclyVisible,
                 aiMatchingEnabled,
                 active,
+                WorkType.REMOTE,
                 ResumeWritingStatus.DONE,
                 skills
         );
@@ -259,6 +368,49 @@ class ResumeQueryRepositoryTest {
             boolean publiclyVisible,
             boolean aiMatchingEnabled,
             boolean active,
+            WorkType preferredWorkType,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                preferredWorkType,
+                ResumeWritingStatus.DONE,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            ResumeWritingStatus writingStatus,
+            SkillAssignment... skills
+    ) {
+        return saveResume(
+                suffix,
+                careerYears,
+                publiclyVisible,
+                aiMatchingEnabled,
+                active,
+                WorkType.REMOTE,
+                writingStatus,
+                skills
+        );
+    }
+
+    private Resume saveResume(
+            String suffix,
+            byte careerYears,
+            boolean publiclyVisible,
+            boolean aiMatchingEnabled,
+            boolean active,
+            WorkType preferredWorkType,
             ResumeWritingStatus writingStatus,
             SkillAssignment... skills
     ) {
@@ -276,7 +428,7 @@ class ResumeQueryRepositoryTest {
                 "소개-" + suffix,
                 careerYears,
                 new CareerPayload(),
-                WorkType.REMOTE,
+                preferredWorkType,
                 writingStatus,
                 null
         );
@@ -299,6 +451,32 @@ class ResumeQueryRepositoryTest {
 
     private static SkillAssignment skill(Skill skill, Proficiency proficiency) {
         return new SkillAssignment(skill, proficiency);
+    }
+
+    private ProposalPosition createProposalPosition(ProposalWorkType workType) {
+        Proposal proposal = Proposal.create(
+                createMember(),
+                "추천 요청",
+                "raw-input",
+                null,
+                null,
+                null,
+                null
+        );
+
+        String workPlace = workType == ProposalWorkType.REMOTE ? null : "서울";
+        return proposal.addPosition(
+                Position.create("백엔드 개발자"),
+                "백엔드 개발자",
+                workType,
+                1L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                workPlace
+        );
     }
 
     private record SkillAssignment(Skill skill, Proficiency proficiency) {

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -90,6 +90,40 @@ class ResumeQueryRepositoryTest {
                 .containsExactly(13, 8, 8, 8, 9);
     }
 
+    @DisplayName("findCandidatePool은 정렬된 후보 중 limit 개수만 반환한다")
+    @Test
+    void findCandidatePool_appliesLimitAfterOrdering() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-limit", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-limit", null));
+
+        Resume strongest = saveResume("pool-limit-1", (byte) 5, true, true, true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE));
+        Resume higherCareer = saveResume("pool-limit-2", (byte) 10, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        saveResume("pool-limit-3", (byte) 7, true, true, true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE));
+        saveResume("pool-limit-4", (byte) 20, true, true, true,
+                skill(java, Proficiency.ADVANCED));
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                List.of(java.getId(), spring.getId()),
+                2
+        );
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(
+                        strongest.getId(),
+                        higherCareer.getId()
+                );
+    }
+
     @DisplayName("findRecommendableResumeIds는 추천 가능 이력서만 경력과 id 순으로 조회한다")
     @Test
     void findRecommendableResumeIds_filtersAndOrdersResumes() {
@@ -110,6 +144,26 @@ class ResumeQueryRepositoryTest {
                 highestCareer.getId(),
                 mediumCareerLowId.getId(),
                 mediumCareerHighId.getId()
+        );
+    }
+
+    @DisplayName("findRecommendableResumeIds는 정렬된 이력서 중 limit 개수만 반환한다")
+    @Test
+    void findRecommendableResumeIds_appliesLimitAfterOrdering() {
+        // given
+        Resume highestCareer = saveResume("recommend-limit-1", (byte) 9, true, true, true);
+        Resume mediumCareerLowId = saveResume("recommend-limit-2", (byte) 5, true, true, true);
+        saveResume("recommend-limit-3", (byte) 5, true, true, true);
+        saveResume("recommend-limit-4", (byte) 1, true, true, true);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(2);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(
+                highestCareer.getId(),
+                mediumCareerLowId.getId()
         );
     }
 

--- a/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeRepositoryTest.java
@@ -7,13 +7,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.annotation.H2RepositoryTest;
 import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.CareerEmploymentType;
 import com.generic4.itda.domain.resume.CareerItemPayload;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +35,9 @@ class ResumeRepositoryTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private SkillRepository skillRepository;
 
     @DisplayName("경력이 없는 CareerPayload도 JSON으로 정상 저장/조회된다")
     @Test
@@ -299,6 +305,57 @@ class ResumeRepositoryTest {
         assertThat(result).isEmpty();
     }
 
+    @DisplayName("findAllWithSkillsByIds는 skills와 skill 연관을 한 번에 조회하며 중복 없이 반환한다")
+    @Test
+    void findAllWithSkillsByIds_fetchesSkillsWithoutDuplicates() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-fetch-join", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-fetch-join", null));
+        Skill kotlin = skillRepository.saveAndFlush(Skill.create("Kotlin-fetch-join", null));
+
+        Resume first = createResume("fetch-1", (byte) 5);
+        first.addSkill(java, Proficiency.ADVANCED);
+        first.addSkill(spring, Proficiency.INTERMEDIATE);
+        Resume savedFirst = resumeRepository.saveAndFlush(first);
+
+        Resume second = createResume("fetch-2", (byte) 3);
+        second.addSkill(kotlin, Proficiency.BEGINNER);
+        Resume savedSecond = resumeRepository.saveAndFlush(second);
+
+        entityManager.clear();
+
+        PersistenceUnitUtil util = entityManager.getEntityManagerFactory().getPersistenceUnitUtil();
+        Resume lazyLoaded = resumeRepository.findById(savedFirst.getId()).orElseThrow();
+        assertThat(util.isLoaded(lazyLoaded, "skills")).isFalse();
+
+        entityManager.clear();
+
+        // when
+        List<Resume> found = resumeRepository.findAllWithSkillsByIds(List.of(savedFirst.getId(), savedSecond.getId()));
+
+        // then
+        assertThat(found).hasSize(2);
+        assertThat(found).extracting(Resume::getId)
+                .containsExactlyInAnyOrder(savedFirst.getId(), savedSecond.getId());
+
+        Resume fetchedFirst = found.stream()
+                .filter(resume -> resume.getId().equals(savedFirst.getId()))
+                .findFirst()
+                .orElseThrow();
+        Resume fetchedSecond = found.stream()
+                .filter(resume -> resume.getId().equals(savedSecond.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(util.isLoaded(fetchedFirst, "skills")).isTrue();
+        assertThat(util.isLoaded(fetchedSecond, "skills")).isTrue();
+        assertThat(fetchedFirst.getSkills()).hasSize(2);
+        assertThat(fetchedSecond.getSkills()).hasSize(1);
+        assertThat(util.isLoaded(fetchedFirst.getSkills().first(), "skill")).isTrue();
+        assertThat(fetchedFirst.getSkills()).extracting(resumeSkill -> resumeSkill.getSkill().getName())
+                .containsExactly("Java-fetch-join", "Spring-fetch-join");
+    }
+
 
     private static CareerPayload createCareerPayload() {
         CareerItemPayload item = new CareerItemPayload();
@@ -314,5 +371,26 @@ class ResumeRepositoryTest {
         CareerPayload payload = new CareerPayload();
         payload.getItems().add(item);
         return payload;
+    }
+
+    private Resume createResume(String suffix, byte careerYears) {
+        String phone = "010-0000-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
+        Member member = memberRepository.save(createMember(
+                "resume-" + suffix + "@example.com",
+                "hashed-password",
+                "name-" + suffix,
+                "nickname-" + suffix,
+                phone
+        ));
+
+        return Resume.create(
+                member,
+                "자기소개-" + suffix,
+                careerYears,
+                createCareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -1,0 +1,189 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.ResumeQueryRepository;
+import com.generic4.itda.repository.ResumeRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationCandidateFinderTest {
+
+    @Mock
+    private ResumeQueryRepository resumeQueryRepository;
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @InjectMocks
+    private RecommendationCandidateFinder finder;
+
+    @DisplayName("필수 스킬이 없으면 전체 추천 가능 이력서 풀을 조회하고 id 순서를 유지한다")
+    @Test
+    void findCandidates_usesRecommendablePoolWhenNoEssentialSkills() {
+        // given
+        RecommendationRun run = createRun(
+                3,
+                skillRequirement(201L, "Communication", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume second = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findRecommendableResumeIds(100)).willReturn(List.of(11L, 22L));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L, 22L);
+        assertThat(result.get(0).skills()).extracting(RecommendationCandidate.CandidateSkill::skillName)
+                .containsExactly("Java");
+
+        verify(resumeQueryRepository).findRecommendableResumeIds(100);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("필수 스킬이 있으면 필수 스킬 id만으로 후보 풀을 조회하고 topK에 따라 풀 크기를 늘린다")
+    @Test
+    void findCandidates_usesEssentialSkillsAndExpandedPoolSize() {
+        // given
+        RecommendationRun run = createRun(
+                6,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL),
+                skillRequirement(202L, "React", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume first = createResume(11L, (byte) 9, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume second = createResume(22L, (byte) 4, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findCandidatePool(List.of(101L), 120)).willReturn(List.of(
+                new CandidatePoolRow(22L, 1L, 4, (byte) 4),
+                new CandidatePoolRow(11L, 1L, 9, (byte) 9)
+        ));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(first, second));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(22L, 11L);
+
+        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 120);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("후보 풀 조회 결과가 비어 있으면 Resume 상세 조회 없이 빈 리스트를 반환한다")
+    @Test
+    void findCandidates_returnsEmptyWhenCandidatePoolIsEmpty() {
+        // given
+        RecommendationRun run = createRun(
+                5,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
+        );
+        given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(run);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 100);
+        verifyNoInteractions(resumeRepository);
+        verifyNoMoreInteractions(resumeQueryRepository);
+    }
+
+    private RecommendationRun createRun(int topK, SkillRequirement... requirements) {
+        Proposal proposal = Proposal.create(
+                createMember(),
+                "추천 요청",
+                "raw-input",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        ProposalPosition proposalPosition = proposal.addPosition(Position.create("백엔드"), 1L, null, null);
+
+        for (SkillRequirement requirement : requirements) {
+            Skill skill = Skill.create(requirement.name(), null);
+            ReflectionTestUtils.setField(skill, "id", requirement.skillId());
+            proposalPosition.addSkill(skill, requirement.importance());
+        }
+
+        return RecommendationRun.create(
+                proposalPosition,
+                "fingerprint",
+                RecommendationAlgorithm.HEURISTIC_V1,
+                topK
+        );
+    }
+
+    private Resume createResume(long resumeId, byte careerYears, SkillData... skills) {
+        Resume resume = Resume.create(
+                createMember(),
+                "소개-" + resumeId,
+                careerYears,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+        ReflectionTestUtils.setField(resume, "id", resumeId);
+
+        for (SkillData skillData : skills) {
+            Skill skill = Skill.create(skillData.name(), null);
+            ReflectionTestUtils.setField(skill, "id", skillData.skillId());
+            resume.addSkill(skill, skillData.proficiency());
+        }
+
+        return resume;
+    }
+
+    private static SkillRequirement skillRequirement(
+            long skillId,
+            String name,
+            ProposalPositionSkillImportance importance
+    ) {
+        return new SkillRequirement(skillId, name, importance);
+    }
+
+    private static SkillData skillData(long skillId, String name, Proficiency proficiency) {
+        return new SkillData(skillId, name, proficiency);
+    }
+
+    private record SkillRequirement(long skillId, String name, ProposalPositionSkillImportance importance) {
+    }
+
+    private record SkillData(long skillId, String name, Proficiency proficiency) {
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -11,6 +11,7 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
@@ -50,7 +51,7 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findRecommendableResumeIds(100)).willReturn(List.of(11L, 22L));
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L));
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
 
         // when
@@ -62,7 +63,7 @@ class RecommendationCandidateFinderTest {
         assertThat(result.get(0).skills()).extracting(RecommendationCandidate.CandidateSkill::skillName)
                 .containsExactly("Java");
 
-        verify(resumeQueryRepository).findRecommendableResumeIds(100);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -78,7 +79,7 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 9, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 4, skillData(101L, "Java", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findCandidatePool(List.of(101L), 120)).willReturn(List.of(
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 120)).willReturn(List.of(
                 new CandidatePoolRow(22L, 1L, 4, (byte) 4),
                 new CandidatePoolRow(11L, 1L, 9, (byte) 9)
         ));
@@ -91,7 +92,7 @@ class RecommendationCandidateFinderTest {
         assertThat(result).extracting(RecommendationCandidate::resumeId)
                 .containsExactly(22L, 11L);
 
-        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 120);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 120);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -103,19 +104,59 @@ class RecommendationCandidateFinderTest {
         ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
         );
-        given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 100)).willReturn(List.of());
 
         // when
         List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 5);
 
         // then
         assertThat(result).isEmpty();
-        verify(resumeQueryRepository).findCandidatePool(List.of(101L), 100);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 100);
         verifyNoInteractions(resumeRepository);
         verifyNoMoreInteractions(resumeQueryRepository);
     }
 
+    @DisplayName("후보 이력서가 경력 범위를 벗어나면 최종 후보에서 제외한다")
+    @Test
+    void findCandidates_filtersResumesOutsideCareerRange() {
+        // given
+        ProposalPosition proposalPosition = createProposalPosition(
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                3,
+                7,
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume inRange = createResume(11L, (byte) 5, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume belowRange = createResume(22L, (byte) 2, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+        Resume aboveRange = createResume(33L, (byte) 9, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L, 33L));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L, 33L)))
+                .willReturn(List.of(aboveRange, inRange, belowRange));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3);
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L, 33L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
     private ProposalPosition createProposalPosition(SkillRequirement... requirements) {
+        return createProposalPosition("백엔드", null, null, null, requirements);
+    }
+
+    private ProposalPosition createProposalPosition(
+            String title,
+            ProposalWorkType workType,
+            Integer careerMinYears,
+            Integer careerMaxYears,
+            SkillRequirement... requirements
+    ) {
         Proposal proposal = Proposal.create(
                 createMember(),
                 "추천 요청",
@@ -123,11 +164,20 @@ class RecommendationCandidateFinderTest {
                 null,
                 null,
                 null,
-                null,
-                null,
                 null
         );
-        ProposalPosition proposalPosition = proposal.addPosition(Position.create("백엔드"), 1L, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                Position.create(title),
+                title,
+                workType,
+                1L,
+                null,
+                null,
+                null,
+                careerMinYears,
+                careerMaxYears,
+                workType == ProposalWorkType.REMOTE || workType == null ? null : "서울"
+        );
 
         for (SkillRequirement requirement : requirements) {
             Skill skill = Skill.create(requirement.name(), null);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -11,8 +11,6 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
-import com.generic4.itda.domain.recommendation.RecommendationRun;
-import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
@@ -46,8 +44,7 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_usesRecommendablePoolWhenNoEssentialSkills() {
         // given
-        RecommendationRun run = createRun(
-                3,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(201L, "Communication", ProposalPositionSkillImportance.PREFERENCE)
         );
         Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
@@ -57,7 +54,7 @@ class RecommendationCandidateFinderTest {
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3);
 
         // then
         assertThat(result).extracting(RecommendationCandidate::resumeId)
@@ -74,8 +71,7 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_usesEssentialSkillsAndExpandedPoolSize() {
         // given
-        RecommendationRun run = createRun(
-                6,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL),
                 skillRequirement(202L, "React", ProposalPositionSkillImportance.PREFERENCE)
         );
@@ -89,7 +85,7 @@ class RecommendationCandidateFinderTest {
         given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(first, second));
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 6);
 
         // then
         assertThat(result).extracting(RecommendationCandidate::resumeId)
@@ -104,14 +100,13 @@ class RecommendationCandidateFinderTest {
     @Test
     void findCandidates_returnsEmptyWhenCandidatePoolIsEmpty() {
         // given
-        RecommendationRun run = createRun(
-                5,
+        ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
         );
         given(resumeQueryRepository.findCandidatePool(List.of(101L), 100)).willReturn(List.of());
 
         // when
-        List<RecommendationCandidate> result = finder.findCandidates(run);
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 5);
 
         // then
         assertThat(result).isEmpty();
@@ -120,7 +115,7 @@ class RecommendationCandidateFinderTest {
         verifyNoMoreInteractions(resumeQueryRepository);
     }
 
-    private RecommendationRun createRun(int topK, SkillRequirement... requirements) {
+    private ProposalPosition createProposalPosition(SkillRequirement... requirements) {
         Proposal proposal = Proposal.create(
                 createMember(),
                 "추천 요청",
@@ -140,12 +135,7 @@ class RecommendationCandidateFinderTest {
             proposalPosition.addSkill(skill, requirement.importance());
         }
 
-        return RecommendationRun.create(
-                proposalPosition,
-                "fingerprint",
-                RecommendationAlgorithm.HEURISTIC_V1,
-                topK
-        );
+        return proposalPosition;
     }
 
     private Resume createResume(long resumeId, byte careerYears, SkillData... skills) {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateTest.java
@@ -1,0 +1,99 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecommendationCandidateTest {
+
+    @DisplayName("skills 리스트는 방어적으로 복사되고 외부에서 수정할 수 없다")
+    @Test
+    void constructor_makesDefensiveCopyOfSkills() {
+        // given
+        List<RecommendationCandidate.CandidateSkill> original = new ArrayList<>();
+        original.add(new RecommendationCandidate.CandidateSkill(1L, "Java", Proficiency.ADVANCED));
+
+        RecommendationCandidate candidate = new RecommendationCandidate(
+                100L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 5,
+                original
+        );
+
+        // when
+        original.add(new RecommendationCandidate.CandidateSkill(2L, "Spring", Proficiency.INTERMEDIATE));
+
+        // then
+        assertThat(candidate.skills()).hasSize(1);
+        assertThatThrownBy(() -> candidate.skills()
+                .add(new RecommendationCandidate.CandidateSkill(3L, "Kotlin", Proficiency.BEGINNER)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @DisplayName("ACTIVE 상태일 때만 활성 후보로 판단한다")
+    @Test
+    void isActive_returnsTrueOnlyWhenStatusIsActive() {
+        RecommendationCandidate active = new RecommendationCandidate(
+                1L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of()
+        );
+        RecommendationCandidate inactive = new RecommendationCandidate(
+                2L,
+                ResumeStatus.INACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of()
+        );
+
+        assertThat(active.isActive()).isTrue();
+        assertThat(inactive.isActive()).isFalse();
+    }
+
+    @DisplayName("CandidateSkill.of는 ResumeSkill의 필드를 계산용 DTO로 복사한다")
+    @Test
+    void candidateSkillOf_mapsResumeSkillFields() {
+        // given
+        Skill java = Skill.create("Java", null);
+        ReflectionTestUtils.setField(java, "id", 10L);
+
+        Resume resume = Resume.create(
+                createMember(),
+                "백엔드 개발자입니다.",
+                (byte) 5,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+        ResumeSkill resumeSkill = ResumeSkill.create(resume, java, Proficiency.ADVANCED);
+
+        // when
+        RecommendationCandidate.CandidateSkill result = RecommendationCandidate.CandidateSkill.of(resumeSkill);
+
+        // then
+        assertThat(result.skillId()).isEqualTo(10L);
+        assertThat(result.skillName()).isEqualTo("Java");
+        assertThat(result.proficiency()).isEqualTo(Proficiency.ADVANCED);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -229,7 +229,7 @@ class RecommendationResultCreatorTest {
 
             // then
             List<String> highlights = results.get(0).getReasonFacts().highlights();
-            assertThat(highlights).contains("공토 스킬 2개 보유");
+            assertThat(highlights).contains("공통 스킬 2개 보유");
             assertThat(highlights).contains("관련 경력 5년");
             assertThat(highlights).contains("요구 조건과 높은 유사도");
         }
@@ -257,7 +257,7 @@ class RecommendationResultCreatorTest {
             ReasonFacts facts = results.get(0).getReasonFacts();
             assertThat(facts.matchedSkills()).isEmpty();
             assertThat(facts.highlights()).doesNotContainAnyElementsOf(
-                    List.of("공토 스킬 2개 보유")
+                    List.of("공통 스킬 2개 보유")
             );
         }
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -43,9 +43,9 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate low = scoredCandidate(1L, 10L, 101L, 0.5, 3);
-            ScoredCandidate mid = scoredCandidate(2L, 20L, 102L, 0.7, 3);
-            ScoredCandidate high = scoredCandidate(3L, 30L, 103L, 0.9, 3);
+            ScoredCandidate low = scoredCandidate(101L, 0.5, 3);
+            ScoredCandidate mid = scoredCandidate(102L, 0.7, 3);
+            ScoredCandidate high = scoredCandidate(103L, 0.9, 3);
 
             Resume resume101 = resumeWithId(101L);
             Resume resume102 = resumeWithId(102L);
@@ -81,8 +81,8 @@ class RecommendationResultCreatorTest {
             // 낮은 점수가 입력 리스트에 먼저 위치 → 정렬 후 dedup 시 올바르게 제거되는지 검증
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate lowerScore = scoredCandidate(1L, 10L, 100L, 0.4, 2);
-            ScoredCandidate higherScore = scoredCandidate(2L, 20L, 100L, 0.8, 2);
+            ScoredCandidate lowerScore = scoredCandidate(100L, 0.4, 2);
+            ScoredCandidate higherScore = scoredCandidate(100L, 0.8, 2);
 
             Resume resume = resumeWithId(100L);
             given(resumeRepository.findAllById(anyList()))
@@ -109,9 +109,9 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 101L, 0.9, 3);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 102L, 0.7, 3);
-            ScoredCandidate c3 = scoredCandidate(3L, 30L, 103L, 0.5, 3);
+            ScoredCandidate c1 = scoredCandidate(101L, 0.9, 3);
+            ScoredCandidate c2 = scoredCandidate(102L, 0.7, 3);
+            ScoredCandidate c3 = scoredCandidate(103L, 0.5, 3);
 
             Resume resume101 = resumeWithId(101L);
             Resume resume102 = resumeWithId(102L);
@@ -138,8 +138,8 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 201L, 0.9, 2);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 202L, 0.7, 2);
+            ScoredCandidate c1 = scoredCandidate(201L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(202L, 0.7, 2);
 
             Resume resume201 = resumeWithId(201L);
             Resume resume202 = resumeWithId(202L);
@@ -163,8 +163,8 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate c1 = scoredCandidate(1L, 10L, 301L, 0.9, 2);
-            ScoredCandidate c2 = scoredCandidate(2L, 20L, 302L, 0.7, 2);
+            ScoredCandidate c1 = scoredCandidate(301L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(302L, 0.7, 2);
 
             // 302L에 해당하는 Resume 누락
             Resume resume301 = resumeWithId(301L);
@@ -188,10 +188,7 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 401L, 0.9, 3,
-                    Set.of("Java", "Spring", "Redis")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(401L, 0.9, 3, Set.of("Java", "Spring", "Redis"));
 
             Resume resume = resumeWithId(401L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -214,10 +211,7 @@ class RecommendationResultCreatorTest {
             RecommendationRun run = mock(RecommendationRun.class);
 
             // careerYears=5, similarityScore=0.9, matchedSkills=["Java","Spring"]
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 501L, 0.9, 5,
-                    Set.of("Java", "Spring")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(501L, 0.9, 5, Set.of("Java", "Spring"));
 
             Resume resume = resumeWithId(501L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -240,10 +234,7 @@ class RecommendationResultCreatorTest {
             // given
             RecommendationRun run = mock(RecommendationRun.class);
 
-            ScoredCandidate candidate = scoredCandidateWithSkills(
-                    1L, 10L, 601L, 0.5, 0,
-                    Set.of("Java", "Spring")
-            );
+            ScoredCandidate candidate = scoredCandidateWithSkills(601L, 0.5, 0, Set.of("Java", "Spring"));
 
             Resume resume = resumeWithId(601L);
             given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
@@ -264,18 +255,18 @@ class RecommendationResultCreatorTest {
 
     // --- fixture helpers ---
 
-    private ScoredCandidate scoredCandidate(
-            Long candidateId, Long memberId, Long resumeId, double finalScore, int careerYears
-    ) {
-        return scoredCandidateWithSkills(candidateId, memberId, resumeId, finalScore, careerYears, Set.of());
+    private ScoredCandidate scoredCandidate(Long resumeId, double finalScore, int careerYears) {
+        return scoredCandidateWithSkills(resumeId, finalScore, careerYears, Set.of());
     }
 
     private ScoredCandidate scoredCandidateWithSkills(
-            Long candidateId, Long memberId, Long resumeId,
-            double finalScore, int careerYears, Set<String> skills
+            Long resumeId,
+            double finalScore,
+            int careerYears,
+            Set<String> skills
     ) {
         RecommendationScorableCandidate candidate = new RecommendationScorableCandidate(
-                candidateId, memberId, resumeId, careerYears, skills
+                resumeId, careerYears, skills
         );
         ScoreBreakdown breakdown = new ScoreBreakdown(finalScore, 0.0, 0.0, finalScore);
         return new ScoredCandidate(candidate, breakdown);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationResultCreatorTest.java
@@ -1,0 +1,289 @@
+package com.generic4.itda.service.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeRepository;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationResultCreatorTest {
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @InjectMocks
+    private RecommendationResultCreator creator;
+
+    @Nested
+    @DisplayName("finalScore 기준 내림차순 정렬")
+    class SortByFinalScore {
+
+        @Test
+        @DisplayName("여러 후보가 finalScore 내림차순으로 정렬되고 rank는 1부터 순서대로 부여된다")
+        void finalScore_내림차순_정렬_및_rank_순서_검증() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate low = scoredCandidate(1L, 10L, 101L, 0.5, 3);
+            ScoredCandidate mid = scoredCandidate(2L, 20L, 102L, 0.7, 3);
+            ScoredCandidate high = scoredCandidate(3L, 30L, 103L, 0.9, 3);
+
+            Resume resume101 = resumeWithId(101L);
+            Resume resume102 = resumeWithId(102L);
+            Resume resume103 = resumeWithId(103L);
+
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume101, resume102, resume103));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(low, mid, high), 3, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).getRank()).isEqualTo(1);
+            assertThat(results.get(0).getResume()).isEqualTo(resume103); // 0.9
+            assertThat(results.get(1).getRank()).isEqualTo(2);
+            assertThat(results.get(1).getResume()).isEqualTo(resume102); // 0.7
+            assertThat(results.get(2).getRank()).isEqualTo(3);
+            assertThat(results.get(2).getResume()).isEqualTo(resume101); // 0.5
+        }
+    }
+
+    @Nested
+    @DisplayName("resumeId 기준 중복 제거")
+    class DeduplicateByResumeId {
+
+        @Test
+        @DisplayName("같은 resumeId를 가진 후보 중 finalScore가 높은 것만 결과에 포함된다")
+        void 같은_resumeId_중_높은_점수만_결과에_포함() {
+            // given
+            // 낮은 점수가 입력 리스트에 먼저 위치 → 정렬 후 dedup 시 올바르게 제거되는지 검증
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate lowerScore = scoredCandidate(1L, 10L, 100L, 0.4, 2);
+            ScoredCandidate higherScore = scoredCandidate(2L, 20L, 100L, 0.8, 2);
+
+            Resume resume = resumeWithId(100L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(lowerScore, higherScore), 3, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getFinalScore().doubleValue()).isEqualTo(0.8);
+        }
+    }
+
+    @Nested
+    @DisplayName("topK 제한")
+    class TopKLimit {
+
+        @Test
+        @DisplayName("후보가 topK보다 많으면 결과는 정확히 topK개다")
+        void 후보가_topK보다_많으면_결과는_topK개() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 101L, 0.9, 3);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 102L, 0.7, 3);
+            ScoredCandidate c3 = scoredCandidate(3L, 30L, 103L, 0.5, 3);
+
+            Resume resume101 = resumeWithId(101L);
+            Resume resume102 = resumeWithId(102L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume101, resume102));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(c1, c2, c3), 2, Set.of()
+            );
+
+            // then
+            assertThat(results).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Resume 일괄 조회")
+    class ResumeLoading {
+
+        @Test
+        @DisplayName("resumeRepository.findAllById() 결과가 RecommendationResult에 정확히 매핑된다")
+        void resume_일괄_조회_결과가_결과에_매핑된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 201L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 202L, 0.7, 2);
+
+            Resume resume201 = resumeWithId(201L);
+            Resume resume202 = resumeWithId(202L);
+
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume201, resume202));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(c1, c2), 2, Set.of()
+            );
+
+            // then
+            assertThat(results.get(0).getResume()).isEqualTo(resume201);
+            assertThat(results.get(1).getResume()).isEqualTo(resume202);
+        }
+
+        @Test
+        @DisplayName("일부 resumeId에 해당하는 Resume이 조회되지 않으면 IllegalStateException이 발생한다")
+        void 일부_resume_누락_시_예외_발생() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate c1 = scoredCandidate(1L, 10L, 301L, 0.9, 2);
+            ScoredCandidate c2 = scoredCandidate(2L, 20L, 302L, 0.7, 2);
+
+            // 302L에 해당하는 Resume 누락
+            Resume resume301 = resumeWithId(301L);
+            given(resumeRepository.findAllById(anyList()))
+                    .willReturn(List.of(resume301));
+
+            // when & then
+            assertThatThrownBy(() -> creator.create(run, List.of(c1, c2), 2, Set.of()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("추천 결과 생성 대상 이력서 일부를 찾을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("ReasonFacts 생성")
+    class ReasonFactsCreation {
+
+        @Test
+        @DisplayName("후보 스킬과 requiredSkillNames의 교집합이 matchedSkills로 정렬되어 설정된다")
+        void matchedSkills가_교집합으로_정확히_계산된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 401L, 0.9, 3,
+                    Set.of("Java", "Spring", "Redis")
+            );
+
+            Resume resume = resumeWithId(401L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of("Spring", "Redis", "Docker")
+            );
+
+            // then
+            ReasonFacts facts = results.get(0).getReasonFacts();
+            assertThat(facts.matchedSkills())
+                    .containsExactly("Redis", "Spring"); // 알파벳 오름차순 정렬
+        }
+
+        @Test
+        @DisplayName("matchedSkills가 있으면 highlights에 스킬 개수가, careerYears > 0이면 경력이, similarityScore >= 0.8이면 유사도 메시지가 포함된다")
+        void highlights가_규칙대로_생성된다() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            // careerYears=5, similarityScore=0.9, matchedSkills=["Java","Spring"]
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 501L, 0.9, 5,
+                    Set.of("Java", "Spring")
+            );
+
+            Resume resume = resumeWithId(501L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of("Java", "Spring")
+            );
+
+            // then
+            List<String> highlights = results.get(0).getReasonFacts().highlights();
+            assertThat(highlights).contains("공토 스킬 2개 보유");
+            assertThat(highlights).contains("관련 경력 5년");
+            assertThat(highlights).contains("요구 조건과 높은 유사도");
+        }
+
+        @Test
+        @DisplayName("requiredSkillNames가 비어있으면 matchedSkills는 빈 리스트이고 스킬 highlight는 없다")
+        void requiredSkillNames가_비어있으면_matchedSkills_비어있음() {
+            // given
+            RecommendationRun run = mock(RecommendationRun.class);
+
+            ScoredCandidate candidate = scoredCandidateWithSkills(
+                    1L, 10L, 601L, 0.5, 0,
+                    Set.of("Java", "Spring")
+            );
+
+            Resume resume = resumeWithId(601L);
+            given(resumeRepository.findAllById(anyList())).willReturn(List.of(resume));
+
+            // when
+            List<RecommendationResult> results = creator.create(
+                    run, List.of(candidate), 1, Set.of()
+            );
+
+            // then
+            ReasonFacts facts = results.get(0).getReasonFacts();
+            assertThat(facts.matchedSkills()).isEmpty();
+            assertThat(facts.highlights()).doesNotContainAnyElementsOf(
+                    List.of("공토 스킬 2개 보유")
+            );
+        }
+    }
+
+    // --- fixture helpers ---
+
+    private ScoredCandidate scoredCandidate(
+            Long candidateId, Long memberId, Long resumeId, double finalScore, int careerYears
+    ) {
+        return scoredCandidateWithSkills(candidateId, memberId, resumeId, finalScore, careerYears, Set.of());
+    }
+
+    private ScoredCandidate scoredCandidateWithSkills(
+            Long candidateId, Long memberId, Long resumeId,
+            double finalScore, int careerYears, Set<String> skills
+    ) {
+        RecommendationScorableCandidate candidate = new RecommendationScorableCandidate(
+                candidateId, memberId, resumeId, careerYears, skills
+        );
+        ScoreBreakdown breakdown = new ScoreBreakdown(finalScore, 0.0, 0.0, finalScore);
+        return new ScoredCandidate(candidate, breakdown);
+    }
+
+    private Resume resumeWithId(Long id) {
+        Resume resume = mock(Resume.class);
+        given(resume.getId()).willReturn(id);
+        return resume;
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunExecutorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunExecutorTest.java
@@ -1,9 +1,9 @@
 package com.generic4.itda.service.recommend;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.util.List;
@@ -19,7 +19,7 @@ import org.springframework.data.domain.PageRequest;
 @ExtendWith(MockitoExtension.class)
 class RecommendationRunExecutorTest {
 
-    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 1);
+    private static final PageRequest NEXT_PENDING_RUN = PageRequest.of(0, 10);
 
     @Mock
     private RecommendationRunRepository recommendationRunRepository;
@@ -65,10 +65,10 @@ class RecommendationRunExecutorTest {
     }
 
     @Test
-    @DisplayName("여러 대기 run이 있어도 가장 앞의 run 하나만 점유 시도한다")
-    void 여러_대기_run이_있어도_가장_앞의_run_하나만_점유_시도한다() {
+    @DisplayName("가장 앞의 run 점유에 성공하면 다음 run은 점유 시도하지 않는다")
+    void 가장_앞의_run_점유에_성공하면_다음_run은_점유_시도하지_않는다() {
         given(recommendationRunRepository.findPendingRunIds(NEXT_PENDING_RUN))
-                .willReturn(List.of(1L));
+                .willReturn(List.of(1L, 2L));
 
         given(recommendationRunRepository.claimAsRunning(1L))
                 .willReturn(1);
@@ -77,5 +77,6 @@ class RecommendationRunExecutorTest {
 
         assertThat(result).contains(1L);
         then(recommendationRunRepository).should().claimAsRunning(1L);
+        then(recommendationRunRepository).should(never()).claimAsRunning(2L);
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -1,0 +1,182 @@
+package com.generic4.itda.service.recommend;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class RecommendationRunProcessorIntegrationTest {
+
+    private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;
+    private static final int DEFAULT_TOP_K = 3;
+
+    @Autowired
+    private RecommendationRunProcessor recommendationRunProcessor;
+
+    @Autowired
+    private RecommendationRunRepository recommendationRunRepository;
+
+    @Autowired
+    private RecommendationResultRepository recommendationResultRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProposalRepository proposalRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private RecommendationCandidateFinder recommendationCandidateFinder;
+
+    @MockitoBean
+    private HeuristicV1RecommendationScorer recommendationScorer;
+
+    @MockitoBean
+    private RecommendationResultCreator recommendationResultCreator;
+
+    @Test
+    @DisplayName("RUNNING 상태 run 처리 완료 후 RecommendationResult가 DB에 저장되고 status가 COMPUTED로 변경된다")
+    void process_happyPath_savesResultsAndMarksComputed() {
+        // given
+        RunFixture fixture = createRunningRunFixture("proc-happy@test.com", "fp-happy");
+
+        Member resumeOwner = memberRepository.save(createMember("resume-owner-happy@test.com", "pw", "이력서소유자", "010-1111-2222"));
+        Resume resume = persist(Resume.create(resumeOwner, "백엔드 개발 경험", (byte) 3, new CareerPayload(), null, ResumeWritingStatus.DONE, null));
+
+        RecommendationResult stubbedResult = RecommendationResult.create(
+                fixture.run(),
+                resume,
+                1,
+                BigDecimal.valueOf(0.8500),
+                BigDecimal.valueOf(0.7000),
+                new ReasonFacts(List.of("Java"), List.of(), 3, List.of())
+        );
+
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of());
+        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of());
+        given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(stubbedResult));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        assertThatCode(() -> recommendationRunProcessor.process(fixture.runId()))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: RecommendationRun 상태 검증
+        RecommendationRun persistedRun = recommendationRunRepository.findById(fixture.runId()).orElseThrow();
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(persistedRun.getErrorMessage()).isNull();
+
+        // then: HardFilterStat 반영 검증 (candidates=0개, results=1개)
+        HardFilterStat stat = persistedRun.getHardFilterStats();
+        assertThat(stat).isNotNull();
+        assertThat(stat.totalCandidates()).isZero();
+        assertThat(stat.finalCandidates()).isEqualTo(1);
+        assertThat(persistedRun.getCandidateCount()).isEqualTo(1);
+
+        // then: RecommendationResult DB 저장 검증
+        List<RecommendationResult> savedResults = recommendationResultRepository.findAll();
+        assertThat(savedResults).hasSize(1);
+        RecommendationResult savedResult = savedResults.get(0);
+        assertThat(savedResult.getRecommendationRun().getId()).isEqualTo(fixture.runId());
+        assertThat(savedResult.getResume().getId()).isEqualTo(resume.getId());
+        assertThat(savedResult.getRank()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("처리 중 예외 발생 시 process()가 예외를 전파하지 않고 status가 FAILED로 변경되며 errorMessage가 저장된다")
+    void process_exceptionDuringProcessing_doesNotPropagateAndMarksFailed() {
+        // given
+        RunFixture fixture = createRunningRunFixture("proc-fail@test.com", "fp-fail");
+
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt()))
+                .willThrow(new RuntimeException("후보 조회 중 오류 발생"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        assertThatCode(() -> recommendationRunProcessor.process(fixture.runId()))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: RecommendationRun 상태 검증
+        RecommendationRun persistedRun = recommendationRunRepository.findById(fixture.runId()).orElseThrow();
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(persistedRun.getErrorMessage()).isEqualTo("후보 조회 중 오류 발생");
+
+        // then: RecommendationResult가 저장되지 않았음을 검증
+        assertThat(recommendationResultRepository.count()).isZero();
+    }
+
+    private RunFixture createRunningRunFixture(String ownerEmail, String fingerprint) {
+        Member owner = memberRepository.save(createMember(ownerEmail, "pw", "제안자", "010-0000-0001"));
+        Position position = persist(Position.create("백엔드 개발자"));
+        Skill java = persist(Skill.create("Java", null));
+
+        Proposal proposal = Proposal.create(owner, "AI 추천 테스트 제안서", "원본 입력", "설명", 5_000_000L, 10_000_000L, 6L);
+        ProposalPosition proposalPosition = proposal.addPosition(position, "백엔드 개발자", null, 2L, 1_000_000L, 2_000_000L, null, null, null, null);
+        proposalPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposal.startMatching();
+        proposalRepository.saveAndFlush(proposal);
+
+        RecommendationRun run = RecommendationRun.create(proposalPosition, fingerprint, DEFAULT_ALGORITHM, DEFAULT_TOP_K);
+        run.markRunning();
+        persist(run);
+
+        return new RunFixture(run.getId(), run);
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+
+    private record RunFixture(Long runId, RecommendationRun run) {}
+}

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -23,6 +23,7 @@ import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeStatus;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.repository.MemberRepository;
@@ -30,10 +31,13 @@ import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
 import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +86,23 @@ class RecommendationRunProcessorIntegrationTest {
 
         Member resumeOwner = memberRepository.save(createMember("resume-owner-happy@test.com", "pw", "이력서소유자", "010-1111-2222"));
         Resume resume = persist(Resume.create(resumeOwner, "백엔드 개발 경험", (byte) 3, new CareerPayload(), null, ResumeWritingStatus.DONE, null));
+        RecommendationCandidate stubbedCandidate = new RecommendationCandidate(
+                resume.getId(),
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of(new RecommendationCandidate.CandidateSkill(1L, "Java", com.generic4.itda.domain.resume.Proficiency.ADVANCED))
+        );
+        RecommendationScorableCandidate stubbedScorableCandidate = new RecommendationScorableCandidate(
+                resume.getId(),
+                3,
+                Set.of("Java")
+        );
+        ScoredCandidate stubbedScoredCandidate = new ScoredCandidate(
+                stubbedScorableCandidate,
+                new ScoreBreakdown(0.7000, 0.1000, 0.0500, 0.8500)
+        );
 
         RecommendationResult stubbedResult = RecommendationResult.create(
                 fixture.run(),
@@ -92,8 +113,8 @@ class RecommendationRunProcessorIntegrationTest {
                 new ReasonFacts(List.of("Java"), List.of(), 3, List.of())
         );
 
-        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of());
-        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of());
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(stubbedCandidate));
+        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(stubbedScoredCandidate));
         given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(stubbedResult));
 
         entityManager.flush();
@@ -111,10 +132,10 @@ class RecommendationRunProcessorIntegrationTest {
         assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
         assertThat(persistedRun.getErrorMessage()).isNull();
 
-        // then: HardFilterStat 반영 검증 (candidates=0개, results=1개)
+        // then: HardFilterStat 반영 검증 (candidates=1개, results=1개)
         HardFilterStat stat = persistedRun.getHardFilterStats();
         assertThat(stat).isNotNull();
-        assertThat(stat.totalCandidates()).isZero();
+        assertThat(stat.totalCandidates()).isEqualTo(1);
         assertThat(stat.finalCandidates()).isEqualTo(1);
         assertThat(persistedRun.getCandidateCount()).isEqualTo(1);
 

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -4,23 +4,39 @@ import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.spy;
+import static org.mockito.BDDMockito.then;
 
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.ResumeStatus;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +46,18 @@ class RecommendationRunProcessorTest {
 
     @Mock
     private RecommendationRunRepository recommendationRunRepository;
+
+    @Mock
+    private RecommendationResultRepository recommendationResultRepository;
+
+    @Mock
+    private RecommendationCandidateFinder recommendationCandidateFinder;
+
+    @Mock
+    private HeuristicV1RecommendationScorer recommendationScorer;
+
+    @Mock
+    private RecommendationResultCreator recommendationResultCreator;
 
     @InjectMocks
     private RecommendationRunProcessor recommendationRunProcessor;
@@ -63,62 +91,162 @@ class RecommendationRunProcessorTest {
         }
 
         @Test
-        @DisplayName("RUNNING 상태의 run이면 예외없이 처리한다")
+        @DisplayName("RUNNING 상태의 run이면 예외 없이 처리하고 COMPUTED 상태가 된다")
         void RUNNING_상태의_run이면_예외_없이_처리한다() {
-            RecommendationRun run = createRun(true);
+            ProposalPosition proposalPosition = createProposalPositionWithSkills();
+            RecommendationRun run = createRun(proposalPosition, true);
+
+            List<RecommendationCandidate> candidates = List.of(
+                    createCandidate(101L, 3,
+                            createCandidateSkill(1L, "Java", Proficiency.ADVANCED),
+                            createCandidateSkill(3L, "Kotlin", Proficiency.INTERMEDIATE)),
+                    createCandidate(202L, 1,
+                            createCandidateSkill(2L, "Spring", Proficiency.BEGINNER))
+            );
+            List<ScoredCandidate> scoredCandidates = List.of();
+            List<RecommendationResult> results = List.of(org.mockito.Mockito.mock(RecommendationResult.class));
 
             given(recommendationRunRepository.findById(1L))
                     .willReturn(Optional.of(run));
+            given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                    .willReturn(candidates);
+            given(recommendationScorer.score(
+                    any(),
+                    any(),
+                    anySet(),
+                    anySet(),
+                    anyList()
+            )).willReturn(scoredCandidates);
+            given(recommendationResultCreator.create(
+                    run,
+                    scoredCandidates,
+                    run.getTopK(),
+                    Set.of("Java")
+            )).willReturn(results);
 
             assertThatCode(() -> recommendationRunProcessor.process(1L))
                     .doesNotThrowAnyException();
+
+            assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+            assertThat(run.getCandidateCount()).isEqualTo(1);
+            assertThat(run.getHardFilterStats()).isEqualTo(new HardFilterStat(2, 1));
+            then(recommendationScorer).should().score(
+                    proposalPosition.getProposal(),
+                    proposalPosition,
+                    Set.of("Java"),
+                    Set.of("Spring"),
+                    List.of(
+                            new RecommendationScorableCandidate(101L, 3, Set.of("Java", "Kotlin")),
+                            new RecommendationScorableCandidate(202L, 1, Set.of("Spring"))
+                    )
+            );
+            then(recommendationResultCreator).should().create(
+                    run,
+                    scoredCandidates,
+                    run.getTopK(),
+                    Set.of("Java")
+            );
+            then(recommendationResultRepository).should().saveAll(results);
         }
     }
 
     @Test
-    @DisplayName("처리 중 예외가 발생하면 FAILED 상태로 전이하고 예외 메시지를 저장한다")
+    @DisplayName("finder 처리 중 예외가 발생하면 FAILED 상태로 전이하고 예외 메시지를 저장한다")
     void 처리_중_예외가_발생하면_FAILED_상태로_전이하고_예외_메시지를_저장한다() {
         RecommendationRun run = createRun(true);
-        RecommendationRunProcessor spyProcessor = spy(
-                new RecommendationRunProcessor(recommendationRunRepository)
-        );
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        willThrow(new RuntimeException("하드 필터 계산 실패"))
-                .given(spyProcessor).doProcess(run);
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException("하드 필터 계산 실패"));
 
-        assertThatCode(() -> spyProcessor.process(1L))
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
                 .doesNotThrowAnyException();
 
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("하드 필터 계산 실패");
+        then(recommendationScorer).shouldHaveNoInteractions();
+        then(recommendationResultCreator).shouldHaveNoInteractions();
+        then(recommendationResultRepository).shouldHaveNoInteractions();
     }
 
     @Test
     @DisplayName("예외 메시지가 없으면 기본 실패 메시지로 FAILED 처리한다")
     void 예외_메시지가_없으면_기본_실패_메시지로_FAILED_처리한다() {
         RecommendationRun run = createRun(true);
-        RecommendationRunProcessor spyProcessor = org.mockito.Mockito.spy(
-                new RecommendationRunProcessor(recommendationRunRepository)
-        );
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        org.mockito.BDDMockito.willThrow(new RuntimeException())
-                .given(spyProcessor).doProcess(run);
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException());
 
-        assertThatCode(() -> spyProcessor.process(1L))
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
                 .doesNotThrowAnyException();
 
-        assertThat(run.getStatus()).isEqualTo(
-                com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus.FAILED);
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
     }
 
+    @Test
+    @DisplayName("예외 메시지가 공백이면 기본 실패 메시지로 FAILED 처리한다")
+    void 예외_메시지가_공백이면_기본_실패_메시지로_FAILED_처리한다() {
+        RecommendationRun run = createRun(true);
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willThrow(new RuntimeException("   "));
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("result 저장 중 예외가 발생하면 FAILED 상태로 전이한다")
+    void 결과_저장_중_예외가_발생하면_FAILED_상태로_전이한다() {
+        RecommendationRun run = createRun(true);
+
+        List<RecommendationCandidate> candidates = List.of();
+        List<ScoredCandidate> scoredCandidates = List.of();
+        List<RecommendationResult> results = List.of();
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                anyList()
+        )).willReturn(scoredCandidates);
+        given(recommendationResultCreator.create(
+                run,
+                scoredCandidates,
+                run.getTopK(),
+                Set.of()
+        )).willReturn(results);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("저장 실패"))
+                .given(recommendationResultRepository).saveAll(results);
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("저장 실패");
+    }
+
     private RecommendationRun createRun(boolean running) {
+        return createRun(createProposalPosition(), running);
+    }
+
+    private RecommendationRun createRun(ProposalPosition proposalPosition, boolean running) {
         RecommendationRun run = RecommendationRun.create(
-                createProposalPosition(),
+                proposalPosition,
                 running ? "fp-running" : "fp-pending",
                 RecommendationAlgorithm.HEURISTIC_V1,
                 5
@@ -133,7 +261,6 @@ class RecommendationRunProcessorTest {
 
     private ProposalPosition createProposalPosition() {
         Member member = createMember();
-
         Position position = Position.create("백엔드 개발자");
 
         Proposal proposal = Proposal.create(
@@ -158,5 +285,97 @@ class RecommendationRunProcessorTest {
                 null,
                 null
         );
+    }
+
+    @Test
+    @DisplayName("후보를 scoring 입력 모델로 변환해 scorer에 전달한다")
+    void 후보를_scoring_입력_모델로_변환해_scorer에_전달한다() {
+        RecommendationRun run = createRun(true);
+
+        RecommendationCandidate candidate = new RecommendationCandidate(
+                10L,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of(
+                        new RecommendationCandidate.CandidateSkill(1L, "Java", Proficiency.ADVANCED),
+                        new RecommendationCandidate.CandidateSkill(2L, "Spring", Proficiency.INTERMEDIATE)
+                )
+        );
+
+        List<RecommendationCandidate> candidates = List.of(candidate);
+        List<ScoredCandidate> scoredCandidates = List.of();
+        List<RecommendationResult> results = List.of();
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                any(List.class)
+        )).willReturn(scoredCandidates);
+        given(recommendationResultCreator.create(
+                any(),
+                any(List.class),
+                anyInt(),
+                anySet()
+        )).willReturn(results);
+
+        recommendationRunProcessor.process(1L);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RecommendationScorableCandidate>> captor =
+                ArgumentCaptor.forClass(List.class);
+
+        then(recommendationScorer).should().score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                captor.capture()
+        );
+
+        List<RecommendationScorableCandidate> actual = captor.getValue();
+        assertThat(actual).hasSize(1);
+
+        RecommendationScorableCandidate scorable = actual.get(0);
+        assertThat(scorable.resumeId()).isEqualTo(10L);
+        assertThat(scorable.careerYears()).isEqualTo(3);
+        assertThat(scorable.ownedSkillNames()).containsExactlyInAnyOrder("Java", "Spring");
+    }
+
+    private ProposalPosition createProposalPositionWithSkills() {
+        ProposalPosition proposalPosition = createProposalPosition();
+        proposalPosition.addSkill(Skill.create("Java", null), ProposalPositionSkillImportance.ESSENTIAL);
+        proposalPosition.addSkill(Skill.create("Spring", null), ProposalPositionSkillImportance.PREFERENCE);
+        return proposalPosition;
+    }
+
+    private RecommendationCandidate createCandidate(
+            long resumeId,
+            int careerYears,
+            RecommendationCandidate.CandidateSkill... skills
+    ) {
+        return new RecommendationCandidate(
+                resumeId,
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) careerYears,
+                List.of(skills)
+        );
+    }
+
+    private RecommendationCandidate.CandidateSkill createCandidateSkill(
+            long skillId,
+            String skillName,
+            Proficiency proficiency
+    ) {
+        return new RecommendationCandidate.CandidateSkill(skillId, skillName, proficiency);
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -27,12 +27,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * RecommendationRunQueryService 단위 테스트:
- * - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을 수행하는지 확인한다.
- *
- * 한계:
- * - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다.
- * - proposal/member/proposalPosition 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
+ * RecommendationRunQueryService 단위 테스트: - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을
+ * 수행하는지 확인한다.
+ * <p>
+ * 한계: - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다. - proposal/member/proposalPosition
+ * 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
  */
 @ExtendWith(MockitoExtension.class)
 class RecommendationRunQueryServiceTest {
@@ -240,7 +239,7 @@ class RecommendationRunQueryServiceTest {
             case RUNNING -> run.markRunning();
             case COMPUTED -> {
                 run.markRunning();
-                run.markCompleted(new HardFilterStat(12, 8, 5, 3));
+                run.markCompleted(new HardFilterStat(12, 3));
             }
             case FAILED -> {
                 run.markRunning();

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/CareerAdjustmentCalculatorTest.java
@@ -1,0 +1,79 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("CareerAdjustmentCalculator 단위 테스트")
+class CareerAdjustmentCalculatorTest {
+
+    private final CareerAdjustmentCalculator calculator = new CareerAdjustmentCalculator();
+
+    @Test
+    @DisplayName("최소/최대 경력 요구사항이 모두 없을 경우 0.0을 반환한다.")
+    void calculate_WhenNoRequirements() {
+        // given
+        int candidateYears = 5;
+        Integer minYears = null;
+        Integer maxYears = null;
+
+        // when
+        double result = calculator.calculate(candidateYears, minYears, maxYears);
+
+        // then
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "5, 3, 7",  // 범위 중간
+            "3, 3, 7",  // 최소값 경계
+            "7, 3, 7",  // 최대값 경계
+            "5, 3, ",   // 최소값만 있고 충족
+            "5, , 7"    // 최대값만 있고 충족
+    })
+    @DisplayName("경력 요구사항 범위를 충족할 경우 보너스 점수(0.08)를 반환한다.")
+    void calculate_WhenInRange(int candidateYears, Integer minYears, Integer maxYears) {
+        // when
+        double result = calculator.calculate(candidateYears, minYears, maxYears);
+
+        // then
+        assertThat(result).isCloseTo(0.08, offset(1e-9));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "2, 3, -0.04", // 1년 부족
+            "1, 3, -0.08", // 2년 부족
+            "0, 3, -0.12", // 3년 부족 (최대 페널티)
+            "0, 5, -0.12"  // 5년 부족 (최대 페널티 캡핑)
+    })
+    @DisplayName("최소 경력보다 부족할 경우 연당 -0.04의 페널티를 부여하며 최대 -0.12까지 적용한다.")
+    void calculate_WhenBelowMin(int candidateYears, Integer minYears, double expected) {
+        // when
+        double result = calculator.calculate(candidateYears, minYears, 10);
+
+        // then
+        assertThat(result).isCloseTo(expected, offset(1e-9));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "6, 5, -0.02", // 1년 초과
+            "7, 5, -0.04", // 2년 초과
+            "8, 5, -0.06", // 3년 초과 (최대 페널티)
+            "10, 5, -0.06" // 5년 초과 (최대 페널티 캡핑)
+    })
+    @DisplayName("최대 경력보다 초과할 경우 연당 -0.02의 페널티를 부여하며 최대 -0.06까지 적용한다.")
+    void calculate_WhenAboveMax(int candidateYears, Integer maxYears, double expected) {
+        // when
+        double result = calculator.calculate(candidateYears, 0, maxYears);
+
+        // then
+        assertThat(result).isCloseTo(expected, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/CosineSimilarityCalculatorTest.java
@@ -1,0 +1,119 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CosineSimilarityCalculatorTest {
+
+    private final CosineSimilarityCalculator calculator = new CosineSimilarityCalculator();
+
+    @DisplayName("동일한 두 벡터의 코사인 유사도는 1.0 이어야 한다")
+    @Test
+    void calculate_identicalVectors_returnsOne() {
+        // given
+        List<Double> query = List.of(1.0, 2.0, 3.0);
+        List<Double> target = List.of(1.0, 2.0, 3.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(1.0, offset(1e-9));
+    }
+
+    @DisplayName("서로 직교하는 두 벡터의 코사인 유사도는 0.0 이어야 한다")
+    @Test
+    void calculate_orthogonalVectors_returnsZero() {
+        // given
+        List<Double> query = List.of(1.0, 0.0);
+        List<Double> target = List.of(0.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(0.0, offset(1e-9));
+    }
+
+    @DisplayName("서로 다른 두 벡터의 코사인 유사도를 정확히 계산한다")
+    @Test
+    void calculate_differentVectors_returnsCorrectSimilarity() {
+        // given
+        // query: (1, 1), target: (0, 1)
+        // dotProduct: 1*0 + 1*1 = 1
+        // queryNorm: sqrt(1^2 + 1^2) = sqrt(2)
+        // targetNorm: sqrt(0^2 + 1^2) = 1
+        // similarity: 1 / (sqrt(2) * 1) = 1/sqrt(2) ≈ 0.707106781
+        List<Double> query = List.of(1.0, 1.0);
+        List<Double> target = List.of(0.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isCloseTo(1.0 / Math.sqrt(2.0), offset(1e-9));
+    }
+
+    @DisplayName("벡터 중 하나가 영벡터인 경우 유사도는 0.0 이어야 한다")
+    @Test
+    void calculate_withZeroVector_returnsZero() {
+        // given
+        List<Double> query = List.of(0.0, 0.0);
+        List<Double> target = List.of(1.0, 1.0);
+
+        // when
+        double result = calculator.calculate(query, target);
+
+        // then
+        assertThat(result).isEqualTo(0.0);
+    }
+
+    @DisplayName("입력 리스트가 null인 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_nullInput_throwsException() {
+        assertThatThrownBy(() -> calculator.calculate(null, List.of(1.0)))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> calculator.calculate(List.of(1.0), null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("입력 리스트가 비어 있는 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_emptyInput_throwsException() {
+        assertThatThrownBy(() -> calculator.calculate(List.of(), List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("두 벡터의 차원이 다른 경우 IllegalArgumentException이 발생한다")
+    @Test
+    void calculate_mismatchedDimensions_throwsException() {
+        // given
+        List<Double> query = List.of(1.0, 2.0);
+        List<Double> target = List.of(1.0, 2.0, 3.0);
+
+        // then
+        assertThatThrownBy(() -> calculator.calculate(query, target))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("코사인 유사도는 대칭성을 만족해야 한다")
+    @Test
+    void calculate_isSymmetric() {
+        // given
+        List<Double> a = List.of(1.0, 2.0, 3.0);
+        List<Double> b = List.of(4.0, 5.0, 6.0);
+
+        // when
+        double ab = calculator.calculate(a, b);
+        double ba = calculator.calculate(b, a);
+
+        // then
+        assertThat(ab).isCloseTo(ba, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -1,0 +1,280 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
+import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HeuristicV1RecommendationScorer 단위 테스트")
+class HeuristicV1RecommendationScorerTest {
+
+    @Mock
+    private RecommendationQueryTextGenerator recommendationQueryTextGenerator;
+
+    @Mock
+    private QueryEmbeddingGenerator queryEmbeddingGenerator;
+
+    @Mock
+    private ResumeEmbeddingReader resumeEmbeddingReader;
+
+    @Mock
+    private CosineSimilarityCalculator cosineSimilarityCalculator;
+
+    @Mock
+    private SkillAdjustmentCalculator skillAdjustmentCalculator;
+
+    @Mock
+    private CareerAdjustmentCalculator careerAdjustmentCalculator;
+
+    @Mock
+    private Proposal proposal;
+
+    @Mock
+    private ProposalPosition proposalPosition;
+
+    @InjectMocks
+    private HeuristicV1RecommendationScorer scorer;
+
+    private static final String EMBEDDING_MODEL = "text-embedding-3-small";
+
+    // -------------------------------------------------------------------------
+    // 공통 헬퍼
+    // -------------------------------------------------------------------------
+
+    private RecommendationScorableCandidate candidateWith(long candidateId, long memberId, long resumeId) {
+        return new RecommendationScorableCandidate(candidateId, memberId, resumeId, 3, Set.of("Java"));
+    }
+
+    private List<Double> dummyQueryEmbedding() {
+        return List.of(1.0, 0.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 1: 빈 후보 리스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("후보가 비어 있으면 빈 리스트를 반환한다")
+    void score_ReturnsEmptyList_WhenCandidatesIsEmpty() {
+        // given
+        List<RecommendationScorableCandidate> emptyCandidates = List.of();
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), emptyCandidates, EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).isEmpty();
+
+        verify(recommendationQueryTextGenerator, never()).generate(any(), any(), any(), any());
+        verify(queryEmbeddingGenerator, never()).generate(anyString());
+        verify(resumeEmbeddingReader, never()).readEmbeddingsByResumeIds(anyList(), anyString());
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 2: 이력서 임베딩이 없는 후보는 결과에서 제외
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("이력서 임베딩이 없는 후보는 결과에서 제외된다")
+    void score_ExcludesCandidate_WhenResumeEmbeddingIsMissing() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString()))
+                .willReturn(dummyQueryEmbedding());
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of()); // 임베딩 없음
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 3: finalScore 내림차순 정렬
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("최종 점수(finalScore) 내림차순으로 정렬한다")
+    void score_ReturnsCandidatesSortedByFinalScoreDescending() {
+        // given
+        RecommendationScorableCandidate candidateA = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidateB = candidateWith(2L, 20L, 200L);
+
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> embeddingA = List.of(1.0, 0.0);
+        List<Double> embeddingB = List.of(0.0, 1.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString()))
+                .willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, embeddingA, 200L, embeddingB));
+
+        // candidateA: rawCosine=0.6, skill=0.0, career=0.0 → finalScore=0.6
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, embeddingA)).willReturn(0.6);
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, embeddingB)).willReturn(0.3);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(),
+                List.of(candidateA, candidateB), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).scoreBreakdown().finalScore())
+                .isGreaterThan(result.get(1).scoreBreakdown().finalScore());
+        assertThat(result.get(0).candidate().resumeId()).isEqualTo(100L);
+        assertThat(result.get(1).candidate().resumeId()).isEqualTo(200L);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 4: raw cosine 정규화 → embeddingScore
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("raw cosine -1.0은 embeddingScore 0.0으로 정규화된다")
+    void score_NormalizesRawCosineMinusOne_ToZero() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.0, 1.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(-1.0);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().similarityScore()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("raw cosine 1.0은 embeddingScore 1.0으로 정규화된다")
+    void score_NormalizesRawCosinePlusOne_ToOne() {
+        // given
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(1.0, 0.0);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(1.0);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().similarityScore()).isEqualTo(1.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 5: finalScore 상한 clamp → 1.0
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("embeddingScore와 보정치의 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
+    void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
+        // given — rawCosine(0.8) + skill(0.15) + career(0.08) = 1.03 → clamp 1.0
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.8, 0.2);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(0.8);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.15);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.08);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(1.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 6: finalScore 하한 clamp → 0.0
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("embeddingScore와 보정치의 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
+    void score_ClampsFinalScore_ToZeroWhenSumBelowZero() {
+        // given — rawCosine(-0.8) + skill(-0.15) + career(-0.12) = -1.07 → clamp 0.0
+        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(-0.8, 0.2);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(-0.8);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(-0.15);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(-0.12);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(0.0);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -1,12 +1,15 @@
 package com.generic4.itda.service.recommend.scoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
@@ -68,6 +71,69 @@ class HeuristicV1RecommendationScorerTest {
     }
 
     // -------------------------------------------------------------------------
+    // 시나리오 0: 기본 모델 사용 및 후보 정보 전달
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기본 score 호출은 기본 임베딩 모델과 후보 정보를 그대로 사용한다")
+    void score_UsesDefaultEmbeddingModel_AndPassesCandidateDataToCollaborators() {
+        // given
+        RecommendationScorableCandidate candidate =
+                new RecommendationScorableCandidate(100L, 7, Set.of("Java", "Spring"));
+        Set<String> requiredSkills = Set.of("Java");
+        Set<String> preferredSkills = Set.of("Spring", "Docker");
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.2, 0.8);
+
+        given(proposalPosition.getCareerMinYears()).willReturn(5);
+        given(proposalPosition.getCareerMaxYears()).willReturn(8);
+        given(recommendationQueryTextGenerator.generate(
+                proposal,
+                proposalPosition,
+                requiredSkills,
+                preferredSkills
+        )).willReturn("query text");
+        given(queryEmbeddingGenerator.generate("query text")).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(100L), EMBEDDING_MODEL))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(0.2);
+        given(skillAdjustmentCalculator.calculate(requiredSkills, preferredSkills, candidate.ownedSkillNames()))
+                .willReturn(0.10);
+        given(careerAdjustmentCalculator.calculate(7, 5, 8)).willReturn(0.08);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal,
+                proposalPosition,
+                requiredSkills,
+                preferredSkills,
+                List.of(candidate)
+        );
+
+        // then
+        assertThat(result).singleElement().satisfies(scoredCandidate -> {
+            assertThat(scoredCandidate.resumeId()).isEqualTo(100L);
+            assertThat(scoredCandidate.careerYears()).isEqualTo(7);
+            assertThat(scoredCandidate.ownedSkillNames()).containsExactlyInAnyOrder("Java", "Spring");
+            assertThat(scoredCandidate.similarityScore()).isEqualTo(0.6);
+            assertThat(scoredCandidate.skillAdjustmentScore()).isEqualTo(0.10);
+            assertThat(scoredCandidate.careerAdjustmentScore()).isEqualTo(0.08);
+            assertThat(scoredCandidate.finalScore()).isCloseTo(0.78, offset(1e-9));
+        });
+
+        verify(recommendationQueryTextGenerator).generate(
+                proposal,
+                proposalPosition,
+                requiredSkills,
+                preferredSkills
+        );
+        verify(queryEmbeddingGenerator).generate("query text");
+        verify(resumeEmbeddingReader).readEmbeddingsByResumeIds(List.of(100L), EMBEDDING_MODEL);
+        verify(skillAdjustmentCalculator).calculate(requiredSkills, preferredSkills, candidate.ownedSkillNames());
+        verify(careerAdjustmentCalculator).calculate(7, 5, 8);
+    }
+
+    // -------------------------------------------------------------------------
     // 시나리오 1: 빈 후보 리스트
     // -------------------------------------------------------------------------
 
@@ -117,7 +183,57 @@ class HeuristicV1RecommendationScorerTest {
     }
 
     // -------------------------------------------------------------------------
-    // 시나리오 3: finalScore 내림차순 정렬
+    // 시나리오 3: 일부 후보 임베딩 누락 시 후속 계산 제외
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("임베딩이 없는 후보는 후속 점수 계산을 수행하지 않는다")
+    void score_SkipsDownstreamCalculations_WhenResumeEmbeddingIsMissingForSomeCandidates() {
+        // given
+        RecommendationScorableCandidate missingEmbeddingCandidate =
+                new RecommendationScorableCandidate(100L, 3, Set.of("Java"));
+        RecommendationScorableCandidate scorableCandidate =
+                new RecommendationScorableCandidate(200L, 4, Set.of("Spring"));
+
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.4, 0.6);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate("query text")).willReturn(queryEmbedding);
+        given(proposalPosition.getCareerMinYears()).willReturn(null);
+        given(proposalPosition.getCareerMaxYears()).willReturn(null);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(100L, 200L), EMBEDDING_MODEL))
+                .willReturn(Map.of(200L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(0.4);
+        given(skillAdjustmentCalculator.calculate(Set.of(), Set.of(), scorableCandidate.ownedSkillNames()))
+                .willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(4, null, null)).willReturn(0.0);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal,
+                proposalPosition,
+                Set.of(),
+                Set.of(),
+                List.of(missingEmbeddingCandidate, scorableCandidate),
+                EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).singleElement().satisfies(candidate -> {
+            assertThat(candidate.resumeId()).isEqualTo(200L);
+            assertThat(candidate.finalScore()).isEqualTo(0.7);
+        });
+
+        verify(cosineSimilarityCalculator).calculate(queryEmbedding, resumeEmbedding);
+        verify(skillAdjustmentCalculator).calculate(Set.of(), Set.of(), scorableCandidate.ownedSkillNames());
+        verify(careerAdjustmentCalculator).calculate(4, null, null);
+        verifyNoMoreInteractions(cosineSimilarityCalculator, skillAdjustmentCalculator, careerAdjustmentCalculator);
+    }
+
+    // -------------------------------------------------------------------------
+    // 시나리오 4: finalScore 내림차순 정렬
     // -------------------------------------------------------------------------
 
     @Test
@@ -159,7 +275,7 @@ class HeuristicV1RecommendationScorerTest {
     }
 
     // -------------------------------------------------------------------------
-    // 시나리오 4: raw cosine 정규화 → embeddingScore
+    // 시나리오 5: raw cosine 정규화 → embeddingScore
     // -------------------------------------------------------------------------
 
     @Test
@@ -217,7 +333,7 @@ class HeuristicV1RecommendationScorerTest {
     }
 
     // -------------------------------------------------------------------------
-    // 시나리오 5: finalScore 상한 clamp → 1.0
+    // 시나리오 6: finalScore 상한 clamp → 1.0
     // -------------------------------------------------------------------------
 
     @Test
@@ -248,7 +364,7 @@ class HeuristicV1RecommendationScorerTest {
     }
 
     // -------------------------------------------------------------------------
-    // 시나리오 6: finalScore 하한 clamp → 0.0
+    // 시나리오 7: finalScore 하한 clamp → 0.0
     // -------------------------------------------------------------------------
 
     @Test
@@ -276,5 +392,47 @@ class HeuristicV1RecommendationScorerTest {
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("proposal이 null이면 예외가 발생한다")
+    void score_ThrowsException_WhenProposalIsNull() {
+        assertThatThrownBy(() -> scorer.score(
+                null,
+                proposalPosition,
+                Set.of(),
+                Set.of(),
+                List.of(candidateWith(100L)),
+                EMBEDDING_MODEL
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("proposal은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("proposalPosition이 null이면 예외가 발생한다")
+    void score_ThrowsException_WhenProposalPositionIsNull() {
+        assertThatThrownBy(() -> scorer.score(
+                proposal,
+                null,
+                Set.of(),
+                Set.of(),
+                List.of(candidateWith(100L)),
+                EMBEDDING_MODEL
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("proposalPosition은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("candidates가 null이면 예외가 발생한다")
+    void score_ThrowsException_WhenCandidatesIsNull() {
+        assertThatThrownBy(() -> scorer.score(
+                proposal,
+                proposalPosition,
+                Set.of(),
+                Set.of(),
+                null,
+                EMBEDDING_MODEL
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("candidates는 null일 수 없습니다.");
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -59,8 +59,8 @@ class HeuristicV1RecommendationScorerTest {
     // 공통 헬퍼
     // -------------------------------------------------------------------------
 
-    private RecommendationScorableCandidate candidateWith(long candidateId, long memberId, long resumeId) {
-        return new RecommendationScorableCandidate(candidateId, memberId, resumeId, 3, Set.of("Java"));
+    private RecommendationScorableCandidate candidateWith(long resumeId) {
+        return new RecommendationScorableCandidate(resumeId, 3, Set.of("Java"));
     }
 
     private List<Double> dummyQueryEmbedding() {
@@ -98,7 +98,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("이력서 임베딩이 없는 후보는 결과에서 제외된다")
     void score_ExcludesCandidate_WhenResumeEmbeddingIsMissing() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
 
         given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
                 .willReturn("query text");
@@ -124,8 +124,8 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("최종 점수(finalScore) 내림차순으로 정렬한다")
     void score_ReturnsCandidatesSortedByFinalScoreDescending() {
         // given
-        RecommendationScorableCandidate candidateA = candidateWith(1L, 10L, 100L);
-        RecommendationScorableCandidate candidateB = candidateWith(2L, 20L, 200L);
+        RecommendationScorableCandidate candidateA = candidateWith(100L);
+        RecommendationScorableCandidate candidateB = candidateWith(200L);
 
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> embeddingA = List.of(1.0, 0.0);
@@ -166,7 +166,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("raw cosine -1.0은 embeddingScore 0.0으로 정규화된다")
     void score_NormalizesRawCosineMinusOne_ToZero() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.0, 1.0);
 
@@ -193,7 +193,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("raw cosine 1.0은 embeddingScore 1.0으로 정규화된다")
     void score_NormalizesRawCosinePlusOne_ToOne() {
         // given
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(1.0, 0.0);
 
@@ -224,7 +224,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("embeddingScore와 보정치의 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
     void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
         // given — rawCosine(0.8) + skill(0.15) + career(0.08) = 1.03 → clamp 1.0
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.8, 0.2);
 
@@ -255,7 +255,7 @@ class HeuristicV1RecommendationScorerTest {
     @DisplayName("embeddingScore와 보정치의 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
     void score_ClampsFinalScore_ToZeroWhenSumBelowZero() {
         // given — rawCosine(-0.8) + skill(-0.15) + career(-0.12) = -1.07 → clamp 0.0
-        RecommendationScorableCandidate candidate = candidateWith(1L, 10L, 100L);
+        RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(-0.8, 0.2);
 

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
@@ -1,6 +1,8 @@
 package com.generic4.itda.service.recommend.scoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
@@ -137,5 +139,38 @@ class RecommendationQueryTextGeneratorTest {
         );
 
         assertThat(result).contains("preferred skills: AWS, Docker");
+    }
+
+    @Test
+    @DisplayName("position/workType가 없고 텍스트에 공백이 있어도 null 없이 정규화한다.")
+    void generate_NormalizesBlankAndNullFields() {
+        // given
+        Proposal proposal = mock(Proposal.class);
+        ProposalPosition proposalPosition = mock(ProposalPosition.class);
+
+        given(proposal.getTitle()).willReturn("  Title  ");
+        given(proposal.getDescription()).willReturn("  Description  ");
+        given(proposalPosition.getPosition()).willReturn(null);
+        given(proposalPosition.getWorkType()).willReturn(null);
+        given(proposalPosition.getCareerMinYears()).willReturn(null);
+        given(proposalPosition.getCareerMaxYears()).willReturn(null);
+
+        // when
+        String result = generator.generate(
+                proposal,
+                proposalPosition,
+                Set.of(" Java "),
+                Set.of(" Java ", " Docker ")
+        );
+
+        // then
+        assertThat(result).contains("position: ");
+        assertThat(result).contains("workType: ");
+        assertThat(result).contains("career: ");
+        assertThat(result).contains("required skills: Java");
+        assertThat(result).contains("preferred skills: Docker");
+        assertThat(result).contains("title: Title");
+        assertThat(result).contains("description: Description");
+        assertThat(result).doesNotContain("null");
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/RecommendationQueryTextGeneratorTest.java
@@ -1,0 +1,141 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.fixture.MemberFixture;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("RecommendationQueryTextGenerator 단위 테스트")
+class RecommendationQueryTextGeneratorTest {
+
+    private final RecommendationQueryTextGenerator generator = new RecommendationQueryTextGenerator();
+
+    @Test
+    @DisplayName("제안서 정보를 바탕으로 임베딩용 쿼리 텍스트를 생성한다.")
+    void generate_ReturnsFormattedText() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        ReflectionTestUtils.setField(position, "id", 1L);
+
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        Set<String> requiredSkills = Set.of("Java", "Spring");
+        Set<String> preferredSkills = Set.of("AWS", "Docker", "Java"); // Java is redundant
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, requiredSkills, preferredSkills);
+
+        // then
+        assertThat(result).contains("position: Backend Developer");
+        assertThat(result).contains("workType: REMOTE");
+        assertThat(result).contains("career: 3~5 years");
+        assertThat(result).contains("required skills: Java, Spring");
+        assertThat(result).contains("preferred skills: AWS, Docker"); // Java should be filtered out
+        assertThat(result).contains("title: Title");
+        assertThat(result).contains("description: Description");
+    }
+
+    @Test
+    @DisplayName("경력 요구사항이 null일 경우 빈 문자열로 처리한다.")
+    void generate_WithNullCareer_ReturnsEmptyCareer() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, null, null, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: ");
+        assertThat(result).doesNotContain("career: null");
+    }
+
+    @Test
+    @DisplayName("최소 경력만 있을 경우의 포맷을 확인한다.")
+    void generate_WithMinCareerOnly() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, null, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: 3+ years");
+    }
+
+    @Test
+    @DisplayName("최대 경력만 있을 경우의 포맷을 확인한다.")
+    void generate_WithMaxCareerOnly() {
+        // given
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, null, 5, null
+        );
+
+        // when
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        // then
+        assertThat(result).contains("career: up to 5 years");
+    }
+
+    @Test
+    @DisplayName("required/preferred skill이 null이어도 null 문자열을 출력하지 않는다.")
+    void generate_WithNullSkills_DoesNotPrintNull() {
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        String result = generator.generate(proposal, proposalPosition, null, null);
+
+        assertThat(result).contains("required skills: ");
+        assertThat(result).contains("preferred skills: ");
+        assertThat(result).doesNotContain("null");
+    }
+
+    @Test
+    @DisplayName("required skill이 비어 있으면 preferred skill을 그대로 포함한다.")
+    void generate_WithOnlyPreferredSkills_IncludesPreferredSkills() {
+        Member client = MemberFixture.createMember();
+        Position position = Position.create("Backend Developer");
+        Proposal proposal = Proposal.create(client, "Title", "Raw Input", "Description", null, null, null);
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position, "Position Title", ProposalWorkType.REMOTE, 1L, null, null, null, 3, 5, null
+        );
+
+        String result = generator.generate(
+                proposal,
+                proposalPosition,
+                null,
+                Set.of("AWS", "Docker")
+        );
+
+        assertThat(result).contains("preferred skills: AWS, Docker");
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
@@ -1,0 +1,129 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.domain.recommendation.vo.EmbeddingVector;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeEmbeddingReaderImplTest {
+
+    @Mock
+    private ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    private ResumeEmbeddingReaderImpl resumeEmbeddingReader;
+
+    @BeforeEach
+    void setUp() {
+        resumeEmbeddingReader = new ResumeEmbeddingReaderImpl(resumeEmbeddingRepository);
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록으로 임베딩을 조회하여 맵 형태로 반환한다")
+    void 이력서_ID_목록으로_임베딩을_조회하여_맵_형태로_반환한다() {
+        // given
+        List<Long> resumeIds = List.of(1L, 2L);
+        String model = "text-embedding-3-small";
+
+        Resume resume1 = mock(Resume.class);
+        given(resume1.getId()).willReturn(1L);
+        Resume resume2 = mock(Resume.class);
+        given(resume2.getId()).willReturn(2L);
+
+        ResumeEmbedding embedding1 = mock(ResumeEmbedding.class);
+        given(embedding1.getResume()).willReturn(resume1);
+        given(embedding1.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        ResumeEmbedding embedding2 = mock(ResumeEmbedding.class);
+        given(embedding2.getResume()).willReturn(resume2);
+        given(embedding2.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.3, 0.4)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, model))
+                .willReturn(List.of(embedding1, embedding2));
+
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, model);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(1L)).containsExactly(0.1, 0.2);
+        assertThat(result.get(2L)).containsExactly(0.3, 0.4);
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록이 비어있으면 빈 맵을 반환한다")
+    void 이력서_ID_목록이_비어있으면_빈_맵을_반환한다() {
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(Collections.emptyList(),
+                "model");
+
+        // then
+        assertThat(result).isEmpty();
+        then(resumeEmbeddingRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("이력서 ID 목록이 null이면 빈 맵을 반환한다")
+    void 이력서_ID_목록이_null이면_빈_맵을_반환한다() {
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(null, "model");
+
+        // then
+        assertThat(result).isEmpty();
+        then(resumeEmbeddingRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("모델명이 없으면 예외가 발생한다")
+    void 모델명이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), null))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), ""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(1L), "   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("조회되지 않은 이력서 ID는 결과 맵에 포함하지 않는다")
+    void 조회되지_않은_이력서_ID는_결과_맵에_포함하지_않는다() {
+        // given
+        List<Long> resumeIds = List.of(1L, 2L);
+        String model = "text-embedding-3-small";
+
+        Resume resume1 = mock(Resume.class);
+        given(resume1.getId()).willReturn(1L);
+
+        ResumeEmbedding embedding1 = mock(ResumeEmbedding.class);
+        given(embedding1.getResume()).willReturn(resume1);
+        given(embedding1.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, model))
+                .willReturn(List.of(embedding1));
+
+        // when
+        Map<Long, List<Double>> result = resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, model);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey(1L);
+        assertThat(result).doesNotContainKey(2L);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/ResumeEmbeddingReaderImplTest.java
@@ -126,4 +126,27 @@ class ResumeEmbeddingReaderImplTest {
         assertThat(result).containsKey(1L);
         assertThat(result).doesNotContainKey(2L);
     }
+
+    @Test
+    @DisplayName("모델명 앞뒤 공백은 제거한 뒤 조회한다")
+    void 모델명_앞뒤_공백은_제거한_뒤_조회한다() {
+        List<Long> resumeIds = List.of(1L);
+        String inputModel = " text-embedding-3-small ";
+        String normalizedModel = "text-embedding-3-small";
+
+        Resume resume = mock(Resume.class);
+        given(resume.getId()).willReturn(1L);
+
+        ResumeEmbedding embedding = mock(ResumeEmbedding.class);
+        given(embedding.getResume()).willReturn(resume);
+        given(embedding.getEmbeddingVector()).willReturn(new EmbeddingVector(List.of(0.1, 0.2)));
+
+        given(resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(resumeIds, normalizedModel))
+                .willReturn(List.of(embedding));
+
+        Map<Long, List<Double>> result =
+                resumeEmbeddingReader.readEmbeddingsByResumeIds(resumeIds, inputModel);
+
+        assertThat(result).containsEntry(1L, List.of(0.1, 0.2));
+    }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculatorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/SkillAdjustmentCalculatorTest.java
@@ -1,0 +1,126 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SkillAdjustmentCalculatorTest {
+
+    private final SkillAdjustmentCalculator calculator = new SkillAdjustmentCalculator();
+
+    @DisplayName("필수 기술과 선택 기술이 모두 일치할 때 가산점을 정확히 계산한다")
+    @Test
+    void calculate_allSkillsMatch_returnsMaxBonus() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker", "AWS");
+        Set<String> owned = Set.of("Java", "Spring", "Docker", "AWS", "Git");
+
+        // when
+        // requiredAdjustment: (1.0 - 0.5) * 0.3 = 0.15
+        // preferredAdjustment: 1.0 * 0.05 = 0.05
+        // total: 0.20
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.20, offset(1e-9));
+    }
+
+    @DisplayName("일치하는 기술이 하나도 없을 때 감점을 정확히 계산한다")
+    @Test
+    void calculate_noSkillsMatch_returnsMinPenalty() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker", "AWS");
+        Set<String> owned = Set.of("Python", "Django");
+
+        // when
+        // requiredAdjustment: (0.0 - 0.5) * 0.3 = -0.15
+        // preferredAdjustment: 0.0 * 0.05 = 0.0
+        // total: -0.15
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(-0.15, offset(1e-9));
+    }
+
+    @DisplayName("필수 기술이 절반만 일치할 때 필수 기술 보정치는 0이어야 한다")
+    @Test
+    void calculate_halfRequiredSkillsMatch_returnsZeroRequiredAdjustment() {
+        // given
+        Set<String> required = Set.of("Java", "Spring", "JPA", "Querydsl");
+        Set<String> preferred = Collections.emptySet();
+        Set<String> owned = Set.of("Java", "Spring");
+
+        // when
+        // requiredAdjustment: (2/4 - 0.5) * 0.3 = 0.0
+        // preferredAdjustment: 0.0
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.0, offset(1e-9));
+    }
+
+    @DisplayName("기술 목록이 null이거나 비어있을 때 0.0을 반환한다")
+    @Test
+    void calculate_emptyOrNullSkills_returnsZero() {
+        // when & then
+        assertThat(calculator.calculate(null, null, Set.of("Java"))).isEqualTo(0.0);
+        assertThat(calculator.calculate(Collections.emptySet(), Collections.emptySet(), Set.of("Java"))).isEqualTo(0.0);
+    }
+
+    @DisplayName("선택 기술만 일부 일치할 때 가산점을 정확히 계산한다")
+    @Test
+    void calculate_onlyPreferredSkillsMatch_returnsCorrectBonus() {
+        // given
+        Set<String> required = Collections.emptySet();
+        Set<String> preferred = Set.of("Docker", "AWS", "Kubernetes", "Terraform");
+        Set<String> owned = Set.of("Docker", "AWS");
+
+        // when
+        // requiredAdjustment: 0.0
+        // preferredAdjustment: (2/4) * 0.05 = 0.025
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        assertThat(result).isCloseTo(0.025, offset(1e-9));
+    }
+
+    @DisplayName("필수 기술과 중복된 우대 기술은 우대 가산점에 중복 반영되지 않는다")
+    @Test
+    void calculate_overlappingPreferredSkills_doesNotDoubleCount() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Spring", "AWS");
+        Set<String> owned = Set.of("Java", "Spring");
+
+        // when
+        double result = calculator.calculate(required, preferred, owned);
+
+        // then
+        // requiredAdjustment: (2/2 - 0.5) * 0.3 = 0.15
+        // preferredAdjustment: AWS만 유효 preferred로 남으면 0.0
+        assertThat(result).isCloseTo(0.15, offset(1e-9));
+    }
+
+    @DisplayName("보유 기술 수가 많아도 required/preferred 기준으로만 보정한다")
+    @Test
+    void calculate_extraOwnedSkills_doNotAffectAdjustment() {
+        // given
+        Set<String> required = Set.of("Java", "Spring");
+        Set<String> preferred = Set.of("Docker");
+        Set<String> owned1 = Set.of("Java", "Spring", "Docker");
+        Set<String> owned2 = Set.of("Java", "Spring", "Docker", "Redis", "Kafka", "MySQL");
+
+        // when
+        double result1 = calculator.calculate(required, preferred, owned1);
+        double result2 = calculator.calculate(required, preferred, owned2);
+
+        // then
+        assertThat(result1).isCloseTo(result2, offset(1e-9));
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGeneratorTest.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StubQueryEmbeddingGeneratorTest {
+
+    private final StubQueryEmbeddingGenerator generator = new StubQueryEmbeddingGenerator();
+
+    @Test
+    @DisplayName("생성 시 UnsupportedOperationException이 발생한다")
+    void 생성_시_UnsupportedOperationException이_발생한다() {
+        assertThatThrownBy(() -> generator.generate("any query"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("쿼리 임베딩 생성은 별도 이슈에서 구현합니다.");
+    }
+}


### PR DESCRIPTION
## 🔎 What

`HEURISTIC_V1` 추천 알고리즘(MVP)을 구현했습니다.

* `RecommendationCandidateFinder → Scorer → ResultCreator → 저장`으로 이어지는 추천 계산 파이프라인을 구성했습니다.
* 하드 필터링 이후, query embedding과 resume embedding 간 코사인 유사도, 스킬/경력 가중치 보정을 결합해 최종 추천 점수를 계산합니다.
* 상위 후보를 `RecommendationResult`로 생성 및 저장하도록 구현했습니다.

### 주요 구현 내용

* `RecommendationCandidate`를 하드필터/스코어링 입력 중심 모델로 정리
* `RecommendationScorableCandidate`를 최소 입력 구조로 정리 (resumeId, careerYears, ownedSkillNames)
* Java 기반 코사인 유사도 계산 로직 구현
* 스킬/경력 가중치 보정 로직 구현
* embedding score + heuristic score 결합 방식 정의
* finalScore 산출 및 정렬 로직 구현
* topK 선정 및 `RecommendationResult` 생성/저장 로직 구현
* 결과 정렬 시 `resumeId` 기반 tie-break를 적용해 deterministic한 결과를 보장
* `HardFilterStat`을 파이프라인 기준(`totalCandidates`, `finalCandidates`)으로 단순화

### 설계 변경 사항

* 추천 계산 로직을 `HeuristicV1RecommendationScorer`와 `RecommendationResultCreator`로 분리하여 책임을 명확히 했습니다.
* `RecommendationScorableCandidate`에서 불필요한 식별자(`memberId`, `candidateId`)를 제거하고 `resumeId` 기준으로 통일했습니다.

---

## 🔗 Issue

* Closes: #40 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?

---

## 💡 참고 사항

* query embedding 생성기는 현재 stub으로 연결되어 있으며, 실제 OpenAI 기반 embedding 생성기 연동은 후속 이슈에서 진행합니다.
* `RecommendationRunProcessor`를 통한 실행 오케스트레이션 및 상태 전이는 별도 이슈에서 마무리 예정입니다.
* 현재 구현은 Java 기반 계산을 사용하는 MVP 추천(`HEURISTIC_V1`)에 한정되며, 벡터 검색 인프라(pgvector, HNSW 등)는 포함하지 않습니다.
