### PR TITLE
[Feat] 추천 쿼리 임베딩 생성기 구현 및 scorer 연동 안정화

### DIFF
--- a/src/main/java/com/generic4/itda/ItDaApplication.java
+++ b/src/main/java/com/generic4/itda/ItDaApplication.java
@@ -3,8 +3,9 @@ package com.generic4.itda;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-//@EnableScheduling
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ItDaApplication {

--- a/src/main/java/com/generic4/itda/config/ai/AiEmbeddingProperties.java
+++ b/src/main/java/com/generic4/itda/config/ai/AiEmbeddingProperties.java
@@ -1,0 +1,20 @@
+package com.generic4.itda.config.ai;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ai.embedding")
+public class AiEmbeddingProperties {
+
+    private boolean enabled = false;
+    private String apiUrl = "https://api.openai.com/v1/embeddings";
+    private String apiKey;
+    private String model = "text-embedding-3-small";
+
+    private Integer timeoutMillis = 5000;
+}

--- a/src/main/java/com/generic4/itda/exception/QueryEmbeddingGenerationException.java
+++ b/src/main/java/com/generic4/itda/exception/QueryEmbeddingGenerationException.java
@@ -1,0 +1,12 @@
+package com.generic4.itda.exception;
+
+public class QueryEmbeddingGenerationException extends RuntimeException {
+
+    public QueryEmbeddingGenerationException(String message) {
+        super(message);
+    }
+
+    public QueryEmbeddingGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.service.recommend.scoring;
 
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
@@ -18,8 +19,7 @@ import org.springframework.util.Assert;
 @RequiredArgsConstructor
 public class HeuristicV1RecommendationScorer {
 
-    private static final String DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
-
+    private final AiEmbeddingProperties properties;
     private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
     private final QueryEmbeddingGenerator queryEmbeddingGenerator;
     private final ResumeEmbeddingReader resumeEmbeddingReader;
@@ -40,7 +40,7 @@ public class HeuristicV1RecommendationScorer {
                 requiredSkillNames,
                 preferredSkillNames,
                 candidates,
-                DEFAULT_EMBEDDING_MODEL
+                properties.getModel()
         );
     }
 

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGenerator.java
@@ -1,0 +1,100 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
+import com.generic4.itda.exception.QueryEmbeddingGenerationException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "ai.embedding", name = "enabled", havingValue = "true")
+public class OpenAiQueryEmbeddingGenerator implements QueryEmbeddingGenerator {
+
+    private final RestClient restClient;
+    private final AiEmbeddingProperties properties;
+
+    @Autowired
+    public OpenAiQueryEmbeddingGenerator(RestClient.Builder restClientBuilder, AiEmbeddingProperties properties) {
+        Assert.hasText(properties.getApiKey(), "임베딩 API 키는 필수값입니다.");
+        Assert.hasText(properties.getApiUrl(), "임베딩 API URL은 필수값입니다.");
+        Assert.hasText(properties.getModel(), "임베딩 모델명은 필수값입니다.");
+
+        this.properties = properties;
+        this.restClient = restClientBuilder.build();
+    }
+
+    // 테스트 전용: RestClient를 직접 주입할 수 있는 패키지-private 생성자
+    OpenAiQueryEmbeddingGenerator(RestClient restClient, AiEmbeddingProperties properties) {
+        this.restClient = restClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public List<Double> generate(String queryText) {
+        Assert.hasText(queryText, "queryText는 비어있을 수 없습니다.");
+
+        try {
+            JsonNode responseBody = restClient.post()
+                    .uri(properties.getApiUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .headers(headers -> headers.setBearerAuth(properties.getApiKey()))
+                    .body(new EmbeddingRequest(
+                            properties.getModel(),
+                            queryText.trim()
+                    ))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return extractEmbedding(responseBody);
+        } catch (QueryEmbeddingGenerationException e) {
+            throw e;
+        } catch (RestClientException e) {
+            throw new QueryEmbeddingGenerationException("OpenAI 임베딩 호출에 실패했습니다.", e);
+        } catch (RuntimeException e) {
+            throw new QueryEmbeddingGenerationException("임베딩 생성에 실패했습니다.", e);
+        }
+    }
+
+    private List<Double> extractEmbedding(JsonNode responseBody) {
+        if (responseBody == null || responseBody.isNull()) {
+            throw new QueryEmbeddingGenerationException("임베딩 응답이 비어있습니다.");
+        }
+
+        JsonNode data = responseBody.get("data");
+        if (data == null || !data.isArray() || data.isEmpty()) {
+            throw new QueryEmbeddingGenerationException("임베딩 응답에 data가 없습니다.");
+        }
+
+        JsonNode firstItem = data.get(0);
+        JsonNode embeddingNode = firstItem.get("embedding");
+        if (embeddingNode == null || !embeddingNode.isArray() || embeddingNode.isEmpty()) {
+            throw new QueryEmbeddingGenerationException("임베딩 응답에 embedding 값이 없습니다.");
+        }
+
+        List<Double> embedding = new ArrayList<>();
+        for (JsonNode valueNode : embeddingNode) {
+            if (!valueNode.isNumber()) {
+                throw new QueryEmbeddingGenerationException("임베딩 응답 형식이 올바르지 않습니다.");
+            }
+            embedding.add(valueNode.doubleValue());
+        }
+
+        return embedding;
+    }
+
+    private record EmbeddingRequest(
+            String model,
+            String input
+    ) {
+
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/StubQueryEmbeddingGenerator.java
@@ -1,9 +1,11 @@
 package com.generic4.itda.service.recommend.scoring;
 
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(prefix = "ai.embedding", name = "enabled", havingValue = "false", matchIfMissing = true)
 public class StubQueryEmbeddingGenerator implements QueryEmbeddingGenerator {
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,12 @@ ai:
     api-key: ${AI_BRIEF_API_KEY:}
     model: ${AI_BRIEF_MODEL:gpt-5-mini}
     max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:4000}
+  embedding:
+    enabled: true
+    api-url: https://api.openai.com/v1/embeddings
+    api-key: ${OPENAI_API_KEY}
+    model: text-embedding-3-small
+    timeout-millis: 5000
 
 app:
   seed:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ ai:
     model: ${AI_BRIEF_MODEL:gpt-5-mini}
     max-output-tokens: ${AI_BRIEF_MAX_OUTPUT_TOKENS:4000}
   embedding:
-    enabled: true
+    enabled: ${AI_EMBEDDING_ENABLED:false}
     api-url: https://api.openai.com/v1/embeddings
     api-key: ${OPENAI_API_KEY}
     model: text-embedding-3-small

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -24,12 +25,21 @@ import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.ResumeStatus;
 import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.exception.QueryEmbeddingGenerationException;
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.scoring.CareerAdjustmentCalculator;
+import com.generic4.itda.service.recommend.scoring.CosineSimilarityCalculator;
 import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
+import com.generic4.itda.service.recommend.scoring.QueryEmbeddingGenerator;
+import com.generic4.itda.service.recommend.scoring.RecommendationQueryTextGenerator;
+import com.generic4.itda.service.recommend.scoring.ResumeEmbeddingReader;
+import com.generic4.itda.service.recommend.scoring.SkillAdjustmentCalculator;
 import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
 import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -58,6 +68,27 @@ class RecommendationRunProcessorTest {
 
     @Mock
     private RecommendationResultCreator recommendationResultCreator;
+
+    @Mock
+    private RecommendationQueryTextGenerator recommendationQueryTextGenerator;
+
+    @Mock
+    private AiEmbeddingProperties aiEmbeddingProperties;
+
+    @Mock
+    private QueryEmbeddingGenerator queryEmbeddingGenerator;
+
+    @Mock
+    private ResumeEmbeddingReader resumeEmbeddingReader;
+
+    @Mock
+    private CosineSimilarityCalculator cosineSimilarityCalculator;
+
+    @Mock
+    private SkillAdjustmentCalculator skillAdjustmentCalculator;
+
+    @Mock
+    private CareerAdjustmentCalculator careerAdjustmentCalculator;
 
     @InjectMocks
     private RecommendationRunProcessor recommendationRunProcessor;
@@ -166,6 +197,164 @@ class RecommendationRunProcessorTest {
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("하드 필터 계산 실패");
         then(recommendationScorer).shouldHaveNoInteractions();
+        then(recommendationResultCreator).shouldHaveNoInteractions();
+        then(recommendationResultRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("후보가 존재하고 query embedding 생성이 성공하면 scorer 실경로를 거쳐 결과를 저장하고 COMPUTED 상태가 된다")
+    void query_embedding_생성이_성공하면_scorer_실경로를_거쳐_정상_완료된다() {
+        ProposalPosition proposalPosition = createProposalPositionWithSkills();
+        RecommendationRun run = createRun(proposalPosition, true);
+        RecommendationRunProcessor processorWithRealScorer = createProcessorWithRealScorer();
+
+        List<RecommendationCandidate> candidates = List.of(
+                createCandidate(101L, 3,
+                        createCandidateSkill(1L, "Java", Proficiency.ADVANCED),
+                        createCandidateSkill(2L, "Spring", Proficiency.INTERMEDIATE))
+        );
+        List<Double> queryEmbedding = List.of(0.1, 0.9);
+        List<Double> resumeEmbedding = List.of(0.8, 0.2);
+        List<RecommendationResult> results = List.of(org.mockito.Mockito.mock(RecommendationResult.class));
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationQueryTextGenerator.generate(
+                proposalPosition.getProposal(),
+                proposalPosition,
+                Set.of("Java"),
+                Set.of("Spring")
+        )).willReturn("query text");
+        given(aiEmbeddingProperties.getModel()).willReturn("text-embedding-3-small");
+        given(queryEmbeddingGenerator.generate("query text"))
+                .willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(101L), "text-embedding-3-small"))
+                .willReturn(Map.of(101L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding))
+                .willReturn(0.4);
+        given(skillAdjustmentCalculator.calculate(anySet(), anySet(), anySet()))
+                .willReturn(0.1);
+        given(careerAdjustmentCalculator.calculate(anyInt(), any(), any()))
+                .willReturn(0.08);
+        given(recommendationResultCreator.create(
+                any(),
+                anyList(),
+                anyInt(),
+                anySet()
+        )).willReturn(results);
+
+        assertThatCode(() -> processorWithRealScorer.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(run.getErrorMessage()).isNull();
+        assertThat(run.getHardFilterStats()).isEqualTo(new HardFilterStat(1, 1));
+        assertThat(run.getCandidateCount()).isEqualTo(1);
+        then(queryEmbeddingGenerator).should().generate("query text");
+        then(recommendationResultCreator).should().create(
+                eq(run),
+                anyList(),
+                anyInt(),
+                anySet()
+        );
+        then(recommendationResultRepository).should().saveAll(results);
+    }
+
+    @Test
+    @DisplayName("query embedding 생성 중 예외가 발생하면 FAILED 상태로 전이하고 결과를 저장하지 않는다")
+    void query_embedding_생성_실패시_FAILED_처리하고_결과를_저장하지_않는다() {
+        ProposalPosition proposalPosition = createProposalPositionWithSkills();
+        RecommendationRun run = createRun(proposalPosition, true);
+        RecommendationRunProcessor processorWithRealScorer = createProcessorWithRealScorer();
+
+        List<RecommendationCandidate> candidates = List.of(
+                createCandidate(101L, 3,
+                        createCandidateSkill(1L, "Java", Proficiency.ADVANCED))
+        );
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationQueryTextGenerator.generate(
+                proposalPosition.getProposal(),
+                proposalPosition,
+                Set.of("Java"),
+                Set.of("Spring")
+        )).willReturn("query text");
+        given(aiEmbeddingProperties.getModel()).willReturn("text-embedding-3-small");
+        given(queryEmbeddingGenerator.generate("query text"))
+                .willThrow(new QueryEmbeddingGenerationException("임베딩 실패"));
+
+        assertThatCode(() -> processorWithRealScorer.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("임베딩 실패");
+        then(recommendationResultCreator).shouldHaveNoInteractions();
+        then(recommendationResultRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("scorer 내부 예외가 발생하면 FAILED 상태로 전이하고 결과를 저장하지 않는다")
+    void scorer_내부_예외가_발생하면_FAILED_처리하고_결과를_저장하지_않는다() {
+        RecommendationRun run = createRun(true);
+
+        List<RecommendationCandidate> candidates = List.of(
+                createCandidate(10L, 3,
+                        createCandidateSkill(1L, "Java", Proficiency.ADVANCED))
+        );
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                anyList()
+        )).willThrow(new RuntimeException("scorer 계산 실패"));
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("scorer 계산 실패");
+        then(recommendationResultCreator).shouldHaveNoInteractions();
+        then(recommendationResultRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("scorer 예외 메시지가 없으면 기본 실패 메시지로 FAILED 처리한다")
+    void scorer_예외_메시지가_없으면_기본_실패_메시지로_FAILED_처리한다() {
+        RecommendationRun run = createRun(true);
+
+        List<RecommendationCandidate> candidates = List.of(
+                createCandidate(10L, 3,
+                        createCandidateSkill(1L, "Java", Proficiency.ADVANCED))
+        );
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                anyList()
+        )).willThrow(new RuntimeException());
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
         then(recommendationResultCreator).shouldHaveNoInteractions();
         then(recommendationResultRepository).shouldHaveNoInteractions();
     }
@@ -377,5 +566,25 @@ class RecommendationRunProcessorTest {
             Proficiency proficiency
     ) {
         return new RecommendationCandidate.CandidateSkill(skillId, skillName, proficiency);
+    }
+
+    private RecommendationRunProcessor createProcessorWithRealScorer() {
+        HeuristicV1RecommendationScorer realScorer = new HeuristicV1RecommendationScorer(
+                aiEmbeddingProperties,
+                recommendationQueryTextGenerator,
+                queryEmbeddingGenerator,
+                resumeEmbeddingReader,
+                cosineSimilarityCalculator,
+                skillAdjustmentCalculator,
+                careerAdjustmentCalculator
+        );
+
+        return new RecommendationRunProcessor(
+                recommendationRunRepository,
+                recommendationResultRepository,
+                recommendationCandidateFinder,
+                realScorer,
+                recommendationResultCreator
+        );
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -138,6 +138,32 @@ class HeuristicV1RecommendationScorerTest {
         verify(careerAdjustmentCalculator).calculate(7, 5, 8);
     }
 
+    @Test
+    @DisplayName("명시적 embeddingModel을 전달하면 properties가 아닌 전달된 모델로 reader를 호출한다")
+    void score_UsesExplicitEmbeddingModel_NotProperties_WhenModelParamIsPassed() {
+        // given
+        String customModel = "custom-model-v1";
+        RecommendationScorableCandidate candidate = candidateWith(100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.2, 0.8);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(List.of(100L), customModel))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(any(), any())).willReturn(0.0);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.0);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.0);
+
+        // when
+        scorer.score(proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), customModel);
+
+        // then
+        verify(resumeEmbeddingReader).readEmbeddingsByResumeIds(List.of(100L), customModel);
+        verify(properties, never()).getModel();
+    }
+
     // -------------------------------------------------------------------------
     // 시나리오 1: 빈 후보 리스트
     // -------------------------------------------------------------------------
@@ -185,6 +211,9 @@ class HeuristicV1RecommendationScorerTest {
 
         // then
         assertThat(result).isEmpty();
+        verify(cosineSimilarityCalculator, never()).calculate(any(), any());
+        verify(skillAdjustmentCalculator, never()).calculate(any(), any(), any());
+        verify(careerAdjustmentCalculator, never()).calculate(any(int.class), any(), any());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
@@ -28,6 +29,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("HeuristicV1RecommendationScorer 단위 테스트")
 class HeuristicV1RecommendationScorerTest {
+
+    @Mock
+    private AiEmbeddingProperties properties;
 
     @Mock
     private RecommendationQueryTextGenerator recommendationQueryTextGenerator;
@@ -85,6 +89,7 @@ class HeuristicV1RecommendationScorerTest {
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.2, 0.8);
 
+        given(properties.getModel()).willReturn(EMBEDDING_MODEL);
         given(proposalPosition.getCareerMinYears()).willReturn(5);
         given(proposalPosition.getCareerMaxYears()).willReturn(8);
         given(recommendationQueryTextGenerator.generate(

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGeneratorLiveTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGeneratorLiveTest.java
@@ -1,0 +1,53 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * OpenAiQueryEmbeddingGenerator 실제 API 연동 검증 테스트
+ * <p>
+ * [실행 전 필수 조건] 1. 환경 변수 또는 설정 파일에 아래 값이 반드시 설정되어야 합니다: - OPENAI_API_KEY=sk-... (OpenAI API 키)
+ * <p>
+ * 2. 실행 방법 (예시): OPENAI_API_KEY=sk-xxx ./gradlew test --tests "*.OpenAiQueryEmbeddingGeneratorLiveTest"
+ * <p>
+ * [주의 사항] - 실제 OpenAI API를 호출하므로 API 비용이 발생합니다. - CI/CD 파이프라인에서는 실행되지 않도록 @Disabled가 유지되어야 합니다.
+ */
+@Disabled("OpenAI 실제 API 호출 테스트 (수동 실행 전용)")
+@IntegrationTest
+@TestPropertySource(properties = {
+        "ai.embedding.enabled=true",
+        "ai.embedding.model=text-embedding-3-small",
+        "ai.embedding.api-key=${OPENAI_API_KEY:}"
+})
+@DisplayName("OpenAiQueryEmbeddingGenerator 실제 API 연동 테스트")
+class OpenAiQueryEmbeddingGeneratorLiveTest {
+
+    @Autowired
+    private OpenAiQueryEmbeddingGenerator generator;
+
+    @Test
+    @DisplayName("실제 OpenAI API 호출 시 embedding 벡터를 정상적으로 반환한다")
+    void generate_실제API호출_embedding벡터반환() {
+        // given
+        String queryText = "Java Spring backend developer with PostgreSQL experience";
+
+        // when
+        List<Double> embedding = generator.generate(queryText);
+
+        // then
+        assertThat(embedding).isNotNull();
+        assertThat(embedding).isNotEmpty();
+        assertThat(embedding).allSatisfy(value ->
+                assertThat(value).isInstanceOf(Double.class)
+        );
+
+        System.out.println("embedding size = " + embedding.size());
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/OpenAiQueryEmbeddingGeneratorTest.java
@@ -1,0 +1,233 @@
+package com.generic4.itda.service.recommend.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
+import com.generic4.itda.exception.QueryEmbeddingGenerationException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * OpenAiQueryEmbeddingGenerator 단위 테스트
+ *
+ * [mocking 전략]
+ * RestClient fluent chain 전체를 mock하는 방식은 Spring 6.2 + Mockito 5 조합에서
+ * 오버로드 충돌(body/uri vararg)로 불안정하다.
+ *
+ * 대신 Spring이 공식 제공하는 MockRestServiceServer를 사용한다.
+ * - 실제 RestClient.Builder에 바인딩하여 HTTP 레이어만 가로챔
+ * - fluent chain 자체는 실제로 동작하므로 chain mocking 문제 없음
+ * - 프로덕션 코드와 동일한 직렬화/역직렬화 경로를 검증 가능
+ */
+@DisplayName("OpenAiQueryEmbeddingGenerator 단위 테스트")
+class OpenAiQueryEmbeddingGeneratorTest {
+
+    private static final String API_URL = "https://api.openai.com/v1/embeddings";
+
+    private MockRestServiceServer mockServer;
+    private OpenAiQueryEmbeddingGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+
+        AiEmbeddingProperties properties = new AiEmbeddingProperties();
+        properties.setApiKey("test-api-key");
+        properties.setApiUrl(API_URL);
+        properties.setModel("text-embedding-3-small");
+
+        generator = new OpenAiQueryEmbeddingGenerator(builder, properties);
+    }
+
+    @Nested
+    @DisplayName("generate() - 정상 경로")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("정상 응답이면 embedding 리스트를 반환한다")
+        void generate_정상응답_embeddingList반환() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                              "data": [
+                                {
+                                  "embedding": [0.12, -0.34, 0.56]
+                                }
+                              ]
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            List<Double> result = generator.generate("some text");
+
+            // then
+            assertThat(result).containsExactly(0.12, -0.34, 0.56);
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("embedding 값이 정수형이어도 Double로 반환한다")
+        void generate_정수형embedding_Double반환() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess(
+                            "{\"data\": [{\"embedding\": [1, 2, 3]}]}",
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // when
+            List<Double> result = generator.generate("query");
+
+            // then
+            assertThat(result).containsExactly(1.0, 2.0, 3.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("generate() - 입력 검증")
+    class InputValidationTest {
+
+        @Test
+        @DisplayName("queryText가 null이면 IllegalArgumentException이 발생한다")
+        void generate_nullQueryText_예외발생() {
+            assertThatThrownBy(() -> generator.generate(null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("queryText가 빈 문자열이면 IllegalArgumentException이 발생한다")
+        void generate_emptyQueryText_예외발생() {
+            assertThatThrownBy(() -> generator.generate(""))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("queryText가 blank이면 IllegalArgumentException이 발생한다")
+        void generate_blankQueryText_예외발생() {
+            assertThatThrownBy(() -> generator.generate("   "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("generate() - 응답 오류 처리")
+    class ResponseErrorTest {
+
+        @Test
+        @DisplayName("응답 body가 비어 있으면 QueryEmbeddingGenerationException을 던진다")
+        void generate_emptyResponseBody_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("비어있습니다");
+        }
+
+        @Test
+        @DisplayName("응답에 data 필드가 없으면 QueryEmbeddingGenerationException을 던진다")
+        void generate_dataFieldMissing_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("data");
+        }
+
+        @Test
+        @DisplayName("응답 data가 빈 배열이면 QueryEmbeddingGenerationException을 던진다")
+        void generate_dataEmpty_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess("{\"data\": []}", MediaType.APPLICATION_JSON));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("data");
+        }
+
+        @Test
+        @DisplayName("첫 번째 data item에 embedding 필드가 없으면 QueryEmbeddingGenerationException을 던진다")
+        void generate_embeddingFieldMissing_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess("{\"data\": [{}]}", MediaType.APPLICATION_JSON));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("embedding");
+        }
+
+        @Test
+        @DisplayName("embedding 배열이 비어 있으면 QueryEmbeddingGenerationException을 던진다")
+        void generate_embeddingEmpty_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess(
+                            "{\"data\": [{\"embedding\": []}]}",
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("embedding");
+        }
+
+        @Test
+        @DisplayName("embedding 배열에 숫자가 아닌 값이 있으면 QueryEmbeddingGenerationException을 던진다")
+        void generate_nonNumericEmbedding_예외던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withSuccess(
+                            "{\"data\": [{\"embedding\": [0.12, \"not-a-number\", 0.56]}]}",
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class)
+                    .hasMessageContaining("형식");
+        }
+    }
+
+    @Nested
+    @DisplayName("generate() - 외부 호출 예외 처리")
+    class ExternalCallErrorTest {
+
+        @Test
+        @DisplayName("서버 5xx 응답이면 QueryEmbeddingGenerationException으로 감싸서 던진다")
+        void generate_서버오류응답_감싸서던짐() {
+            // given
+            mockServer.expect(requestTo(API_URL))
+                    .andRespond(withServerError());
+
+            // when/then
+            assertThatThrownBy(() -> generator.generate("some text"))
+                    .isInstanceOf(QueryEmbeddingGenerationException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 What

추천 실행 시 query embedding stub으로 인해 실패하던 문제를 해결하고,
실제 OpenAI 기반 임베딩 생성과 scorer 연동을 통해 추천 계산 흐름을 정상화했습니다.

* `QueryEmbeddingGenerator` stub 제거 및 실제 구현(`OpenAiQueryEmbeddingGenerator`) 적용
* `RecommendationQueryTextGenerator` → query embedding → scorer까지 연결
* scorer의 embedding model을 설정값(`AiEmbeddingProperties`) 기반으로 변경
* `ResumeEmbedding`과의 모델 호환성 검증 로직 테스트로 고정
* query embedding 생성 실패 시 fallback 없이 `run FAILED`로 처리하도록 정책 확정
* `RecommendationRunProcessor` 테스트 보강 (정상/실패 경로 모두 검증)
* scorer 테스트 보강 (모델 일치/불일치 및 후보 제외 동작 검증)
* OpenAI 실제 연동 검증용 live 테스트 추가 (`@Disabled`)

---

## 🔗 Issue

* Closes: #84 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
