### PR TITLE
[Feat] 제안서 상세보기 화면 구현 (Client/Freelancer 공용)

### DIFF
--- a/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
+++ b/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
@@ -1,5 +1,7 @@
 package com.generic4.itda.config;
 
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
@@ -17,6 +19,7 @@ import com.generic4.itda.domain.resume.ResumeStatus;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
@@ -59,6 +62,7 @@ public class SeedDataInitializer implements ApplicationRunner {
     private final SkillRepository skillRepository;
     private final ResumeRepository resumeRepository;
     private final ProposalRepository proposalRepository;
+    private final MatchingRepository matchingRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Value("${app.seed.default-password:demo1234}")
@@ -202,12 +206,12 @@ public class SeedDataInitializer implements ApplicationRunner {
                 추천 설명, 필터링, 결과 비교 흐름까지 한 번에 다듬을 수 있는 팀이 필요합니다.
                 """,
                 "추천 엔진 MVP를 운영 가능한 수준으로 끌어올리는 고도화 프로젝트",
-                19_500_000L,
-                25_500_000L,
+                19_000_000L,
+                25_000_000L,
                 16L,
                 true
         );
-        ensureProposalPosition(
+        ProposalPosition backendPos1 = ensureProposalPosition(
                 matchingProposal,
                 positions.get("백엔드 개발자"),
                 "추천 API 백엔드 개발자",
@@ -227,27 +231,7 @@ public class SeedDataInitializer implements ApplicationRunner {
                 ),
                 skills
         );
-        ensureProposalPosition(
-                matchingProposal,
-                positions.get("백엔드 개발자"),
-                "LLM 워크플로 백엔드 개발자",
-                ProposalWorkType.REMOTE,
-                1L,
-                6_500_000L,
-                8_500_000L,
-                12L,
-                3,
-                6,
-                null,
-                skillRequirements(
-                        skillRequirement("Java", ProposalPositionSkillImportance.ESSENTIAL),
-                        skillRequirement("Spring", ProposalPositionSkillImportance.ESSENTIAL),
-                        skillRequirement("Docker", ProposalPositionSkillImportance.PREFERENCE),
-                        skillRequirement("Redis", ProposalPositionSkillImportance.PREFERENCE)
-                ),
-                skills
-        );
-        ensureProposalPosition(
+        ProposalPosition aiPos = ensureProposalPosition(
                 matchingProposal,
                 positions.get("AI 엔지니어"),
                 "추천 모델/프롬프트 AI 엔지니어",
@@ -300,11 +284,21 @@ public class SeedDataInitializer implements ApplicationRunner {
                 skills
         );
 
+        // ── Matching 시드 ────────────────────────────────────
+        // matchingProposal의 포지션에 프리랜서 매칭 이력 생성
+        // → seed.backend / seed.ai 로그인 시 해당 제안서 상세 페이지 접근 가능
+        Resume backendResume = resumeRepository.findByMemberId(backend.getId()).orElseThrow();
+        Resume aiResume      = resumeRepository.findByMemberId(aiEngineer.getId()).orElseThrow();
+
+        ensureMatching(backendResume, backendPos1, client, backend,    MatchingStatus.PROPOSED);
+        ensureMatching(aiResume,      aiPos,       client, aiEngineer, MatchingStatus.ACCEPTED);
+
         log.info(
                 """
                 Seed data is ready.
                 Seed client email={} matchingProposalId={} writingProposalId={}
                 Seed freelancer emails=[{}, {}, {}, {}]
+                Matching seeds: backend→backendPos1(PROPOSED), ai→aiPos(ACCEPTED)
                 """,
                 client.getEmail().getValue(),
                 matchingProposal.getId(),
@@ -423,6 +417,9 @@ public class SeedDataInitializer implements ApplicationRunner {
             boolean matching
     ) {
         Proposal proposal = proposalRepository.findByMemberIdAndTitle(member.getId(), title)
+                // Proposal.positions is LAZY. To make the seed idempotent we must ensure positions are loaded,
+                // otherwise `proposal.getPositions()` may look empty and we would try to insert duplicates.
+                .map(existing -> proposalRepository.findWithPositionsById(existing.getId()).orElse(existing))
                 .orElseGet(() -> proposalRepository.save(
                         Proposal.create(
                                 member,
@@ -502,14 +499,51 @@ public class SeedDataInitializer implements ApplicationRunner {
             proposalPosition.addSkill(skill, requirement.importance());
         }
 
-        proposalRepository.save(proposal);
-        return proposalPosition;
+        // ProposalPosition은 Proposal에 의해 생성되지만, Matching 생성 시점에는 proposalPosition.id가 필요하다.
+        // saveAndFlush가 merge로 동작하면 반환된 엔티티가 영속 상태가 되므로,
+        // 반환값 기준으로 다시 ProposalPosition을 찾아 id가 채워진 인스턴스를 리턴한다.
+        Proposal savedProposal = proposalRepository.saveAndFlush(proposal);
+        Proposal hydrated = proposalRepository.findWithPositionsById(savedProposal.getId()).orElse(savedProposal);
+
+        return hydrated.getPositions().stream()
+                .filter(existing -> hasSamePositionIdentity(existing, position, title))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("시드 포지션 저장에 실패했습니다. proposalId=" + savedProposal.getId()));
     }
 
     private boolean hasSamePositionIdentity(ProposalPosition existing, Position position, String title) {
-        return existing.getPosition().getId() != null && position.getId() != null
+        boolean samePosition = existing.getPosition().getId() != null && position.getId() != null
                 ? existing.getPosition().getId().equals(position.getId())
                 : existing.getPosition().getName().equals(position.getName());
+        // DB unique constraint is (proposal_id, position_id). One proposal cannot contain multiple
+        // ProposalPositions with the same Position, so treat "same Position" as identity and update
+        // the rest of fields (title, budgets, skills...) in-place.
+        return samePosition;
+    }
+
+    private Matching ensureMatching(
+            Resume resume,
+            ProposalPosition proposalPosition,
+            Member clientMember,
+            Member freelancerMember,
+            MatchingStatus desiredStatus
+    ) {
+        Matching matching = matchingRepository
+                .findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(
+                        proposalPosition.getProposal().getId(),
+                        freelancerMember.getEmail().getValue())
+                .stream()
+                .filter(m -> m.getProposalPosition().getId().equals(proposalPosition.getId()))
+                .findFirst()
+                .orElseGet(() -> matchingRepository.save(
+                        Matching.create(resume, proposalPosition, clientMember, freelancerMember)
+                ));
+
+        // 저장된 매칭 상태가 PROPOSED이고 원하는 상태가 ACCEPTED인 경우 수락 처리
+        if (matching.getStatus() == MatchingStatus.PROPOSED && desiredStatus == MatchingStatus.ACCEPTED) {
+            matching.accept();
+        }
+        return matching;
     }
 
     private Position ensurePosition(String name) {

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -124,6 +124,7 @@ public class ProposalController {
             return "redirect:/";
         } catch (AccessDeniedException ignored) {
             // 소유자가 아닌 경우 → 프리랜서 접근 시도
+            return "redirect:/";
         }
 
         // 2) 프리랜서(매칭 이력 기반) 접근 시도

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -124,7 +124,6 @@ public class ProposalController {
             return "redirect:/";
         } catch (AccessDeniedException ignored) {
             // 소유자가 아닌 경우 → 프리랜서 접근 시도
-            return "redirect:/";
         }
 
         // 2) 프리랜서(매칭 이력 기반) 접근 시도

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -1,6 +1,8 @@
 package com.generic4.itda.controller;
 
+import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.AiInterviewMessageResponse;
@@ -8,13 +10,16 @@ import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.ProposalService;
 import jakarta.validation.Valid;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
@@ -42,6 +47,7 @@ public class ProposalController {
     private final ProposalService proposalService;
     private final ProposalAiInterviewService proposalAiInterviewService;
     private final PositionRepository positionRepository;
+    private final MatchingRepository matchingRepository;
 
     @GetMapping("/new")
     public String newForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
@@ -106,17 +112,52 @@ public class ProposalController {
             Model model,
             RedirectAttributes redirectAttributes
     ) {
+        // 1) 클라이언트(소유자) 접근 시도
         try {
             Proposal proposal = proposalService.findOwnedProposal(proposalId, principal.getEmail());
             model.addAttribute("proposal", proposal);
+            model.addAttribute("viewerRole", "CLIENT");
             addMemberAttributes(model, principal);
             return "client/proposalDetail";
         } catch (ProposalNotFoundException e) {
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
-            return "redirect:/client/dashboard";
+            return "redirect:/";
+        } catch (AccessDeniedException ignored) {
+            // 소유자가 아닌 경우 → 프리랜서 접근 시도
+        }
+
+        // 2) 프리랜서(매칭 이력 기반) 접근 시도
+        // - findOwnedProposal에서 AccessDeniedException이 났다는 것은 제안서가 존재한다는 의미
+        //   이므로 ProposalNotFoundException은 실질적으로 발생하지 않지만 방어적으로 처리
+        try {
+            Proposal proposal = proposalService.findProposalForFreelancer(proposalId, principal.getEmail());
+
+            List<Matching> myMatchings = matchingRepository
+                    .findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(
+                            proposalId, principal.getEmail());
+            Map<Long, Matching> matchingByPositionId = myMatchings.stream()
+                    .collect(Collectors.toMap(
+                            m -> m.getProposalPosition().getId(),
+                            m -> m,
+                            (a, b) -> a)); // 포지션당 첫 번째 매칭 유지
+
+            // 프리랜서가 제안받은 포지션만 뷰에 노출
+            List<ProposalPosition> proposedPositions = proposal.getPositions().stream()
+                    .filter(pos -> matchingByPositionId.containsKey(pos.getId()))
+                    .toList();
+
+            model.addAttribute("proposal", proposal);
+            model.addAttribute("viewerRole", "FREELANCER");
+            model.addAttribute("matchingByPositionId", matchingByPositionId);
+            model.addAttribute("proposedPositions", proposedPositions);
+            addMemberAttributes(model, principal);
+            return "client/proposalDetail";
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+            return "redirect:/";
         } catch (AccessDeniedException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 조회할 수 있습니다.");
-            return "redirect:/client/dashboard";
+            redirectAttributes.addFlashAttribute("errorMessage", "접근 권한이 없는 제안서입니다.");
+            return "redirect:/";
         }
     }
 

--- a/src/main/java/com/generic4/itda/domain/matching/Matching.java
+++ b/src/main/java/com/generic4/itda/domain/matching/Matching.java
@@ -61,4 +61,18 @@ public class Matching extends BaseTimeEntity {
                 .status(MatchingStatus.PROPOSED)
                 .build();
     }
+
+    public void accept() {
+        if (this.status != MatchingStatus.PROPOSED) {
+            throw new IllegalStateException("제안 상태의 매칭만 수락할 수 있습니다.");
+        }
+        this.status = MatchingStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        if (this.status != MatchingStatus.PROPOSED) {
+            throw new IllegalStateException("제안 상태의 매칭만 거절할 수 있습니다.");
+        }
+        this.status = MatchingStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
+++ b/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
@@ -18,14 +18,6 @@ public record FreelancerDashboardItem(
 ) {
 
     /**
-     * Dashboard 뷰에서 스킬 태그 렌더링을 위해 사용하는 접근자.
-     * 현재 dashboard 조회 쿼리는 스킬을 포함하지 않으므로 기본값은 빈 리스트로 둔다.
-     */
-    public List<String> skillNames() {
-        return List.of();
-    }
-
-    /**
      * Thymeleaf 템플릿에서 `item.status()` 형태로 호출하고 있어 호환을 위해 제공한다.
      */
     public DashboardProposalStatus status() {

--- a/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
+++ b/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
@@ -4,6 +4,7 @@ import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record FreelancerDashboardItem(
         Long proposalId,
@@ -15,6 +16,21 @@ public record FreelancerDashboardItem(
         Long budgetMax,
         LocalDateTime receivedAt
 ) {
+
+    /**
+     * Dashboard 뷰에서 스킬 태그 렌더링을 위해 사용하는 접근자.
+     * 현재 dashboard 조회 쿼리는 스킬을 포함하지 않으므로 기본값은 빈 리스트로 둔다.
+     */
+    public List<String> skillNames() {
+        return List.of();
+    }
+
+    /**
+     * Thymeleaf 템플릿에서 `item.status()` 형태로 호출하고 있어 호환을 위해 제공한다.
+     */
+    public DashboardProposalStatus status() {
+        return getStatus();
+    }
 
     public DashboardProposalStatus getStatus() {
         if (this.matchingStatus == null) return DashboardProposalStatus.NEW;

--- a/src/main/java/com/generic4/itda/repository/MatchingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepository.java
@@ -3,6 +3,7 @@ package com.generic4.itda.repository;
 import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
@@ -10,4 +11,8 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     boolean existsByProposalPosition_Proposal_Id(Long proposalId);
 
     boolean existsByProposalPosition_Proposal_IdAndStatusIn(Long proposalId, Collection<MatchingStatus> statuses);
+
+    boolean existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
+
+    List<Matching> findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
 }

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -176,6 +176,19 @@ public class ProposalService {
     }
 
     @Transactional(readOnly = true)
+    public Proposal findProposalForFreelancer(Long proposalId, String freelancerEmail) {
+        boolean hasAccess = matchingRepository.existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(
+                proposalId, freelancerEmail);
+        if (!hasAccess) {
+            throw new AccessDeniedException("매칭 이력이 없는 제안서입니다.");
+        }
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+        proposalRepository.findPositionsWithSkillsByProposalId(proposalId);
+        return proposal;
+    }
+
+    @Transactional(readOnly = true)
     public ProposalForm findOwnedProposalForm(Long proposalId, String memberEmail) {
         Proposal proposal = findOwnedProposal(proposalId, memberEmail);
         return ProposalForm.from(proposal);

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -139,16 +139,12 @@
                             th:attr="data-href=@{/proposals/{id}(id=${project.proposalId})}"
                             class="project-row cursor-pointer transition hover:bg-slate-50/70">
                             <td class="px-8 py-7">
-                                <div class="max-w-[320px]">
-                                    <p class="text-xl font-black tracking-tight text-slate-900" th:text="${project.title}">
-                                        AI 프리랜서 추천 플랫폼 고도화
-                                    </p>
-                                    <p class="mt-2 text-xs font-semibold uppercase tracking-widest text-slate-400"
-                                       th:text="'Proposal #' + ${project.proposalId}">
-                                        Proposal #1
-                                    </p>
-                                </div>
-                            </td>
+                                 <div class="max-w-[320px]">
+                                     <p class="text-xl font-black tracking-tight text-slate-900" th:text="${project.title}">
+                                         AI 프리랜서 추천 플랫폼 고도화
+                                     </p>
+                                 </div>
+                             </td>
                             <td class="px-6 py-7">
                                 <span th:classappend="${
                                         project.statusKey == 'WRITING' ? 'border-slate-200 bg-slate-100 text-slate-600' :

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -1,0 +1,448 @@
+﻿<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${proposal.title} + ' | IT-da'">제안서 상세 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-5xl">
+
+            
+            <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+
+                    <div class="flex items-center gap-4">
+                        
+                        <a th:if="${viewerRole == 'CLIENT'}" th:href="@{/client/dashboard}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            대시보드로
+                        </a>
+                        <a th:if="${viewerRole == 'FREELANCER'}" th:href="@{/freelancers/dashboard}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            대시보드로
+                        </a>
+
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">PROPOSAL DETAIL</p>
+                            <h2 class="mt-1 text-2xl font-black tracking-tight text-slate-950 sm:text-3xl"
+                                th:text="${proposal.title}">제안서 제목</h2>
+                        </div>
+                    </div>
+
+                     <div class="flex items-center gap-3">
+                        
+                        <th:block th:if="${viewerRole == 'CLIENT'}">
+                            
+                            <a th:if="${proposal.status.name() == 'WRITING'}"
+                               th:href="@{/proposals/{id}/edit(id=${proposal.id})}"
+                               class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                <i data-lucide="pencil" class="h-4 w-4"></i>
+                                제안서 수정
+                            </a>
+                            
+                            <a th:if="${proposal.status.name() == 'MATCHING'}"
+                               th:href="@{/proposals/{id}/recommendations(id=${proposal.id})}"
+                               class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                                <i data-lucide="sparkles" class="h-4 w-4"></i>
+                                추천 결과 보기
+                            </a>
+                            
+                            <span th:if="${proposal.status.name() == 'COMPLETE'}"
+                                  class="inline-flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-sm font-bold text-emerald-600">
+                                <i data-lucide="badge-check" class="h-4 w-4"></i>
+                                완료된 프로젝트
+                            </span>
+                        </th:block>
+
+                         
+                         <th:block th:if="${viewerRole == 'FREELANCER'}">
+                             
+                             <th:block th:if="${proposedPositions != null and !#lists.isEmpty(proposedPositions)}">
+                                 
+                                 <th:block th:if="${#lists.size(proposedPositions) == 1}"
+                                           th:with="pos=${proposedPositions[0]}, myMatching=${matchingByPositionId != null ? matchingByPositionId[proposedPositions[0].id] : null}">
+                                     <th:block th:if="${myMatching != null and myMatching.status.name() == 'PROPOSED'}">
+                                         <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
+                                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                             <button type="submit"
+                                                     class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                                                 <i data-lucide="check" class="h-4 w-4"></i>
+                                                 수락하기
+                                             </button>
+                                         </form>
+                                         <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
+                                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                             <button type="submit"
+                                                     class="inline-flex items-center gap-2 rounded-2xl border border-red-200 bg-white px-5 py-3 text-sm font-bold text-red-500 transition hover:bg-red-50">
+                                                 <i data-lucide="x" class="h-4 w-4"></i>
+                                                 거절하기
+                                             </button>
+                                         </form>
+                                     </th:block>
+                                 </th:block>
+
+                                 
+                                 <th:block th:if="${#lists.size(proposedPositions) > 1}">
+                                     <div class="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm">
+                                         <p class="text-xs font-black uppercase tracking-widest text-slate-400">응답할 포지션</p>
+                                         <div class="flex flex-col gap-2">
+                                             <th:block th:each="pos : ${proposedPositions}"
+                                                       th:with="myMatching=${matchingByPositionId != null ? matchingByPositionId[pos.id] : null}">
+                                                 <div th:if="${myMatching != null and myMatching.status.name() == 'PROPOSED'}"
+                                                      class="flex flex-wrap items-center justify-between gap-2">
+                                                     <span class="text-sm font-bold text-slate-700" th:text="${pos.title}">포지션</span>
+                                                     <div class="flex items-center gap-2">
+                                                         <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
+                                                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                             <button type="submit"
+                                                                     class="inline-flex items-center gap-1.5 rounded-xl bg-blue-600 px-3 py-2 text-xs font-bold text-white transition hover:bg-blue-700">
+                                                                 수락
+                                                             </button>
+                                                         </form>
+                                                         <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
+                                                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                             <button type="submit"
+                                                                     class="inline-flex items-center gap-1.5 rounded-xl border border-red-200 bg-white px-3 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
+                                                                 거절
+                                                             </button>
+                                                         </form>
+                                                     </div>
+                                                 </div>
+                                             </th:block>
+                                         </div>
+                                     </div>
+                                 </th:block>
+                             </th:block>
+                         </th:block>
+                     </div>
+                 </div>
+             </div>
+
+            
+            <section class="fade-up relative mb-6 rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70"
+                     x-show="loaded"
+                     x-transition.enter>
+
+                <!-- 상태 배지 — 우측 상단 고정 -->
+                <span th:classappend="${
+                          proposal.status.name() == 'WRITING'   ? 'border-slate-200 bg-slate-100 text-slate-600' :
+                          (proposal.status.name() == 'MATCHING' ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                                                   'border-emerald-200 bg-emerald-50 text-emerald-600')
+                      }"
+                      class="absolute right-7 top-7 inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-bold"
+                      th:text="${proposal.status.description}">
+                    모집/추천 진행 중
+                </span>
+
+                <div th:if="${!#strings.isEmpty(proposal.description)}" class="pr-36">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">프로젝트 설명</p>
+                    <p class="mt-2 text-xl leading-relaxed text-slate-700"
+                       th:text="${proposal.description}">
+                        프로젝트 설명을 입력하세요.
+                    </p>
+                </div>
+
+                
+                <div class="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                    <div class="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-5">
+                        <div class="flex items-center gap-1.5">
+                            <i data-lucide="clock" class="h-4 w-4 shrink-0 text-slate-400"></i>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">전체 예상 기간</p>
+                        </div>
+                        <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                           th:text="${proposal.expectedPeriod != null ? proposal.expectedPeriod + '주' : '미정'}">
+                            8주</p>
+                    </div>
+
+                    <div class="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-5">
+                        <div class="flex items-center gap-1.5">
+                            <i data-lucide="wallet" class="h-4 w-4 shrink-0 text-slate-400"></i>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">총 예산 (최소)</p>
+                        </div>
+                        <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                           th:text="${proposal.totalBudgetMin != null ?
+                               #numbers.formatInteger(proposal.totalBudgetMin, 3, 'COMMA') + '원' : '미정'}">
+                            6,000,000원                        </p>
+                    </div>
+
+                    <div class="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-5">
+                        <div class="flex items-center gap-1.5">
+                            <i data-lucide="banknote" class="h-4 w-4 shrink-0 text-slate-400"></i>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">총 예산 (최대)</p>
+                        </div>
+                        <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                           th:text="${proposal.totalBudgetMax != null ?
+                               #numbers.formatInteger(proposal.totalBudgetMax, 3, 'COMMA') + '원' : '미정'}">
+                            8,000,000원                        </p>
+                    </div>
+
+                    <div class="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-5">
+                        <div class="flex items-center gap-1.5">
+                            <i data-lucide="calendar" class="h-4 w-4 shrink-0 text-slate-400"></i>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">최종 수정일</p>
+                        </div>
+                        <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                           th:text="${#temporals.format(proposal.modifiedAt, 'yyyy.MM.dd')}">
+                            2026.04.17
+                        </p>
+                    </div>
+                </div>
+
+
+
+                
+                <div class="mt-6 flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-400">
+                    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                        <i data-lucide="user-round" class="h-3.5 w-3.5"></i>
+                        <span th:text="${memberName}">클라이언트</span>
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                        <i data-lucide="mail" class="h-3.5 w-3.5"></i>
+                        <span th:text="${memberEmail}">client@example.com</span>
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                        <i data-lucide="hash" class="h-3.5 w-3.5"></i>
+                        <span th:text="'Proposal #' + ${proposal.id}">Proposal #1</span>
+                    </span>
+                </div>
+            </section>
+
+            
+            <section class="fade-up rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70"
+                     x-show="loaded"
+                     x-transition.enter
+                     style="transition-delay: 70ms;">
+
+                <div class="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                        <h3 class="text-xl font-bold tracking-tight text-slate-900"
+                            th:text="${viewerRole == 'FREELANCER' ? '제안받은 포지션' : '포지션 목록'}">포지션 목록</h3>
+                        <p class="mt-1.5 text-sm leading-relaxed text-slate-500">
+                            이 제안서에 등록된 모집 포지션 정보입니다.
+                        </p>
+                    </div>
+                     <span class="inline-flex min-w-10 items-center justify-center rounded-full bg-slate-100 px-3 py-1 text-sm font-bold text-slate-500"
+                          th:text="${viewerRole == 'FREELANCER' and proposedPositions != null ? #lists.size(proposedPositions) : #lists.size(proposal.positions)}">
+                         0
+                     </span>
+                 </div>
+
+                
+                <div th:if="${#lists.isEmpty(proposal.positions)}"
+                     class="mt-6 rounded-[28px] border border-dashed border-slate-200 bg-slate-50 px-6 py-12 text-center">
+                    <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-white text-slate-400 shadow-sm shadow-slate-200/70">
+                        <i data-lucide="briefcase-business" class="h-6 w-6"></i>
+                    </div>
+                    <h4 class="mt-5 text-xl font-black text-slate-900">등록된 포지션이 없습니다</h4>
+                    <p class="mt-3 text-sm leading-7 text-slate-500">아직 포지션이 추가되지 않은 제안서입니다.</p>
+                </div>
+
+                
+                <div th:if="${!#lists.isEmpty(proposal.positions)}" class="mt-6 space-y-4">
+
+                    
+                    <th:block th:if="${viewerRole == 'FREELANCER'}">
+                        <article th:each="pos : ${proposedPositions}"
+                                 class="rounded-[28px] border border-blue-200 bg-blue-50/50 px-6 py-6 shadow-sm shadow-slate-200/50">
+                            <th:block th:replace="~{fragments/proposalDetailFragments :: positionCard(pos=${pos}, viewerRole=${viewerRole}, matchingByPositionId=${matchingByPositionId})}"></th:block>
+                        </article>
+                    </th:block>
+
+                    
+                    <th:block th:if="${viewerRole != 'FREELANCER'}">
+                        <article th:each="pos : ${proposal.positions}"
+                                 class="rounded-[28px] border border-slate-200 bg-slate-50 px-6 py-6 shadow-sm shadow-slate-200/50">
+                            <th:block th:replace="~{fragments/proposalDetailFragments :: positionCard(pos=${pos}, viewerRole=${viewerRole}, matchingByPositionId=${matchingByPositionId})}"></th:block>
+                        </article>
+                    </th:block>
+                </div>
+
+                
+                <th:block th:if="${false}">
+
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div class="space-y-1">
+                                <h4 class="text-2xl font-black tracking-tight text-slate-950"
+                                    th:text="${pos.title}">Node.js 백엔드 개발자/h4>
+                                <p class="text-base font-medium text-slate-400"
+                                   th:text="${pos.position.name}">백엔드 개발자</p>
+                            </div>
+
+                            <div class="flex flex-wrap items-center gap-2">
+                                
+                                <span th:classappend="${
+                                          pos.status.name() == 'OPEN'   ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                          (pos.status.name() == 'FULL'  ? 'border-amber-200 bg-amber-50 text-amber-600' :
+                                                                           'border-slate-200 bg-slate-100 text-slate-500')
+                                      }"
+                                      class="inline-flex rounded-full border px-4 py-1.5 text-xs font-bold"
+                                      th:text="${pos.status.name() == 'OPEN' ? '모집 중 :
+                                                 (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">
+                                    모집 중                                </span>
+
+                                
+                                <th:block th:if="${viewerRole == 'FREELANCER' and matchingByPositionId != null and matchingByPositionId[pos.id] != null}">
+                                    <th:block th:with="myMatching=${matchingByPositionId[pos.id]}">
+                                        
+                                        <span th:classappend="${
+                                                  myMatching.status.name() == 'PROPOSED'    ? 'border-yellow-200 bg-yellow-50 text-yellow-700' :
+                                                  (myMatching.status.name() == 'ACCEPTED'   ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
+                                                  (myMatching.status.name() == 'REJECTED'   ? 'border-red-200 bg-red-50 text-red-600' :
+                                                  (myMatching.status.name() == 'IN_PROGRESS'? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                                  (myMatching.status.name() == 'COMPLETED'  ? 'border-slate-200 bg-slate-100 text-slate-600' :
+                                                                                               'border-slate-200 bg-slate-100 text-slate-500'))))
+                                              }"
+                                              class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold"
+                                              th:text="${myMatching.status.description}">
+                                            제안됨                                        </span>
+
+                                        
+                                        <th:block th:if="${myMatching.status.name() == 'PROPOSED'}">
+                                            <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
+                                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                <button type="submit"
+                                                        class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-xs font-bold text-white shadow-sm transition hover:bg-blue-700">
+                                                    <i data-lucide="check" class="h-3.5 w-3.5"></i>
+                                                    수락
+                                                </button>
+                                            </form>
+                                            <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
+                                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                <button type="submit"
+                                                        class="inline-flex items-center gap-1.5 rounded-2xl border border-red-200 bg-white px-4 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
+                                                    <i data-lucide="x" class="h-3.5 w-3.5"></i>
+                                                    거절
+                                                </button>
+                                            </form>
+                                        </th:block>
+                                    </th:block>
+                                </th:block>
+                            </div>
+                        </div>
+
+                        
+                        <div class="mt-6 grid gap-6 sm:grid-cols-3">
+                            <div>
+                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">모집 인원</p>
+                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900"
+                                   th:text="${pos.headCount != null ? pos.headCount + '명 : '미정'}">2명</p>
+                            </div>
+                            <div>
+                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">예산 (월)</p>
+                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900">
+                                    <span th:if="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}"
+                                          th:text="${#numbers.formatInteger(pos.unitBudgetMin, 3, 'COMMA') + '년~ ' + #numbers.formatInteger(pos.unitBudgetMax, 3, 'COMMA') + '??}">
+                                        3,000,000원~ 4,000,000원                                    </span>
+                                    <span th:unless="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}">미정</span>
+                                </p>
+                            </div>
+                            <div>
+                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">湲곌컙</p>
+                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900"
+                                   th:text="${pos.expectedPeriod != null ? pos.expectedPeriod + '주 : '미정'}">4二?</p>
+                            </div>
+                        </div>
+
+                        
+                        <div class="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+
+                            
+                            <div class="space-y-4">
+                                
+                                <div>
+                                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">필수 기술</p>
+                                    <div class="mt-3 flex flex-wrap gap-2">
+                                        <th:block th:each="skill : ${pos.skills}">
+                                            <span th:if="${skill.importance.name() == 'ESSENTIAL'}"
+                                                  class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700"
+                                                  th:text="${skill.skill.name}">React</span>
+                                        </th:block>
+                                        
+                                        <span th:if="${!#lists.isEmpty(pos.skills) and
+                                                       #lists.isEmpty(pos.skills.?[importance.name() == 'ESSENTIAL'])}"
+                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
+                                            없음
+                                        </span>
+                                        <span th:if="${#lists.isEmpty(pos.skills)}"
+                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
+                                            없음
+                                        </span>
+                                    </div>
+                                </div>
+
+                                
+                                <div>
+                                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">우대 기술</p>
+                                    <div class="mt-3 flex flex-wrap gap-2">
+                                        <th:block th:each="skill : ${pos.skills}">
+                                            <span th:if="${skill.importance.name() == 'PREFERENCE'}"
+                                                  class="rounded-full border border-blue-100 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-600"
+                                                  th:text="${skill.skill.name}">TypeScript</span>
+                                        </th:block>
+                                        
+                                        <span th:if="${!#lists.isEmpty(pos.skills) and
+                                                       #lists.isEmpty(pos.skills.?[importance.name() == 'PREFERENCE'])}"
+                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
+                                            없음
+                                        </span>
+                                        <span th:if="${#lists.isEmpty(pos.skills)}"
+                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
+                                            없음
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            
+                            <div class="rounded-[24px] border border-white bg-white px-5 py-5">
+                                <div class="grid gap-4 sm:grid-cols-2">
+                                    <div>
+                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">근무 형태</p>
+                                        <p class="mt-2 text-base font-bold text-slate-900"
+                                           th:text="${pos.workType != null ? pos.workType.description : '미정'}">?먭꺽</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">근무지</p>
+                                        <p class="mt-2 text-base font-bold text-slate-900"
+                                           th:text="${!#strings.isEmpty(pos.workPlace) ? pos.workPlace : '미정'}">서울 강남구</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">경력 범위</p>
+                                        <p class="mt-2 text-base font-bold text-slate-900">
+                                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears != null}"
+                                                  th:text="${pos.careerMinYears + '년~ ' + pos.careerMaxYears + '??}">3??~ 5??</span>
+                                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears == null}"
+                                                  th:text="${pos.careerMinYears + '년 이상'}">3???댁긽</span>
+                                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears != null}"
+                                                  th:text="${pos.careerMaxYears + '년 이하'}">5???댄븯</span>
+                                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears == null}">미정</span>
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">모집 상태</p>
+                                        <p class="mt-2 text-base font-bold text-slate-900"
+                                           th:text="${pos.status.name() == 'OPEN' ? '모집 중 :
+                                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">모집 중</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                </div>
+                </th:block>
+            </section>
+
+        </div>
+    </main>
+</div>
+</body>
+</html>
+
+
+
+
+

--- a/src/main/resources/templates/fragments/proposalDetailFragments.html
+++ b/src/main/resources/templates/fragments/proposalDetailFragments.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+    <th:block th:fragment="positionCard(pos, viewerRole, matchingByPositionId)">
+
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="space-y-1">
+                <h4 class="text-lg font-bold tracking-tight text-slate-900"
+                    th:text="${pos.title}">Node.js 백엔드 개발자</h4>
+                <p class="text-sm font-medium text-slate-500"
+                   th:text="${pos.position.name}">백엔드 개발자</p>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-2">
+                <!-- 포지션 모집 상태 배지 -->
+                <span th:classappend="${
+                          pos.status.name() == 'OPEN'   ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                          (pos.status.name() == 'FULL'  ? 'border-amber-200 bg-amber-50 text-amber-600' :
+                                                           'border-slate-200 bg-slate-100 text-slate-500')
+                      }"
+                      class="inline-flex rounded-full border px-4 py-1.5 text-xs font-bold"
+                      th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
+                                 (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">
+                    모집 중
+                </span>
+
+                <!-- 프리랜서: 이 포지션에 매칭 요청이 온 경우 상태 배지 (수락/거절은 상단 액션바에서 처리) -->
+                <th:block th:if="${viewerRole == 'FREELANCER' and matchingByPositionId != null and matchingByPositionId[pos.id] != null}">
+                    <th:block th:with="myMatching=${matchingByPositionId[pos.id]}">
+                        <!-- 매칭 상태 배지 -->
+                        <span th:classappend="${
+                                  myMatching.status.name() == 'PROPOSED'    ? 'border-yellow-200 bg-yellow-50 text-yellow-700' :
+                                  (myMatching.status.name() == 'ACCEPTED'   ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
+                                  (myMatching.status.name() == 'REJECTED'   ? 'border-red-200 bg-red-50 text-red-600' :
+                                  (myMatching.status.name() == 'IN_PROGRESS'? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                  (myMatching.status.name() == 'COMPLETED'  ? 'border-slate-200 bg-slate-100 text-slate-600' :
+                                                                               'border-slate-200 bg-slate-100 text-slate-500'))))
+                              }"
+                              class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold"
+                              th:text="${myMatching.status.description}">
+                            제안됨
+                        </span>
+                    </th:block>
+                </th:block>
+            </div>
+        </div>
+
+        <!-- 수치 정보 -->
+        <div class="mt-5 grid gap-4 sm:grid-cols-3">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">인원</p>
+                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
+                    <span th:text="${pos.headCount != null ? pos.headCount + '명' : '미정'}">1명</span>
+                </p>
+            </div>
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산 (인당)</p>
+                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
+                    <span th:if="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}"
+                          th:text="${#numbers.formatInteger(pos.unitBudgetMin, 3, 'COMMA') + ' ~ ' + #numbers.formatInteger(pos.unitBudgetMax, 3, 'COMMA') + '원'}">
+                        3,000,000 ~ 4,000,000원
+                    </span>
+                    <span th:unless="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}">미정</span>
+                </p>
+            </div>
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">기간</p>
+                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900"
+                   th:text="${pos.expectedPeriod != null ? pos.expectedPeriod + '주' : '미정'}">4주</p>
+            </div>
+        </div>
+
+        <!-- 상세 정보 -->
+        <div class="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+
+            <!-- 스킬 영역 -->
+            <div class="space-y-4">
+                <!-- 필수 스킬 -->
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        <th:block th:each="skill : ${pos.skills}">
+                            <span th:if="${skill.importance.name() == 'ESSENTIAL'}"
+                                  class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700"
+                                  th:text="${skill.skill.name}">React</span>
+                        </th:block>
+                        <span th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'ESSENTIAL'])}"
+                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+                        <span th:if="${#lists.isEmpty(pos.skills)}"
+                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+                    </div>
+                </div>
+
+                <!-- 우대 스킬 -->
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        <th:block th:each="skill : ${pos.skills}">
+                            <span th:if="${skill.importance.name() == 'PREFERENCE'}"
+                                  class="rounded-full border border-blue-100 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-600"
+                                  th:text="${skill.skill.name}">TypeScript</span>
+                        </th:block>
+                        <span th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'PREFERENCE'])}"
+                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+                        <span th:if="${#lists.isEmpty(pos.skills)}"
+                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 근무 조건 카드 -->
+            <div class="rounded-[24px] border border-white bg-white px-5 py-5">
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
+                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
+                           th:text="${pos.workType != null ? pos.workType.description : '미정'}">원격</p>
+                    </div>
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무지</p>
+                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
+                           th:text="${#strings.isEmpty(pos.workPlace) ? '미정' : pos.workPlace}">서울 강남구</p>
+                    </div>
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">경력 범위</p>
+                        <p class="mt-1.5 text-sm font-semibold text-slate-800">
+                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears != null}"
+                                  th:text="${pos.careerMinYears + '년 ~ ' + pos.careerMaxYears + '년'}">3년 ~ 5년</span>
+                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears == null}"
+                                  th:text="${pos.careerMinYears + '년 이상'}">3년 이상</span>
+                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears != null}"
+                                  th:text="${pos.careerMaxYears + '년 이하'}">5년 이하</span>
+                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears == null}">미정</span>
+                        </p>
+                    </div>
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">모집 상태</p>
+                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
+                           th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
+                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">모집 중</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </th:block>
+</body>
+</html>

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -104,10 +104,6 @@
                             <span class="text-slate-300">·</span>
                             <span th:text="${item.positionName()}">포지션</span>
                         </div>
-                        <div class="flex flex-wrap gap-1 pt-0.5">
-                            <span th:each="skill : ${item.skillNames()}" th:text="${skill}"
-                                  class="px-2 py-0.5 bg-slate-100 text-slate-600 text-xs font-medium rounded-lg">스킬</span>
-                        </div>
                     </div>
                     <div>
                         <span th:text="${item.status().label}"

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -93,7 +93,9 @@
             </div>
 
             <div th:if="${not items.isEmpty()}" class="divide-y divide-slate-100">
-                <div th:each="item : ${items}" class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_80px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors">
+                <div th:each="item : ${items}"
+                     th:attr="data-href=@{/proposals/{id}(id=${item.proposalId()})}"
+                     class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_80px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors cursor-pointer">
                     <div class="space-y-1">
                         <p class="text-sm font-bold text-slate-900" th:text="${item.proposalTitle()}">프로젝트명</p>
                         <div class="flex items-center gap-1.5 text-xs text-slate-500">
@@ -122,7 +124,7 @@
                     <div class="flex justify-end">
                         <a th:href="@{/proposals/{id}(id=${item.proposalId()})}"
                            class="flex items-center gap-1 text-sm font-semibold text-blue-600 hover:text-blue-700 whitespace-nowrap">
-                            보기<i data-lucide="chevron-right" class="w-4 h-4"></i>
+                            상세 보기<i data-lucide="chevron-right" class="w-4 h-4"></i>
                         </a>
                     </div>
                 </div>
@@ -156,6 +158,18 @@
     var form = document.getElementById('searchForm');
     var inp  = document.getElementById('searchInput');
     if (form) form.addEventListener('submit', function() { cur_query = inp ? inp.value.trim() : ''; loadList(cur_status, cur_query); });
+
+    // Row click navigation (works for both initial render and AJAX-replaced list).
+    document.addEventListener('click', function (e) {
+        var row = e.target.closest('#listSection [data-href]');
+        if (!row) return;
+
+        // Let explicit interactive elements handle their own clicks.
+        if (e.target.closest('a, button, input, select, textarea, label')) return;
+
+        var href = row.dataset.href;
+        if (href) window.location.href = href;
+    });
 
     function loadList(status, q) {
         var p = new URLSearchParams();

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -28,6 +28,7 @@ import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
+import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.service.ProposalAiInterviewService;
@@ -59,6 +60,9 @@ class ProposalControllerTest {
 
     @MockitoBean
     private MemberRepository memberRepository;
+
+    @MockitoBean
+    private MatchingRepository matchingRepository;
 
     @Test
     @DisplayName("인증된 사용자가 새 제안서 작성 화면을 조회하면 편집기를 렌더링한다")
@@ -660,29 +664,53 @@ class ProposalControllerTest {
         );
 
         mockMvc.perform(get("/proposals/999")
+                        .header("Referer", "/client/dashboard")
                         .with(authentication(new UsernamePasswordAuthenticationToken(
                                 principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/client/dashboard"));
+                .andExpect(redirectedUrl("/"));
     }
 
     @Test
-    @DisplayName("제안서 상세 조회 시 타인 제안서이면 대시보드로 리다이렉트하고 오류 메시지를 남긴다")
+    @DisplayName("존재하지 않는 제안서 조회 시 홈으로 리다이렉트된다")
+    void redirectHomeWhenDetailNotFoundWithExternalReferer() throws Exception {
+        given(proposalService.findOwnedProposal(999L, "client@example.com"))
+                .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "client", "010-1234-5678")
+        );
+
+        mockMvc.perform(get("/proposals/999")
+                        .header("Referer", "https://example.com/somewhere")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+    }
+
+    @Test
+    @DisplayName("제안서 상세 조회 권한이 없으면 홈으로 리다이렉트하고 에러 메시지를 남긴다")
     void redirectDashboardWhenDetailAccessDenied() throws Exception {
         given(proposalService.findOwnedProposal(1L, "client@example.com"))
                 .willThrow(new AccessDeniedException("본인 제안서만 조회할 수 있습니다."));
+
+        given(proposalService.findProposalForFreelancer(1L, "client@example.com"))
+                .willThrow(new AccessDeniedException("매칭 이력이 없는 제안서입니다."));
 
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
         );
 
         mockMvc.perform(get("/proposals/1")
+                        .header("Referer", "/client/dashboard")
                         .with(authentication(new UsernamePasswordAuthenticationToken(
                                 principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(redirectedUrl("/"))
                 .andExpect(flash().attributeExists("errorMessage"));
     }
 

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -492,4 +492,42 @@ class ProposalServiceTest {
         then(proposalRepository).should().findWithPositionsById(1L);
         then(proposalRepository).should(never()).findPositionsWithSkillsByProposalId(1L);
     }
+
+    @Test
+    @DisplayName("매칭 이력이 있는 프리랜서는 findProposalForFreelancer로 제안서를 조회할 수 있다")
+    void findProposalForFreelancer_returnsProposal_whenMatchingExists() {
+        Proposal proposal = Proposal.create(member, "클라이언트 프로젝트", "원본", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+        when(matchingRepository.existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(1L, OTHER_EMAIL))
+                .thenReturn(true);
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        Proposal result = proposalService.findProposalForFreelancer(1L, OTHER_EMAIL);
+
+        assertThat(result).isSameAs(proposal);
+        then(proposalRepository).should().findWithPositionsById(1L);
+        then(proposalRepository).should().findPositionsWithSkillsByProposalId(1L);
+    }
+
+    @Test
+    @DisplayName("매칭 이력이 없는 프리랜서는 findProposalForFreelancer에서 접근 거부 예외가 발생한다")
+    void findProposalForFreelancer_throws_whenNoMatchingHistory() {
+        when(matchingRepository.existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(1L, OTHER_EMAIL))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> proposalService.findProposalForFreelancer(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+        then(proposalRepository).should(never()).findWithPositionsById(any());
+    }
+
+    @Test
+    @DisplayName("매칭 이력은 있지만 존재하지 않는 제안서는 findProposalForFreelancer에서 예외가 발생한다")
+    void findProposalForFreelancer_throws_whenProposalNotFound() {
+        when(matchingRepository.existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(99L, OTHER_EMAIL))
+                .thenReturn(true);
+        when(proposalRepository.findWithPositionsById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.findProposalForFreelancer(99L, OTHER_EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
+    }
 }


### PR DESCRIPTION
## 🔎 What


- client/proposalDetail.html 뷰 템플릿 구현
- 제안서 기본 정보 표시 (제목, 상태, 예상 기간, 총 예산, 최종 수정일)
- 포지션 목록 표시 (포지션명, 근무 형태, 모집 인원, 예산 범위, 필수/우대 기술)
- 클라이언트가 본인 제안서를 볼 때, 상태에 따라 제안서 관리용 버튼을 다르게 표시
      - 작성 중(WRITING)인 경우 → "제안서 수정" 버튼 표시
      - 매칭 진행 중(MATCHING)인 경우 → "추천 결과 보기" 버튼 표시
      - 매칭 완료(COMPLETE)인 경우 → 별도 버튼 없이 내용만 표시
- 프리랜서가 “매칭 요청을 받은 제안서”를 조회할 때는 수락/거절 액션 버튼을 노출한다.
- 접근 권한 처리 (프리랜서 조회 허용) 현재 findOwnedProposal은 소유자만 허용 → 프리랜서용 조회 로직 추가 필요 (매칭 이력 기반 접근 검증)
- 뒤로가기 버튼 동작 (클라이언트 → /client/dashboard, 프리랜서 → /freelancers/dashboard)

## 🔗 Issue

- Closes: #78 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?