### PR TITLE
[Refactor] AI 인터뷰 전 자동저장 JSON 엔드포인트 분리

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalAiInterviewController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalAiInterviewController.java
@@ -1,16 +1,21 @@
 package com.generic4.itda.controller;
 
+import com.generic4.itda.dto.proposal.AiInterviewDraftSaveRequest;
 import com.generic4.itda.dto.proposal.AiInterviewSendMessageRequest;
 import com.generic4.itda.dto.proposal.AiInterviewSendMessageResponse;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.ProposalAiInterviewService;
+import com.generic4.itda.service.ProposalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,6 +24,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProposalAiInterviewController {
 
     private final ProposalAiInterviewService proposalAiInterviewService;
+    private final ProposalService proposalService;
+
+    @PatchMapping("/{proposalId}/ai-interview/draft")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void saveDraft(
+            @AuthenticationPrincipal ItDaPrincipal itDaPrincipal,
+            @PathVariable Long proposalId,
+            @Valid @RequestBody AiInterviewDraftSaveRequest request
+    ) {
+        proposalService.saveInterviewDraft(
+                proposalId,
+                itDaPrincipal.getEmail(),
+                request
+        );
+    }
 
     @PostMapping("/{proposalId}/ai-interview/messages")
     public AiInterviewSendMessageResponse sendMessage(

--- a/src/main/java/com/generic4/itda/dto/proposal/AiInterviewDraftSaveRequest.java
+++ b/src/main/java/com/generic4/itda/dto/proposal/AiInterviewDraftSaveRequest.java
@@ -1,0 +1,30 @@
+package com.generic4.itda.dto.proposal;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiInterviewDraftSaveRequest {
+
+    @NotBlank(message = "제안서 제목은 필수값입니다.")
+    @Size(max = 200, message = "제안서 제목은 200자를 초과할 수 없습니다.")
+    private String title;
+
+    @Size(max = 10000, message = "설명은 10000자를 초과할 수 없습니다.")
+    private String description;
+
+    @Min(value = 1, message = "예상 기간은 1 이상이어야 합니다.")
+    private Long expectedPeriod;
+
+    @Valid
+    private List<ProposalPositionForm> positions = new ArrayList<>();
+}

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -11,6 +11,7 @@ import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.proposal.AiInterviewDraftSaveRequest;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.exception.ProposalNotFoundException;
@@ -110,6 +111,23 @@ public class ProposalService {
                 calculateTotalBudgetMin(positionForms),
                 calculateTotalBudgetMax(positionForms),
                 form.getExpectedPeriod()
+        );
+
+        replacePositions(proposal, positionForms);
+        return proposal;
+    }
+
+    public Proposal saveInterviewDraft(Long proposalId, String memberEmail, AiInterviewDraftSaveRequest request) {
+        Proposal proposal = getWritableProposal(proposalId, memberEmail);
+        List<ProposalPositionForm> positionForms = getPositionForms(request);
+
+        proposal.update(
+                request.getTitle(),
+                proposal.getRawInputText(),
+                request.getDescription(),
+                calculateTotalBudgetMin(positionForms),
+                calculateTotalBudgetMax(positionForms),
+                request.getExpectedPeriod()
         );
 
         replacePositions(proposal, positionForms);
@@ -442,6 +460,10 @@ public class ProposalService {
 
     private List<ProposalPositionForm> getPositionForms(ProposalForm form) {
         return form.getPositions() == null ? List.of() : form.getPositions();
+    }
+
+    private List<ProposalPositionForm> getPositionForms(AiInterviewDraftSaveRequest request) {
+        return request.getPositions() == null ? List.of() : request.getPositions();
     }
 
     private Member getMemberByEmail(String memberEmail) {

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -839,35 +839,56 @@
                 },
 
                 async saveCurrentDraftBeforeInterview() {
-                    const formData = new FormData(this.$root);
-                    formData.set('submitAction', 'save');
-                    formData.set('aiBriefRequested', 'false');
-                    formData.set('title', this.title || '');
-                    formData.set('rawInputText', '');
-                    formData.set('description', this.description || '');
-                    formData.set('expectedPeriod', this.expectedPeriod || '');
-
-                    const response = await fetch(this.$root.getAttribute('action'), {
-                        method: 'POST',
+                    const response = await fetch(`/proposals/${bootstrap.proposalId}/ai-interview/draft`, {
+                        method: 'PATCH',
                         headers: {
                             ...this.csrfHeaders(),
-                            'Accept': 'text/html'
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json'
                         },
-                        body: formData,
-                        redirect: 'manual'
+                        body: JSON.stringify(this.buildInterviewDraftPayload())
                     });
 
-                    if (response.type === 'opaqueredirect' || response.status === 0) {
-                        return;
-                    }
-
-                    if (response.status >= 300 && response.status < 400) {
-                        return;
-                    }
-
                     if (!response.ok) {
-                        throw new Error('AI 인터뷰 전 현재 제안서 내용을 임시저장하지 못했습니다. 입력값을 확인해주세요.');
+                        throw new Error(await this.extractErrorMessage(response));
                     }
+                },
+
+                buildInterviewDraftPayload() {
+                    return {
+                        title: this.title || '',
+                        description: this.description || '',
+                        expectedPeriod: this.toNullableNumber(this.expectedPeriod),
+                        positions: this.positions.map(position => this.toInterviewDraftPositionPayload(position))
+                    };
+                },
+
+                toInterviewDraftPositionPayload(position) {
+                    return {
+                        id: this.toNullableNumber(position.id),
+                        positionId: this.toNullableNumber(position.positionId),
+                        title: position.title || '',
+                        workType: position.workType || null,
+                        headCount: this.toNullableNumber(position.headCount),
+                        unitBudgetMin: this.toNullableNumber(position.unitBudgetMin),
+                        unitBudgetMax: this.toNullableNumber(position.unitBudgetMax),
+                        expectedPeriod: this.toNullableNumber(position.expectedPeriod),
+                        careerMinYears: this.toNullableNumber(position.careerMinYears),
+                        careerMaxYears: this.toNullableNumber(position.careerMaxYears),
+                        workPlace: position.workPlace || '',
+                        status: position.status || 'OPEN',
+                        essentialSkillNames: position.essentialSkillNames || [],
+                        preferredSkillNames: position.preferredSkillNames || []
+                    };
+                },
+
+                toNullableNumber(value) {
+                    if (value === null || value === undefined || value === '') {
+                        return null;
+                    }
+
+                    const number = Number(value);
+                    return Number.isNaN(number) ? null : number;
                 },
 
                 appendRawInput(current, input) {

--- a/src/test/java/com/generic4/itda/controller/ProposalAiInterviewControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalAiInterviewControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
@@ -20,6 +21,7 @@ import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.ProposalAiInterviewService;
+import com.generic4.itda.service.ProposalService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +42,116 @@ class ProposalAiInterviewControllerTest {
     private ProposalAiInterviewService proposalAiInterviewService;
 
     @MockitoBean
+    private ProposalService proposalService;
+
+    @MockitoBean
     private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("인증된 사용자가 AI 인터뷰 draft를 JSON으로 저장하면 204를 반환한다")
+    void saveDraft() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678")
+        );
+
+        mockMvc.perform(patch("/proposals/{proposalId}/ai-interview/draft", 1L)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "온라인 쇼핑몰 구축",
+                                  "description": "결제와 관리자 기능이 있는 쇼핑몰을 개발합니다.",
+                                  "expectedPeriod": 12,
+                                  "positions": [
+                                    {
+                                      "id": 1,
+                                      "positionId": 3,
+                                      "title": "백엔드 개발자",
+                                      "workType": "REMOTE",
+                                      "headCount": 2,
+                                      "unitBudgetMin": 3000000,
+                                      "unitBudgetMax": 5000000,
+                                      "expectedPeriod": 8,
+                                      "careerMinYears": 2,
+                                      "careerMaxYears": 5,
+                                      "workPlace": "",
+                                      "status": "OPEN",
+                                      "essentialSkillNames": ["Java", "Spring Boot"],
+                                      "preferredSkillNames": ["AWS"]
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isNoContent());
+
+        then(proposalService).should().saveInterviewDraft(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq("user@example.com"),
+                org.mockito.ArgumentMatchers.argThat(request ->
+                        "온라인 쇼핑몰 구축".equals(request.getTitle())
+                                && "결제와 관리자 기능이 있는 쇼핑몰을 개발합니다.".equals(request.getDescription())
+                                && Long.valueOf(12L).equals(request.getExpectedPeriod())
+                                && request.getPositions().size() == 1
+                                && Long.valueOf(3L).equals(request.getPositions().get(0).getPositionId())
+                                && "백엔드 개발자".equals(request.getPositions().get(0).getTitle())
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 제목이 비어 있으면 400을 반환한다")
+    void failWhenDraftTitleIsBlank() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("user@example.com", "hashed-password", "사용자", "010-1234-5678")
+        );
+
+        mockMvc.perform(patch("/proposals/{proposalId}/ai-interview/draft", 1L)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "",
+                                  "description": "설명",
+                                  "expectedPeriod": 12,
+                                  "positions": []
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        then(proposalService).should(never()).saveInterviewDraft(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 AI 인터뷰 draft 저장 시 로그인 페이지로 리다이렉트된다")
+    void redirectToLoginWhenSaveDraftUnauthenticated() throws Exception {
+        mockMvc.perform(patch("/proposals/{proposalId}/ai-interview/draft", 1L)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "온라인 쇼핑몰 구축",
+                                  "description": "설명",
+                                  "expectedPeriod": 12,
+                                  "positions": []
+                                }
+                                """))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
 
     @Test
     @DisplayName("인증된 사용자가 AI 인터뷰 메시지를 전송하면 갱신된 폼과 메시지 목록을 반환한다")

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -17,6 +17,8 @@ import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.proposal.AiInterviewDraftSaveRequest;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.exception.ProposalNotFoundException;
@@ -155,6 +157,127 @@ class ProposalServiceTest {
         assertThatThrownBy(() -> proposalService.saveDraft(1L, EMAIL, form))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("매칭 중 제안서는 원본을 직접 수정할 수 없습니다. 수정 시작을 통해 새 초안을 만든 뒤 편집해주세요.");
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 저장은 rawInputText를 유지하고 현재 draft 필드를 저장한다")
+    void saveInterviewDraft_keepsRawInputTextAndUpdatesDraftFields() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "기존 설명",
+                null,
+                null,
+                6L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        Position backend = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(backend, "id", 1L);
+
+        ProposalPositionForm positionForm = new ProposalPositionForm();
+        positionForm.setPositionId(1L);
+        positionForm.setTitle("Spring 백엔드 개발자");
+        positionForm.setWorkType(ProposalWorkType.REMOTE);
+        positionForm.setHeadCount(2L);
+        positionForm.setUnitBudgetMin(3_000_000L);
+        positionForm.setUnitBudgetMax(4_000_000L);
+        positionForm.setExpectedPeriod(4L);
+        positionForm.setCareerMinYears(2);
+        positionForm.setCareerMaxYears(5);
+        positionForm.setEssentialSkillNames(List.of("Java", "Spring Boot"));
+        positionForm.setPreferredSkillNames(List.of("AWS"));
+
+        AiInterviewDraftSaveRequest request = new AiInterviewDraftSaveRequest();
+        request.setTitle("수정된 프로젝트");
+        request.setDescription("수정된 설명");
+        request.setExpectedPeriod(8L);
+        request.setPositions(List.of(positionForm));
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(positionRepository.findById(1L)).thenReturn(Optional.of(backend));
+        when(skillRepository.findByName(any())).thenReturn(Optional.empty());
+        when(skillRepository.save(any(Skill.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Proposal saved = proposalService.saveInterviewDraft(1L, EMAIL, request);
+
+        assertThat(saved).isSameAs(proposal);
+        assertThat(saved.getTitle()).isEqualTo("수정된 프로젝트");
+        assertThat(saved.getRawInputText()).isEqualTo("기존 원본 입력");
+        assertThat(saved.getDescription()).isEqualTo("수정된 설명");
+        assertThat(saved.getExpectedPeriod()).isEqualTo(8L);
+        assertThat(saved.getTotalBudgetMin()).isEqualTo(6_000_000L);
+        assertThat(saved.getTotalBudgetMax()).isEqualTo(8_000_000L);
+        assertThat(saved.getPositions()).hasSize(1);
+        assertThat(saved.getPositions().get(0).getTitle()).isEqualTo("Spring 백엔드 개발자");
+        assertThat(saved.getPositions().get(0).getSkills()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 저장은 WRITING 상태가 아니면 실패한다")
+    void saveInterviewDraft_blocksNonWritingProposal() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "설명",
+                null,
+                null,
+                6L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        proposal.startMatching();
+
+        AiInterviewDraftSaveRequest request = new AiInterviewDraftSaveRequest();
+        request.setTitle("수정된 프로젝트");
+        request.setDescription("수정된 설명");
+        request.setExpectedPeriod(6L);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.saveInterviewDraft(1L, EMAIL, request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매칭 중 제안서는 원본을 직접 수정할 수 없습니다. 수정 시작을 통해 새 초안을 만든 뒤 편집해주세요.");
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 저장은 본인 제안서가 아니면 실패한다")
+    void saveInterviewDraft_blocksOtherMemberProposal() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "설명",
+                null,
+                null,
+                6L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        AiInterviewDraftSaveRequest request = new AiInterviewDraftSaveRequest();
+        request.setTitle("수정된 프로젝트");
+        request.setDescription("수정된 설명");
+        request.setExpectedPeriod(6L);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.saveInterviewDraft(1L, OTHER_EMAIL, request))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 저장은 존재하지 않는 제안서면 실패한다")
+    void saveInterviewDraft_throwsWhenNotFound() {
+        AiInterviewDraftSaveRequest request = new AiInterviewDraftSaveRequest();
+        request.setTitle("수정된 프로젝트");
+        request.setDescription("수정된 설명");
+        request.setExpectedPeriod(6L);
+
+        when(proposalRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.saveInterviewDraft(99L, EMAIL, request))
+                .isInstanceOf(ProposalNotFoundException.class);
     }
 
     @Test


### PR DESCRIPTION
## 🔎 What

- AI 인터뷰 draft 자동저장 요청 DTO 추가
- `ProposalService`에 AI 인터뷰 전용 draft 저장 메서드 추가
- 자동저장 시 기존 `rawInputText` 값 유지
- positions 저장은 기존 draft 저장 로직과 동일하게 처리
- `ProposalAiInterviewController`에 JSON 엔드포인트 추가
- `PATCH /proposals/{proposalId}/ai-interview/draft` 추가
- `proposalForm.html`의 `saveCurrentDraftBeforeInterview()` 수정
- `new FormData(this.$root)` 제거
- 기존 `/proposals/{id}/edit` 자동저장 호출 제거
- JSON body에 `title`, `description`, `expectedPeriod`, `positions`만 명시적으로 구성
- JSON body에서 `rawInputText`, `status`, `submitAction`, `aiBriefRequested`, UI 전용 필드 제외
- JSON 자동저장 성공 후 기존 `/proposals/{id}/ai-interview/messages` 호출 흐름 유지
- 서비스 테스트 추가/수정
- 컨트롤러 테스트 추가/수정
- 자동저장 요청이 `application/json`으로 전송되는지 수동 검증
- AI 인터뷰 전송 전 수정한 title, description, expectedPeriod, positions가 저장되는지 수동 검증
- 기존 AI 인터뷰 메시지 저장/복원 흐름이 유지되는지 확인

## 🔗 Issue

- Closes: #81 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?