### PR TITLE
[Feat] 이력서 임베딩 생성 및 갱신 로직 도입

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeEmbeddingRepository.java
@@ -2,9 +2,12 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.ResumeEmbedding;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResumeEmbeddingRepository extends JpaRepository<ResumeEmbedding, Long> {
 
     List<ResumeEmbedding> findAllByResume_IdInAndEmbeddingModel(List<Long> resumeIds, String embeddingModel);
+
+    Optional<ResumeEmbedding> findByResume_IdAndEmbeddingModel(Long resumeId, String embeddingModel);
 }

--- a/src/main/java/com/generic4/itda/service/ResumeEmbeddingService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeEmbeddingService.java
@@ -1,0 +1,61 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.domain.recommendation.vo.EmbeddingVector;
+import com.generic4.itda.domain.recommendation.vo.SourceHash;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingSourceHashGenerator;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingTextGenerator;
+import com.generic4.itda.service.recommend.scoring.QueryEmbeddingGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResumeEmbeddingService {
+
+    private final ResumeEmbeddingRepository resumeEmbeddingRepository;
+    private final ResumeEmbeddingTextGenerator resumeEmbeddingTextGenerator;
+    private final ResumeEmbeddingSourceHashGenerator resumeEmbeddingSourceHashGenerator;
+    private final QueryEmbeddingGenerator queryEmbeddingGenerator;
+    private final AiEmbeddingProperties aiEmbeddingProperties;
+
+    public ResumeEmbedding createOrRefresh(Resume resume) {
+        Assert.notNull(resume, "resume는 필수입니다.");
+        Assert.notNull(resume.getId(), "저장된 resume만 임베딩을 생성할 수 있습니다.");
+
+        String embeddingText = resumeEmbeddingTextGenerator.generate(resume);
+        SourceHash sourceHash = resumeEmbeddingSourceHashGenerator.generate(embeddingText);
+        String embeddingModel = aiEmbeddingProperties.getModel();
+
+        ResumeEmbedding existing = resumeEmbeddingRepository
+                .findByResume_IdAndEmbeddingModel(resume.getId(), embeddingModel)
+                .orElse(null);
+
+        if (existing != null && existing.isSameSource(sourceHash)) {
+            return existing;
+        }
+
+        EmbeddingVector embeddingVector = new EmbeddingVector(
+                queryEmbeddingGenerator.generate(embeddingText)
+        );
+
+        if (existing == null) {
+            ResumeEmbedding created = ResumeEmbedding.create(
+                    resume,
+                    sourceHash,
+                    embeddingModel,
+                    embeddingVector
+            );
+            return resumeEmbeddingRepository.save(created);
+        }
+
+        existing.refresh(sourceHash, embeddingVector);
+        return existing;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/ResumeService.java
+++ b/src/main/java/com/generic4/itda/service/ResumeService.java
@@ -12,12 +12,13 @@ import com.generic4.itda.dto.resume.ResumeSkillItemForm;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.ResumeRepository;
 import com.generic4.itda.repository.SkillRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class ResumeService {
     private final MemberRepository memberRepository;
     private final SkillRepository skillRepository;
     private final ObjectMapper objectMapper;
+    private final ResumeEmbeddingService resumeEmbeddingService;
 
     // 이력서 생성
     @Transactional
@@ -61,7 +63,9 @@ public class ResumeService {
             }
         }
 
-        return resumeRepository.save(resume);
+        Resume saved = resumeRepository.save(resume);
+        triggerResumeEmbedding(saved);
+        return saved;
     }
 
     // 이력서 수정
@@ -86,6 +90,8 @@ public class ResumeService {
         if (resume.isAiMatchingEnabled() != form.isAiMatchingEnabled()) {
             resume.toggleAiMatchingEnabled();
         }
+
+        triggerResumeEmbedding(resume);
     }
 
     // 경력 추가
@@ -93,6 +99,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         resume.addCareerItem(item);
         resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+
+        triggerResumeEmbedding(resume);
     }
 
     // 경력 수정
@@ -100,6 +108,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         resume.updateCareerItem(index, item);
         resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+
+        triggerResumeEmbedding(resume);
     }
 
     // 경력 삭제
@@ -107,6 +117,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         resume.removeCareerItem(index);
         resumeRepository.updateCareerJson(resume.getId(), toCareerJson(resume));
+
+        triggerResumeEmbedding(resume);
     }
 
     private String toCareerJson(Resume resume) {
@@ -122,6 +134,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         Skill skill = getSkillById(skillId);
         resume.addSkill(skill, proficiency);
+
+        triggerResumeEmbedding(resume);
     }
 
     // 스킬 수정
@@ -129,6 +143,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         Skill skill = getSkillById(skillId);
         resume.updateSkill(skill, proficiency);
+
+        triggerResumeEmbedding(resume);
     }
 
     // 스킬 삭제
@@ -136,6 +152,8 @@ public class ResumeService {
         Resume resume = getResumeByEmail(email);
         Skill skill = getSkillById(skillId);
         resume.removeSkill(skill);
+
+        triggerResumeEmbedding(resume);
     }
 
     // 이력서 조회
@@ -171,5 +189,13 @@ public class ResumeService {
     private Skill getSkillById(Long skillId) {
         return skillRepository.findById(skillId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스킬입니다."));
+    }
+
+    private void triggerResumeEmbedding(Resume resume) {
+        try {
+            resumeEmbeddingService.createOrRefresh(resume);
+        } catch (Exception e) {
+            log.error("이력서 임베딩 생성/갱신 실패. resumeId={}", resume.getId(), e);
+        }
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingSourceHashGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingSourceHashGenerator.java
@@ -1,0 +1,30 @@
+package com.generic4.itda.service.recommend.embedding;
+
+import com.generic4.itda.domain.recommendation.vo.SourceHash;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class ResumeEmbeddingSourceHashGenerator {
+
+    public SourceHash generate(String sourceText) {
+        Assert.hasText(sourceText, "sourceText는 필수입니다.");
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(sourceText.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder builder = new StringBuilder();
+            for (byte hashByte : hashBytes) {
+                builder.append(String.format("%02x", hashByte));
+            }
+
+            return new SourceHash(builder.toString());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("sourceHash 생성에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingTextGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingTextGenerator.java
@@ -1,0 +1,132 @@
+package com.generic4.itda.service.recommend.embedding;
+
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import java.util.List;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class ResumeEmbeddingTextGenerator {
+
+    public String generate(Resume resume) {
+        Assert.notNull(resume, "resume은 필수입니다.");
+
+        return """
+                preferredWorkType: %s
+                careerYears: %s
+                introduction: %s
+                skills: %s
+                careerDetails:
+                %s
+                """.formatted(
+                extractPreferredWorkType(resume),
+                buildCareerYears(resume.getCareerYears()),
+                normalizeText(resume.getIntroduction()),
+                joinSkills(resume.getSkills()),
+                joinCareerDetails(resume.getCareer())
+        ).trim();
+    }
+
+    private String extractPreferredWorkType(Resume resume) {
+        return resume.getPreferredWorkType() == null ? "" : resume.getPreferredWorkType().name();
+    }
+
+    private String buildCareerYears(Byte careerYears) {
+        return careerYears == null ? "" : careerYears + " years";
+    }
+
+    private String joinSkills(SortedSet<ResumeSkill> skills) {
+        if (skills == null || skills.isEmpty()) {
+            return "";
+        }
+
+        return skills.stream()
+                .map(this::formatSkill)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String formatSkill(ResumeSkill resumeSkill) {
+        if (resumeSkill == null || resumeSkill.getSkill() == null) {
+            return "";
+        }
+
+        String skillName = normalizeText(resumeSkill.getSkill().getName());
+        String proficiency = resumeSkill.getProficiency() == null
+                ? ""
+                : resumeSkill.getProficiency().name();
+
+        if (skillName.isBlank()) {
+            return "";
+        }
+        return proficiency.isBlank() ? skillName : "%s (%s)".formatted(skillName, proficiency);
+    }
+
+    private String joinCareerDetails(CareerPayload careerPayload) {
+        if (careerPayload == null || careerPayload.getItems() == null || careerPayload.getItems().isEmpty()) {
+            return "";
+        }
+
+        return careerPayload.getItems().stream()
+                .filter(Objects::nonNull)
+                .map(this::formatCareerItem)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatCareerItem(CareerItemPayload item) {
+        String companyName = normalizeText(item.getCompanyName());
+        String position = normalizeText(item.getPosition());
+        String employmentType = item.getEmploymentType() == null
+                ? ""
+                : normalizeText(item.getEmploymentType().getDescription());
+        String period = buildPeriod(item);
+        String summary = normalizeText(item.getSummary());
+        String techStack = joinTechStack(item.getTechStack());
+
+        return "- company: %s | position: %s | employmentType: %s | period: %s | summary: %s | techStack: %s"
+                .formatted(companyName, position, employmentType, period, summary, techStack);
+    }
+
+    private String buildPeriod(CareerItemPayload item) {
+        String start = normalizeText(item.getStartYearMonth());
+        String end = Boolean.TRUE.equals(item.getCurrentlyWorking())
+                ? "present"
+                : normalizeText(item.getEndYearMonth());
+
+        if (start.isBlank() && end.isBlank()) {
+            return "";
+        }
+        if (start.isBlank()) {
+            return end;
+        }
+        if (end.isBlank()) {
+            return start;
+        }
+        return start + "~" + end;
+    }
+
+    private String joinTechStack(List<String> techStack) {
+        if (techStack == null || techStack.isEmpty()) {
+            return "";
+        }
+
+        return techStack.stream()
+                .map(this::normalizeText)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String normalizeText(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim().replaceAll("\\s+", " ");
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeEmbeddingRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.generic4.itda.repository;
 
-import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.generic4.itda.annotation.RepositoryTest;
 import com.generic4.itda.domain.member.Member;
@@ -15,105 +13,138 @@ import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
 import jakarta.persistence.EntityManager;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
 
 @RepositoryTest
+@DisplayName("ResumeEmbeddingRepository 테스트")
 class ResumeEmbeddingRepositoryTest {
 
     @Autowired
     private ResumeEmbeddingRepository resumeEmbeddingRepository;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private ResumeRepository resumeRepository;
-
-    @Autowired
     private EntityManager em;
 
-    private Resume resume;
+    @Nested
+    @DisplayName("findByResume_IdAndEmbeddingModel 파생 쿼리 검증")
+    class FindByResumeIdAndEmbeddingModelTest {
 
-    @BeforeEach
-    void setUp() {
-        Member member = memberRepository.save(createMember());
-        resume = resumeRepository.save(
-                Resume.create(member, "자기소개입니다.", (byte) 3, new CareerPayload(),
-                        WorkType.REMOTE, ResumeWritingStatus.WRITING, null));
+        @Test
+        @DisplayName("resumeId와 embeddingModel이 모두 일치하면 엔티티를 반환해야 한다")
+        void should_return_entity_when_resumeId_and_model_match() {
+            // given
+            Resume resume = createResume("test@example.com");
+            String model = "text-embedding-3-small";
+            createResumeEmbedding(resume, model);
+
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<ResumeEmbedding> found = resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(
+                    resume.getId(), model);
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getResume().getId()).isEqualTo(resume.getId());
+            assertThat(found.get().getEmbeddingModel()).isEqualTo(model);
+        }
+
+        @Test
+        @DisplayName("resumeId는 같지만 embeddingModel이 다르면 조회되지 않아야 한다")
+        void should_return_empty_when_model_mismatch() {
+            // given
+            Resume resume = createResume("test@example.com");
+            createResumeEmbedding(resume, "model-A");
+
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<ResumeEmbedding> found = resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(
+                    resume.getId(), "model-B");
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("embeddingModel은 같지만 resumeId가 다르면 조회되지 않아야 한다")
+        void should_return_empty_when_resumeId_mismatch() {
+            // given
+            Resume resume1 = createResume("user1@example.com");
+            Resume resume2 = createResume("user2@example.com");
+            String model = "target-model";
+            createResumeEmbedding(resume1, model);
+
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<ResumeEmbedding> found = resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(
+                    resume2.getId(), model);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("조건에 맞는 데이터가 없으면 Optional.empty()를 반환해야 한다")
+        void should_return_empty_when_no_matching_data() {
+            // given
+            Long nonExistentResumeId = 999L;
+            String model = "any-model";
+
+            // when
+            Optional<ResumeEmbedding> found = resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(
+                    nonExistentResumeId, model);
+
+            // then
+            assertThat(found).isEmpty();
+        }
     }
 
-    @Test
-    @DisplayName("동일한 resume와 embeddingModel 조합은 중복 저장할 수 없다")
-    void 동일한_resume와_embeddingModel_조합은_중복_저장할_수_없다() {
-        // given - 같은 resume + 같은 model, 다른 hash/vector
-        String model = "text-embedding-3-small";
-        ResumeEmbedding first = ResumeEmbedding.create(
-                resume, new SourceHash("hash001"), model, new EmbeddingVector(List.of(0.1, 0.2)));
-        ResumeEmbedding second = ResumeEmbedding.create(
-                resume, new SourceHash("hash002"), model, new EmbeddingVector(List.of(0.3, 0.4)));
+    /**
+     * 테스트용 Resume 생성 헬퍼 메서드
+     */
+    private Resume createResume(String email) {
+        Member member = Member.create(
+                email,
+                "password123!",
+                "테스트유저",
+                "닉네임",
+                "메모",
+                "010-1234-5678"
+        );
+        em.persist(member);
 
-        // when
-        resumeEmbeddingRepository.saveAndFlush(first);
-
-        // then
-        assertThatThrownBy(() -> resumeEmbeddingRepository.saveAndFlush(second))
-                .isInstanceOf(DataIntegrityViolationException.class);
+        Resume resume = Resume.create(
+                member,
+                "안녕하세요, 테스트 자기소개입니다.",
+                (byte) 3,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                "https://portfolio.it-da.com"
+        );
+        em.persist(resume);
+        return resume;
     }
 
-    @Test
-    @DisplayName("refresh() 후 SourceHash와 EmbeddingVector가 DB round-trip 된다")
-    void refresh_후_SourceHash와_EmbeddingVector가_DB_round_trip된다() {
-        // given
-        ResumeEmbedding embedding = resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(resume, new SourceHash("old-hash"), "text-embedding-3-small",
-                        new EmbeddingVector(List.of(0.1, 0.2))));
-
-        SourceHash newHash = new SourceHash("new-hash");
-        EmbeddingVector newVector = new EmbeddingVector(List.of(0.9, 0.8, 0.7));
-
-        // when
-        embedding.refresh(newHash, newVector);
-        resumeEmbeddingRepository.saveAndFlush(embedding);
-        em.clear();
-
-        // then
-        ResumeEmbedding found = resumeEmbeddingRepository.findById(embedding.getId()).orElseThrow();
-        assertThat(found.getSourceHash()).isEqualTo(newHash);
-        assertThat(found.getEmbeddingVector()).isEqualTo(newVector);
-        assertThat(found.getEmbeddingModel()).isEqualTo("text-embedding-3-small");
-    }
-
-    @Test
-    @DisplayName("이력서 ID 목록과 모델명으로 임베딩을 조회한다")
-    void 이력서_ID_목록과_모델명으로_임베딩을_조회한다() {
-        // given
-        String model = "text-embedding-3-small";
-        resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(resume, new SourceHash("hash1"), model, new EmbeddingVector(List.of(0.1, 0.2))));
-        
-        Member otherMember = memberRepository.save(createMember("other@test.com", "pass", "other", "010-1111-2222"));
-        Resume otherResume = resumeRepository.save(
-                Resume.create(otherMember, "자기소개입니다.", (byte) 5, new CareerPayload(),
-                        WorkType.SITE, ResumeWritingStatus.WRITING, null));
-        resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(otherResume, new SourceHash("hash2"), model, new EmbeddingVector(List.of(0.3, 0.4))));
-        
-        resumeEmbeddingRepository.saveAndFlush(
-                ResumeEmbedding.create(resume, new SourceHash("hash3"), "other-model", new EmbeddingVector(List.of(0.5, 0.6))));
-
-        // when
-        List<ResumeEmbedding> results = resumeEmbeddingRepository.findAllByResume_IdInAndEmbeddingModel(
-                List.of(resume.getId(), otherResume.getId()), model);
-
-        // then
-        assertThat(results).hasSize(2);
-        assertThat(results).extracting(ResumeEmbedding::getEmbeddingModel)
-                .containsOnly(model);
-        assertThat(results).extracting(re -> re.getResume().getId())
-                .containsExactlyInAnyOrder(resume.getId(), otherResume.getId());
+    /**
+     * 테스트용 ResumeEmbedding 생성 및 저장 헬퍼 메서드
+     */
+    private ResumeEmbedding createResumeEmbedding(Resume resume, String model) {
+        ResumeEmbedding embedding = ResumeEmbedding.create(
+                resume,
+                new SourceHash("dummy-source-hash-value"),
+                model,
+                new EmbeddingVector(List.of(0.1, 0.2, 0.3, 0.4, 0.5))
+        );
+        return resumeEmbeddingRepository.save(embedding);
     }
 }

--- a/src/test/java/com/generic4/itda/service/ResumeEmbeddingServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/ResumeEmbeddingServiceIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.domain.recommendation.vo.SourceHash;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingSourceHashGenerator;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingTextGenerator;
+import com.generic4.itda.service.recommend.scoring.QueryEmbeddingGenerator;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@IntegrationTest
+@Transactional
+class ResumeEmbeddingServiceIntegrationTest {
+
+    @Autowired
+    private ResumeEmbeddingService resumeEmbeddingService;
+
+    @Autowired
+    private ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    @Autowired
+    private ResumeEmbeddingTextGenerator resumeEmbeddingTextGenerator;
+
+    @Autowired
+    private ResumeEmbeddingSourceHashGenerator resumeEmbeddingSourceHashGenerator;
+
+    @Autowired
+    private AiEmbeddingProperties aiEmbeddingProperties;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private QueryEmbeddingGenerator queryEmbeddingGenerator;
+
+    @Test
+    @DisplayName("createOrRefresh를 호출하면 실제 텍스트/해시 생성기를 거쳐 ResumeEmbedding이 저장된다")
+    void createOrRefresh_persists_resume_embedding_with_real_generators_and_mocked_embedding_api() {
+        // given
+        Member member = persist(createMember("resume-embedding-owner@test.com", "pw", "이력서소유자", "010-1234-5678"));
+        Skill java = persist(Skill.create("Java", null));
+
+        Resume resume = Resume.create(
+                member,
+                "  백엔드   개발 경험이 있습니다.  ",
+                (byte) 5,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                "https://portfolio.example.com"
+        );
+        resume.addSkill(java, Proficiency.ADVANCED);
+        persist(resume);
+
+        String expectedEmbeddingText = resumeEmbeddingTextGenerator.generate(resume);
+        SourceHash expectedSourceHash = resumeEmbeddingSourceHashGenerator.generate(expectedEmbeddingText);
+        String expectedModel = aiEmbeddingProperties.getModel();
+        List<Double> embeddingVector = List.of(0.12, 0.34, 0.56);
+
+        given(queryEmbeddingGenerator.generate(expectedEmbeddingText)).willReturn(embeddingVector);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Resume storedResume = entityManager.find(Resume.class, resume.getId());
+
+        // when
+        ResumeEmbedding result = resumeEmbeddingService.createOrRefresh(storedResume);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        ResumeEmbedding persisted = resumeEmbeddingRepository
+                .findByResume_IdAndEmbeddingModel(resume.getId(), expectedModel)
+                .orElseThrow();
+
+        assertThat(result.getId()).isNotNull();
+        assertThat(persisted.getId()).isEqualTo(result.getId());
+        assertThat(persisted.getResume().getId()).isEqualTo(resume.getId());
+        assertThat(persisted.getEmbeddingModel()).isEqualTo(expectedModel);
+        assertThat(persisted.getSourceHash()).isEqualTo(expectedSourceHash);
+        assertThat(persisted.getEmbeddingVector().values()).isEqualTo(embeddingVector);
+        then(queryEmbeddingGenerator).should().generate(expectedEmbeddingText);
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ResumeEmbeddingServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ResumeEmbeddingServiceTest.java
@@ -1,0 +1,204 @@
+package com.generic4.itda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.generic4.itda.config.ai.AiEmbeddingProperties;
+import com.generic4.itda.domain.recommendation.ResumeEmbedding;
+import com.generic4.itda.domain.recommendation.vo.EmbeddingVector;
+import com.generic4.itda.domain.recommendation.vo.SourceHash;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.ResumeEmbeddingRepository;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingSourceHashGenerator;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingTextGenerator;
+import com.generic4.itda.service.recommend.scoring.QueryEmbeddingGenerator;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResumeEmbeddingService 단위 테스트")
+class ResumeEmbeddingServiceTest {
+
+    private static final Long RESUME_ID = 1L;
+    private static final String MODEL = "test-model";
+
+    @Mock
+    private ResumeEmbeddingRepository resumeEmbeddingRepository;
+
+    @Mock
+    private ResumeEmbeddingTextGenerator resumeEmbeddingTextGenerator;
+
+    @Mock
+    private ResumeEmbeddingSourceHashGenerator resumeEmbeddingSourceHashGenerator;
+
+    @Mock
+    private QueryEmbeddingGenerator queryEmbeddingGenerator;
+
+    @Mock
+    private AiEmbeddingProperties aiEmbeddingProperties;
+
+    @InjectMocks
+    private ResumeEmbeddingService resumeEmbeddingService;
+
+    @Nested
+    @DisplayName("createOrRefresh 메서드는")
+    class CreateOrRefresh {
+
+        @Test
+        @DisplayName("resume이 null이면 예외가 발생하고 아무 작업도 수행하지 않는다")
+        void should_throw_when_resume_is_null() {
+            assertThatThrownBy(() -> resumeEmbeddingService.createOrRefresh(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("resume는 필수입니다.");
+
+            verifyNoInteractions(
+                    resumeEmbeddingTextGenerator,
+                    resumeEmbeddingSourceHashGenerator,
+                    aiEmbeddingProperties,
+                    queryEmbeddingGenerator,
+                    resumeEmbeddingRepository
+            );
+        }
+
+        @Test
+        @DisplayName("resume id가 null이면 예외가 발생하고 아무 작업도 수행하지 않는다")
+        void should_throw_when_resume_id_is_null() {
+            Resume resume = createResume(null);
+
+            assertThatThrownBy(() -> resumeEmbeddingService.createOrRefresh(resume))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("저장된 resume만 임베딩을 생성할 수 있습니다.");
+
+            verifyNoInteractions(
+                    resumeEmbeddingTextGenerator,
+                    resumeEmbeddingSourceHashGenerator,
+                    aiEmbeddingProperties,
+                    queryEmbeddingGenerator,
+                    resumeEmbeddingRepository
+            );
+        }
+
+        @Test
+        @DisplayName("기존 embedding이 없으면 새로 생성하여 저장한다")
+        void should_create_new_embedding_when_not_exists() {
+            // given
+            Resume resume = createResume(RESUME_ID);
+            String text = "extracted text";
+            SourceHash hash = new SourceHash("hash-val");
+            List<Double> vectorValues = List.of(0.1, 0.2);
+            ArgumentCaptor<ResumeEmbedding> savedEmbeddingCaptor = ArgumentCaptor.forClass(ResumeEmbedding.class);
+
+            given(resumeEmbeddingTextGenerator.generate(resume)).willReturn(text);
+            given(resumeEmbeddingSourceHashGenerator.generate(text)).willReturn(hash);
+            given(aiEmbeddingProperties.getModel()).willReturn(MODEL);
+            given(resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(RESUME_ID, MODEL))
+                    .willReturn(Optional.empty());
+            given(queryEmbeddingGenerator.generate(text)).willReturn(vectorValues);
+            given(resumeEmbeddingRepository.save(any(ResumeEmbedding.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            ResumeEmbedding result = resumeEmbeddingService.createOrRefresh(resume);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getResume()).isSameAs(resume);
+            assertThat(result.getEmbeddingModel()).isEqualTo(MODEL);
+            assertThat(result.getSourceHash()).isEqualTo(hash);
+            assertThat(result.getEmbeddingVector().values()).isEqualTo(vectorValues);
+            verify(queryEmbeddingGenerator).generate(text);
+            verify(resumeEmbeddingRepository).save(savedEmbeddingCaptor.capture());
+            ResumeEmbedding savedEmbedding = savedEmbeddingCaptor.getValue();
+            assertThat(savedEmbedding.getResume()).isSameAs(resume);
+            assertThat(savedEmbedding.getSourceHash()).isEqualTo(hash);
+            assertThat(savedEmbedding.getEmbeddingModel()).isEqualTo(MODEL);
+            assertThat(savedEmbedding.getEmbeddingVector().values()).isEqualTo(vectorValues);
+        }
+
+        @Test
+        @DisplayName("기존 embedding이 있고 sourceHash가 동일하면 재사용한다")
+        void should_reuse_existing_embedding_when_source_hash_matches() {
+            // given
+            Resume resume = createResume(RESUME_ID);
+            String text = "extracted text";
+            SourceHash hash = new SourceHash("hash-val");
+
+            ResumeEmbedding existing = createExistingEmbedding(resume, hash, List.of(0.1, 0.2));
+
+            given(resumeEmbeddingTextGenerator.generate(resume)).willReturn(text);
+            given(resumeEmbeddingSourceHashGenerator.generate(text)).willReturn(hash);
+            given(aiEmbeddingProperties.getModel()).willReturn(MODEL);
+            given(resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(RESUME_ID, MODEL))
+                    .willReturn(Optional.of(existing));
+
+            // when
+            ResumeEmbedding result = resumeEmbeddingService.createOrRefresh(resume);
+
+            // then
+            assertThat(result).isSameAs(existing);
+            verify(queryEmbeddingGenerator, never()).generate(any());
+            verify(resumeEmbeddingRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("기존 embedding이 있지만 sourceHash가 다르면 실제 객체의 필드를 갱신한다")
+        void should_refresh_existing_embedding_when_source_hash_differs() {
+            // given
+            Resume resume = createResume(RESUME_ID);
+            String text = "updated text";
+            SourceHash oldHash = new SourceHash("old-hash");
+            SourceHash newHash = new SourceHash("new-hash");
+            List<Double> oldVectorValues = List.of(0.1, 0.2);
+            List<Double> newVectorValues = List.of(0.3, 0.4);
+
+            ResumeEmbedding existing = createExistingEmbedding(resume, oldHash, oldVectorValues);
+
+            given(resumeEmbeddingTextGenerator.generate(resume)).willReturn(text);
+            given(resumeEmbeddingSourceHashGenerator.generate(text)).willReturn(newHash);
+            given(aiEmbeddingProperties.getModel()).willReturn(MODEL);
+            given(resumeEmbeddingRepository.findByResume_IdAndEmbeddingModel(RESUME_ID, MODEL))
+                    .willReturn(Optional.of(existing));
+            given(queryEmbeddingGenerator.generate(text)).willReturn(newVectorValues);
+
+            // when
+            ResumeEmbedding result = resumeEmbeddingService.createOrRefresh(resume);
+
+            // then
+            assertThat(result).isSameAs(existing);
+            assertThat(result.getEmbeddingModel()).isEqualTo(MODEL);
+            assertThat(result.getSourceHash()).isEqualTo(newHash);
+            assertThat(result.getEmbeddingVector().values()).isEqualTo(newVectorValues);
+            verify(queryEmbeddingGenerator).generate(text);
+            verify(resumeEmbeddingRepository, never()).save(any());
+        }
+    }
+
+    private Resume createResume(Long resumeId) {
+        Resume resume = mock(Resume.class);
+        given(resume.getId()).willReturn(resumeId);
+        return resume;
+    }
+
+    private ResumeEmbedding createExistingEmbedding(Resume resume, SourceHash hash, List<Double> vectorValues) {
+        return ResumeEmbedding.create(
+                resume,
+                hash,
+                MODEL,
+                new EmbeddingVector(vectorValues)
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ResumeServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ResumeServiceTest.java
@@ -1,11 +1,27 @@
 package com.generic4.itda.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.generic4.itda.domain.member.Member;
-import com.generic4.itda.domain.resume.*;
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.resume.ResumeForm;
 import com.generic4.itda.dto.resume.ResumeSkillItemForm;
@@ -14,17 +30,23 @@ import com.generic4.itda.repository.ResumeRepository;
 import com.generic4.itda.repository.SkillRepository;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ResumeServiceTest {
+
+    private static final String EMAIL = "user@test.com";
+    private static final Long MEMBER_ID = 1L;
+    private static final Long RESUME_ID = 10L;
+    private static final Long SKILL_ID = 100L;
 
     @InjectMocks
     private ResumeService resumeService;
@@ -38,36 +60,70 @@ class ResumeServiceTest {
     @Mock
     private SkillRepository skillRepository;
 
-    private final String EMAIL = "user@test.com";
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ResumeEmbeddingService resumeEmbeddingService;
+
     private ResumeForm form;
     private Member member;
 
     @BeforeEach
     void setUp() {
-        // ResumeForm.createDefault()는 존재하지 않음 → new ResumeForm() 사용
         form = new ResumeForm();
         form.setIntroduction("수정된 자기소개");
         form.setCareerYears((byte) 5);
-        // Resume.create() 빌더 내부에서 Assert.notNull(writingStatus) 호출 → 필수 설정
+        form.setCareer(new CareerPayload());
+        form.setPreferredWorkType(WorkType.REMOTE);
         form.setWritingStatus(ResumeWritingStatus.WRITING);
+        form.setPortfolioUrl("https://example.com/portfolio");
+        form.setPubliclyVisible(true);
+        form.setAiMatchingEnabled(true);
 
-        member = mock(Member.class);
+        member = Member.create(EMAIL, "hashed-password", "테스터", null, null, "010-1234-5678");
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
     }
 
     @Test
-    @DisplayName("이력서 생성 성공 - 존재 확인 후 회원 조회 순서 보장")
+    @DisplayName("이력서 생성 시 저장된 이력서를 반환하고 임베딩 갱신을 요청한다")
     void create_Success() {
-        // given
         when(resumeRepository.existsByMemberEmailValue(EMAIL)).thenReturn(false);
         when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
         when(resumeRepository.save(any(Resume.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // when
-        resumeService.create(EMAIL, form);
+        Resume saved = resumeService.create(EMAIL, form);
 
-        // then
+        ArgumentCaptor<Resume> resumeCaptor = ArgumentCaptor.forClass(Resume.class);
+        verify(resumeRepository).save(resumeCaptor.capture());
+        Resume captured = resumeCaptor.getValue();
+
+        assertThat(saved).isSameAs(captured);
+        assertThat(saved.getMember()).isSameAs(member);
+        assertThat(saved.getIntroduction()).isEqualTo(form.getIntroduction());
+        assertThat(saved.getCareerYears()).isEqualTo(form.getCareerYears());
+        assertThat(saved.getCareer()).isSameAs(form.getCareer());
+        assertThat(saved.getPreferredWorkType()).isEqualTo(form.getPreferredWorkType());
+        assertThat(saved.getWritingStatus()).isEqualTo(form.getWritingStatus());
+        assertThat(saved.getPortfolioUrl()).isEqualTo(form.getPortfolioUrl());
+        verify(resumeEmbeddingService).createOrRefresh(saved);
+    }
+
+    @Test
+    @DisplayName("이력서 생성 후 임베딩 갱신이 실패해도 생성은 성공한다")
+    void create_Success_WhenEmbeddingRefreshFails() {
+        when(resumeRepository.existsByMemberEmailValue(EMAIL)).thenReturn(false);
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.save(any(Resume.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doThrow(new RuntimeException("embedding failed"))
+                .when(resumeEmbeddingService)
+                .createOrRefresh(any(Resume.class));
+
+        assertThatCode(() -> resumeService.create(EMAIL, form))
+                .doesNotThrowAnyException();
+
         verify(resumeRepository).save(any(Resume.class));
-        verify(memberRepository).findByEmail_Value(EMAIL);
+        verify(resumeEmbeddingService).createOrRefresh(any(Resume.class));
     }
 
     @Test
@@ -95,68 +151,218 @@ class ResumeServiceTest {
     @Test
     @DisplayName("이력서 생성 실패 - 이미 존재하면 회원 조회를 하지 않음")
     void create_Fail_AlreadyExists() {
-        // given
         when(resumeRepository.existsByMemberEmailValue(EMAIL)).thenReturn(true);
 
-        // when & then
         assertThatThrownBy(() -> resumeService.create(EMAIL, form))
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 이력서가 존재합니다.");
 
-        // 검증: 이미 존재하므로 멤버를 찾는 쿼리는 나가지 않아야 함 (리뷰어 포인트)
         verify(memberRepository, never()).findByEmail_Value(anyString());
+        verify(resumeRepository, never()).save(any(Resume.class));
+        verifyNoInteractions(resumeEmbeddingService);
     }
 
     @Test
-    @DisplayName("이력서 수정 - 엔티티 업데이트 및 토글 로직 검증")
+    @DisplayName("이력서 수정 시 기존 경력을 유지하고 공개 여부와 AI 추천 여부를 토글한다")
     void update_Success() {
-        // given
-        Resume resume = mock(Resume.class);
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
+        CareerPayload storedCareer = new CareerPayload();
+
         when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
-        when(resumeRepository.findByMemberId(any())).thenReturn(Optional.of(resume));
-
-        // 초기 상태 설정
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(resume.getCareer()).thenReturn(storedCareer);
         when(resume.isPubliclyVisible()).thenReturn(true);
-        form.setPubliclyVisible(false); // 변경 대상
+        when(resume.isAiMatchingEnabled()).thenReturn(true);
 
-        // when
+        form.setPubliclyVisible(false);
+        form.setAiMatchingEnabled(false);
+
         resumeService.update(EMAIL, form);
 
-        // then
-        verify(resume).update(anyString(), anyByte(), any(), any(), any(), any());
-        verify(resume).togglePubliclyVisible(); // 값이 다르므로 호출되어야 함
+        verify(resume).update(
+                form.getIntroduction(),
+                form.getCareerYears(),
+                storedCareer,
+                form.getPreferredWorkType(),
+                form.getWritingStatus(),
+                form.getPortfolioUrl()
+        );
+        verify(resume).togglePubliclyVisible();
+        verify(resume).toggleAiMatchingEnabled();
+        verify(resumeEmbeddingService).createOrRefresh(resume);
     }
 
     @Test
-    @DisplayName("이력서 조회 - Fetch Join 메서드를 사용하는지 확인")
+    @DisplayName("이력서 수정 시 공개 여부와 AI 추천 여부가 같으면 토글하지 않는다")
+    void update_DoesNotToggle_WhenFlagsAreUnchanged() {
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
+        CareerPayload storedCareer = new CareerPayload();
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(resume.getCareer()).thenReturn(storedCareer);
+        when(resume.isPubliclyVisible()).thenReturn(true);
+        when(resume.isAiMatchingEnabled()).thenReturn(true);
+
+        resumeService.update(EMAIL, form);
+
+        verify(resume, never()).togglePubliclyVisible();
+        verify(resume, never()).toggleAiMatchingEnabled();
+        verify(resumeEmbeddingService).createOrRefresh(resume);
+    }
+
+    @Test
+    @DisplayName("이력서 조회는 Fetch Join 메서드를 사용한다")
     void findByEmail_WithFetchJoin() {
-        // given
-        Resume resume = mock(Resume.class);
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
         when(resumeRepository.findByMemberEmailWithDetails(EMAIL)).thenReturn(Optional.of(resume));
 
-        // when
         Resume result = resumeService.findByEmail(EMAIL);
 
-        // then
-        assertThat(result).isNotNull();
-        // 성능 최적화된 레포지토리 메서드 호출 확인
+        assertThat(result).isSameAs(resume);
         verify(resumeRepository).findByMemberEmailWithDetails(EMAIL);
     }
 
     @Test
-    @DisplayName("스킬 추가 - 이력서 조회 후 스킬 추가 메서드 호출")
+    @DisplayName("전체 스킬 목록 조회는 저장소 결과를 그대로 반환한다")
+    void findAllSkills_ReturnsRepositoryResult() {
+        Skill java = skill(1L, "Java");
+        Skill spring = skill(2L, "Spring");
+        when(skillRepository.findAll()).thenReturn(List.of(java, spring));
+
+        List<Skill> result = resumeService.findAllSkills();
+
+        assertThat(result).containsExactly(java, spring);
+        verify(skillRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("스킬 추가 시 이력서에 스킬을 반영하고 임베딩을 갱신한다")
     void addSkill_Success() {
-        // given
-        Resume resume = mock(Resume.class);
-        Skill skill = mock(Skill.class);
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
+        Skill skill = skill(SKILL_ID, "Java");
 
         when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
-        when(resumeRepository.findByMemberId(any())).thenReturn(Optional.of(resume));
-        when(skillRepository.findById(1L)).thenReturn(Optional.of(skill));
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(skillRepository.findById(SKILL_ID)).thenReturn(Optional.of(skill));
 
-        // when
-        resumeService.addSkill(EMAIL, 1L, Proficiency.INTERMEDIATE);
+        resumeService.addSkill(EMAIL, SKILL_ID, Proficiency.INTERMEDIATE);
 
-        // then
         verify(resume).addSkill(skill, Proficiency.INTERMEDIATE);
+        verify(resumeEmbeddingService).createOrRefresh(resume);
+    }
+
+    @Test
+    @DisplayName("경력 추가 시 career JSON을 갱신하고 임베딩을 갱신한다")
+    void addCareer_Success() throws Exception {
+        Resume resume = storedResumeWithCareer();
+        CareerItemPayload item = careerItem("회사A", "백엔드 개발자", false, "2023-01", "2024-06");
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(objectMapper.writeValueAsString(any(CareerPayload.class))).thenReturn("career-json");
+
+        resumeService.addCareer(EMAIL, item);
+
+        assertThat(resume.getCareer().getItems()).containsExactly(item);
+        verify(resumeRepository).updateCareerJson(RESUME_ID, "career-json");
+        verify(resumeEmbeddingService).createOrRefresh(resume);
+    }
+
+    @Test
+    @DisplayName("경력 수정 시 career JSON을 갱신하고 임베딩을 갱신한다")
+    void updateCareer_Success() throws Exception {
+        CareerItemPayload original = careerItem("회사A", "백엔드 개발자", false, "2022-01", "2023-01");
+        Resume resume = storedResumeWithCareer(original);
+        CareerItemPayload updated = careerItem("회사B", "플랫폼 개발자", true, "2023-02", null);
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(objectMapper.writeValueAsString(any(CareerPayload.class))).thenReturn("updated-career-json");
+
+        resumeService.updateCareer(EMAIL, 0, updated);
+
+        assertThat(resume.getCareer().getItems()).containsExactly(updated);
+        verify(resumeRepository).updateCareerJson(RESUME_ID, "updated-career-json");
+        verify(resumeEmbeddingService).createOrRefresh(resume);
+    }
+
+    @Test
+    @DisplayName("경력 삭제 시 career JSON을 갱신하고 임베딩을 갱신한다")
+    void removeCareer_Success() throws Exception {
+        CareerItemPayload original = careerItem("회사A", "백엔드 개발자", false, "2022-01", "2023-01");
+        Resume resume = storedResumeWithCareer(original);
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(objectMapper.writeValueAsString(any(CareerPayload.class))).thenReturn("removed-career-json");
+
+        resumeService.removeCareer(EMAIL, 0);
+
+        assertThat(resume.getCareer().getItems()).isEmpty();
+        verify(resumeRepository).updateCareerJson(RESUME_ID, "removed-career-json");
+        verify(resumeEmbeddingService).createOrRefresh(resume);
+    }
+
+    @Test
+    @DisplayName("경력 JSON 직렬화에 실패하면 updateCareerJson과 임베딩 갱신을 수행하지 않는다")
+    void addCareer_Fail_WhenCareerSerializationFails() throws Exception {
+        Resume resume = storedResumeWithCareer();
+        CareerItemPayload item = careerItem("회사A", "백엔드 개발자", false, "2023-01", "2024-06");
+
+        when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
+        when(resumeRepository.findByMemberId(MEMBER_ID)).thenReturn(Optional.of(resume));
+        when(objectMapper.writeValueAsString(any(CareerPayload.class)))
+                .thenThrow(new JsonProcessingException("json failed") {
+                });
+
+        assertThatThrownBy(() -> resumeService.addCareer(EMAIL, item))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("경력 JSON 직렬화에 실패했습니다.");
+
+        verify(resumeRepository, never()).updateCareerJson(anyLong(), anyString());
+        verifyNoInteractions(resumeEmbeddingService);
+    }
+
+    private Resume storedResumeWithCareer(CareerItemPayload... items) {
+        CareerPayload career = new CareerPayload();
+        career.setItems(List.of(items));
+
+        Resume resume = Resume.create(
+                member,
+                "기존 자기소개",
+                (byte) 3,
+                career,
+                WorkType.HYBRID,
+                ResumeWritingStatus.DONE,
+                "https://example.com/existing"
+        );
+        ReflectionTestUtils.setField(resume, "id", RESUME_ID);
+        return resume;
+    }
+
+    private Skill skill(Long id, String name) {
+        Skill skill = Skill.create(name, null);
+        ReflectionTestUtils.setField(skill, "id", id);
+        return skill;
+    }
+
+    private CareerItemPayload careerItem(
+            String companyName,
+            String position,
+            boolean currentlyWorking,
+            String startYearMonth,
+            String endYearMonth
+    ) {
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName(companyName);
+        item.setPosition(position);
+        item.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        item.setStartYearMonth(startYearMonth);
+        item.setEndYearMonth(endYearMonth);
+        item.setCurrentlyWorking(currentlyWorking);
+        item.setSummary(companyName + " 경력");
+        item.setTechStack(List.of("Java", "Spring"));
+        return item;
     }
 }

--- a/src/test/java/com/generic4/itda/service/embedding/ResumeEmbeddingTextGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/embedding/ResumeEmbeddingTextGeneratorTest.java
@@ -1,0 +1,351 @@
+package com.generic4.itda.service.embedding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.fixture.MemberFixture;
+import com.generic4.itda.service.recommend.embedding.ResumeEmbeddingTextGenerator;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("ResumeEmbeddingTextGenerator 단위 테스트")
+class ResumeEmbeddingTextGeneratorTest {
+
+    private final ResumeEmbeddingTextGenerator generator = new ResumeEmbeddingTextGenerator();
+
+    @Nested
+    @DisplayName("generate()")
+    class GenerateTest {
+
+        @Test
+        @DisplayName("resume이 null이면 예외가 발생한다")
+        void generate_nullResume_예외발생() {
+            assertThatThrownBy(() -> generator.generate(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("resume은 필수입니다.");
+        }
+
+        @Test
+        @DisplayName("모든 주요 필드가 결과 문자열에 정상적으로 반영된다")
+        void generate_모든필드정상반영() {
+            // given
+            CareerItemPayload item = careerItem(
+                    "Generic4", "Backend Engineer", CareerEmploymentType.FULL_TIME,
+                    "2022-03", "2024-12", false, "Spring Boot API 개발", List.of("Java", "Spring Boot")
+            );
+            Resume resume = createResumeWithCareer(careerPayload(item));
+            resume.addSkill(Skill.create("Java", null), Proficiency.ADVANCED);
+            resume.addSkill(Skill.create("Python", null), Proficiency.BEGINNER);
+
+            // when
+            String result = generator.generate(resume);
+
+            // then
+            assertThat(result).contains("preferredWorkType: HYBRID");
+            assertThat(result).contains("careerYears: 3 years");
+            assertThat(result).contains("introduction: 백엔드 개발자입니다.");
+            assertThat(result).contains("skills: Java (ADVANCED), Python (BEGINNER)");
+            assertThat(result).contains("company: Generic4");
+            assertThat(result).contains("position: Backend Engineer");
+            assertThat(result).contains("employmentType: 정규직");
+            assertThat(result).contains("period: 2022-03~2024-12");
+            assertThat(result).contains("summary: Spring Boot API 개발");
+            assertThat(result).contains("techStack: Java, Spring Boot");
+        }
+
+        @Test
+        @DisplayName("결과 문자열이 정해진 섹션 순서를 유지한다")
+        void generate_전체포맷_섹션순서검증() {
+            // given
+            Resume resume = createMinimalResume();
+
+            // when
+            String result = generator.generate(resume);
+
+            // then
+            assertThat(result).matches(
+                    "(?s)preferredWorkType:.*careerYears:.*introduction:.*skills:.*careerDetails:.*");
+        }
+
+        @Nested
+        @DisplayName("공백 정규화 및 Trim")
+        class NormalizationTest {
+
+            @Test
+            @DisplayName("introduction의 연속 공백과 줄바꿈은 한 칸 공백으로 정규화된다")
+            void generate_introduction_공백정규화() {
+                Resume resume = createMinimalResume();
+                ReflectionTestUtils.setField(resume, "introduction", "  Hello  \n\n  World  ");
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("introduction: Hello World");
+            }
+
+            @Test
+            @DisplayName("career summary의 공백과 줄바꿈은 한 칸 공백으로 정규화된다")
+            void generate_careerSummary_공백정규화() {
+                CareerItemPayload item = careerItem(
+                        "회사A", "개발자", CareerEmploymentType.FULL_TIME,
+                        "2023-01", null, true, "  개발  \n  업무  ", null
+                );
+                Resume resume = createResumeWithCareer(careerPayload(item));
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("summary: 개발 업무");
+            }
+
+            @Test
+            @DisplayName("companyName과 position에 trim이 적용된다")
+            void generate_companyAndPosition_trimApplied() {
+                CareerItemPayload item = careerItem(
+                        "  Generic4  ", "  Backend  ", CareerEmploymentType.FULL_TIME,
+                        "2023-01", null, true, "summary", null
+                );
+                Resume resume = createResumeWithCareer(careerPayload(item));
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("company: Generic4");
+                assertThat(result).contains("position: Backend");
+            }
+        }
+
+        @Nested
+        @DisplayName("nullable 필드 처리")
+        class NullableFieldsTest {
+
+            @Test
+            @DisplayName("주요 필드가 null이거나 비어 있으면 빈 값으로 처리한다")
+            void generate_nullable필드_빈값처리() {
+                Resume resume = createMinimalResume();
+                ReflectionTestUtils.setField(resume, "preferredWorkType", null);
+                ReflectionTestUtils.setField(resume, "careerYears", null);
+                ReflectionTestUtils.setField(resume, "introduction", null);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("preferredWorkType: \n");
+                assertThat(result).contains("careerYears: \n");
+                assertThat(result).contains("introduction: \n");
+                assertThat(result).contains("skills: \n");
+            }
+
+            @Test
+            @DisplayName("career가 null이거나 항목이 없으면 careerDetails는 빈 섹션으로 남는다")
+            void generate_careerNullOrEmpty_빈섹션처리() {
+                Resume resume = createMinimalResume();
+                ReflectionTestUtils.setField(resume, "career", null);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).endsWith("careerDetails:");
+            }
+        }
+
+        @Nested
+        @DisplayName("스킬 포맷")
+        class SkillFormatTest {
+
+            @Test
+            @DisplayName("proficiency가 null이면 스킬 이름만 출력된다")
+            void generate_skillProficiency가없으면스킬명만반영() {
+                Resume resume = createMinimalResume();
+                resume.addSkill(Skill.create("Java", null), Proficiency.ADVANCED);
+                ResumeSkill resumeSkill = resume.getSkills().first();
+                ReflectionTestUtils.setField(resumeSkill, "proficiency", null);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("skills: Java\n");
+            }
+
+            @Test
+            @DisplayName("skill 객체 자체가 null인 ResumeSkill은 안전하게 무시한다")
+            void generate_nullSkillObject_무시() {
+                Resume resume = createMinimalResume();
+                resume.addSkill(Skill.create("Java", null), Proficiency.ADVANCED);
+                ResumeSkill resumeSkill = resume.getSkills().first();
+                ReflectionTestUtils.setField(resumeSkill, "skill", null);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("skills: ");
+                assertThat(result).doesNotContain("null");
+            }
+
+            @Test
+            @DisplayName("여러 스킬이 ', '로 join된다")
+            void generate_multipleSkills_joinedWithComma() {
+                Resume resume = createMinimalResume();
+                resume.addSkill(Skill.create("Docker", null), Proficiency.INTERMEDIATE);
+                resume.addSkill(Skill.create("Kotlin", null), Proficiency.BEGINNER);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("skills: Docker (INTERMEDIATE), Kotlin (BEGINNER)");
+            }
+        }
+
+        @Nested
+        @DisplayName("경력 항목 포맷")
+        class CareerItemFormatTest {
+
+            @Test
+            @DisplayName("여러 경력 항목은 줄바꿈으로 연결되며 입력 순서가 유지된다")
+            void generate_multipleCareerItems_joinedWithNewlineAndOrdered() {
+                CareerItemPayload item1 = careerItem("회사A", "역할A", null, "2021", "2022", false, null, null);
+                CareerItemPayload item2 = careerItem("회사B", "역할B", null, "2022", null, true, null, null);
+                Resume resume = createResumeWithCareer(careerPayload(item1, item2));
+
+                String result = generator.generate(resume);
+
+                String details = result.substring(result.indexOf("careerDetails:"));
+                assertThat(details).contains("- company: 회사A");
+                assertThat(details).contains("- company: 회사B");
+                assertThat(details.indexOf("회사A")).isLessThan(details.indexOf("회사B"));
+            }
+
+            @Test
+            @DisplayName("null인 경력 항목은 결과에서 제외된다")
+            void generate_nullCareerItem_제외() {
+                List<CareerItemPayload> items = new ArrayList<>();
+                items.add(null);
+                items.add(careerItem("회사A", "개발자", null, null, null, false, null, null));
+
+                CareerPayload payload = new CareerPayload();
+                payload.setItems(items);
+                Resume resume = createResumeWithCareer(payload);
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("careerDetails:");
+                assertThat(result).contains("- company: 회사A");
+                assertThat(result).doesNotContain("\n- \n");
+            }
+
+            @Test
+            @DisplayName("currentlyWorking=true이면 종료일 대신 present가 출력된다")
+            void generate_currentlyWorking이면_present_출력() {
+                CareerItemPayload item = careerItem("회사A", "개발자", null, "2023-01", null, true, null, null);
+                Resume resume = createResumeWithCareer(careerPayload(item));
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("period: 2023-01~present");
+            }
+
+            @Test
+            @DisplayName("startYearMonth와 endYearMonth 조합 로직을 검증한다")
+            void generate_period_조합로직() {
+                // start만 있는 경우
+                CareerItemPayload startOnly = careerItem("A", "P", null, "2023", null, false, null, null);
+                assertThat(generator.generate(createResumeWithCareer(careerPayload(startOnly))))
+                        .contains("period: 2023 |");
+
+                // end만 있는 경우
+                CareerItemPayload endOnly = careerItem("B", "P", null, null, "2024", false, null, null);
+                assertThat(generator.generate(createResumeWithCareer(careerPayload(endOnly))))
+                        .contains("period: 2024 |");
+
+                // 둘 다 없는 경우
+                CareerItemPayload none = careerItem("C", "P", null, null, null, false, null, null);
+                assertThat(generator.generate(createResumeWithCareer(careerPayload(none))))
+                        .contains("period:  |");
+            }
+        }
+
+        @Nested
+        @DisplayName("techStack 처리")
+        class TechStackTest {
+
+            @Test
+            @DisplayName("blank 값은 제외하고 나머지를 trim 후 ', '로 join한다")
+            void generate_techStack_정규화및join() {
+                CareerItemPayload item = careerItem(
+                        "회사A", "개발자", null, null, null, false, null,
+                        List.of(" Java ", "  ", " Spring Boot ", "")
+                );
+                Resume resume = createResumeWithCareer(careerPayload(item));
+
+                String result = generator.generate(resume);
+
+                assertThat(result).contains("techStack: Java, Spring Boot");
+            }
+        }
+    }
+
+    // ---- fixture helpers ----
+
+    private Resume createMinimalResume() {
+        CareerPayload emptyCareer = new CareerPayload();
+        Member member = MemberFixture.createMember();
+        return Resume.create(
+                member,
+                "최소 자기소개",
+                (byte) 0,
+                emptyCareer,
+                WorkType.SITE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+    }
+
+    private Resume createResumeWithCareer(CareerPayload career) {
+        Member member = MemberFixture.createMember();
+        return Resume.create(
+                member,
+                "백엔드 개발자입니다.",
+                (byte) 3,
+                career,
+                WorkType.HYBRID,
+                ResumeWritingStatus.DONE,
+                null
+        );
+    }
+
+    private CareerPayload careerPayload(CareerItemPayload... items) {
+        CareerPayload payload = new CareerPayload();
+        payload.setItems(new ArrayList<>(List.of(items)));
+        return payload;
+    }
+
+    private CareerItemPayload careerItem(
+            String companyName,
+            String position,
+            CareerEmploymentType employmentType,
+            String startYearMonth,
+            String endYearMonth,
+            boolean currentlyWorking,
+            String summary,
+            List<String> techStack
+    ) {
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName(companyName);
+        item.setPosition(position);
+        item.setEmploymentType(employmentType);
+        item.setStartYearMonth(startYearMonth);
+        item.setEndYearMonth(endYearMonth);
+        item.setCurrentlyWorking(currentlyWorking);
+        item.setSummary(summary);
+        if (techStack != null) {
+            item.setTechStack(new ArrayList<>(techStack));
+        }
+        return item;
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingSourceHashGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/embedding/ResumeEmbeddingSourceHashGeneratorTest.java
@@ -1,0 +1,101 @@
+package com.generic4.itda.service.recommend.embedding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.generic4.itda.domain.recommendation.vo.SourceHash;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResumeEmbeddingSourceHashGenerator 단위 테스트")
+class ResumeEmbeddingSourceHashGeneratorTest {
+
+    private final ResumeEmbeddingSourceHashGenerator generator = new ResumeEmbeddingSourceHashGenerator();
+
+    @Test
+    @DisplayName("동일한 입력 문자열에 대해 항상 동일한 SourceHash를 반환해야 한다")
+    void should_return_same_hash_for_same_input() {
+        // given
+        String sourceText = "This is a sample source text for hashing.";
+
+        // when
+        SourceHash hash1 = generator.generate(sourceText);
+        SourceHash hash2 = generator.generate(sourceText);
+
+        // then
+        // 객체 equals 대신 getValue() 값을 직접 비교하여 검증
+        assertThat(hash1.getValue()).isEqualTo(hash2.getValue());
+    }
+
+    @Test
+    @DisplayName("서로 다른 입력 문자열에 대해 서로 다른 SourceHash를 반환해야 한다")
+    void should_return_different_hash_for_different_input() {
+        // given
+        String sourceText1 = "First input text";
+        String sourceText2 = "Second input text";
+
+        // when
+        SourceHash hash1 = generator.generate(sourceText1);
+        SourceHash hash2 = generator.generate(sourceText2);
+
+        // then
+        assertThat(hash1.getValue()).isNotEqualTo(hash2.getValue());
+    }
+
+    @Test
+    @DisplayName("현재 생성기 구현은 입력 문자열을 trim()하지 않으므로 공백이 다르면 다른 해시를 반환한다")
+    void should_return_different_hash_when_whitespaces_differ_due_to_no_trim_in_generator() {
+        // given
+        String sourceText = "  Normal text  ";
+        String trimmedText = "Normal text";
+
+        // when
+        SourceHash hash1 = generator.generate(sourceText);
+        SourceHash hash2 = generator.generate(trimmedText);
+
+        // then
+        // 현재 generator 구현(sourceText.getBytes())에 따르면 두 해시는 달라야 함
+        assertThat(hash1.getValue()).isNotEqualTo(hash2.getValue());
+    }
+
+    @Nested
+    @DisplayName("잘못된 입력 처리")
+    class InvalidInputTest {
+
+        @Test
+        @DisplayName("null 입력 시 예외가 발생해야 한다")
+        void should_throw_exception_when_input_is_null() {
+            assertThatThrownBy(() -> generator.generate(null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 입력 시 예외가 발생해야 한다")
+        void should_throw_exception_when_input_is_empty() {
+            assertThatThrownBy(() -> generator.generate(""))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("공백 문자열 입력 시 예외가 발생해야 한다")
+        void should_throw_exception_when_input_is_blank() {
+            assertThatThrownBy(() -> generator.generate("   "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("반환된 SourceHash의 value는 SHA-256 hex 문자열이므로 길이는 64여야 한다")
+    void should_have_length_64_for_sha256_hex_string() {
+        // given
+        String sourceText = "Any source text";
+
+        // when
+        SourceHash hash = generator.generate(sourceText);
+
+        // then
+        assertThat(hash.getValue()).hasSize(64);
+        assertThat(hash.getValue()).matches("^[0-9a-f]{64}$");
+    }
+}


### PR DESCRIPTION
## 🔎 What

* 이력서(`Resume`) 데이터를 기반으로 임베딩을 생성하고 관리하는 기능을 구현했습니다.
* `ResumeEmbeddingTextGenerator`를 통해 이력서 주요 정보(skills, career, introduction 등)를 임베딩 입력 텍스트로 변환하도록 구성했습니다.
* 텍스트 기반 `sourceHash`를 도입하여, 이력서 변경 여부를 감지하고 불필요한 임베딩 재생성을 방지하도록 했습니다.
* `(resume_id, embedding_model)` 기준으로 기존 `ResumeEmbedding`을 조회하여, 동일 데이터는 재사용하고 변경 시에만 갱신하도록 `createOrRefresh` 로직을 구현했습니다.
* `ResumeService`의 생성/수정/경력/스킬 변경 지점에 임베딩 생성 로직을 연동하여, 이력서 변경 시 자동으로 임베딩이 최신 상태를 유지하도록 했습니다.
* 관련 단위 테스트(텍스트 생성, hash 생성, 서비스 로직) 및 통합 테스트(이력서 → 임베딩 생성 → 저장 흐름)를 추가했습니다.

## 🔗 Issue

* Closes: #90 

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
