### PR TITLE
[Feat] 추천 후보 풀에서 제안서 작성자 제외 처리 (DB pre-filter 적용)

### DIFF
--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -55,6 +55,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .where(
                         recommendable(),
                         workTypeMatches(proposalPosition),
+                        excludeProposalOwner(proposalPosition),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -78,7 +79,8 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .from(resume)
                 .where(
                         recommendable(),
-                        workTypeMatches(proposalPosition)
+                        workTypeMatches(proposalPosition),
+                        excludeProposalOwner(proposalPosition)
                 )
                 .orderBy(
                         resume.careerYears.desc(),
@@ -107,5 +109,10 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
             case REMOTE -> resume.preferredWorkType.in(WorkType.REMOTE, WorkType.HYBRID);
             case HYBRID -> resume.preferredWorkType.eq(WorkType.HYBRID);
         };
+    }
+
+    private BooleanExpression excludeProposalOwner(ProposalPosition proposalPosition) {
+        Long proposalOwnerId = proposalPosition.getProposal().getMember().getId();
+        return resume.member.id.ne(proposalOwnerId);
     }
 }

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -18,6 +18,7 @@ import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.service.recommend.CandidatePoolRow;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -201,6 +202,44 @@ class ResumeQueryRepositoryTest {
                 .containsExactly(doneResume.getId());
     }
 
+    @DisplayName("findCandidatePool은 제안서 작성자의 이력서를 후보 풀에서 제외한다")
+    @Test
+    void findCandidatePool_excludesProposalOwnerResume() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-owner", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-owner", null));
+
+        Resume proposalOwnerResume = saveResume(
+                "pool-owner",
+                (byte) 20,
+                true,
+                true,
+                true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED)
+        );
+        Resume otherResume = saveResume(
+                "pool-other",
+                (byte) 10,
+                true,
+                true,
+                true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                createProposalPosition(null, proposalOwnerResume.getMember()),
+                List.of(java.getId(), spring.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(otherResume.getId());
+    }
+
     @DisplayName("findCandidatePool은 근무 형태 정책 조합에 따라 후보를 필터링한다")
     @ParameterizedTest(name = "proposalWorkType={0}")
     @MethodSource("workTypePolicyCases")
@@ -297,6 +336,23 @@ class ResumeQueryRepositoryTest {
 
         // then
         assertThat(result).containsExactly(doneResume.getId());
+    }
+
+    @DisplayName("findRecommendableResumeIds는 제안서 작성자의 이력서를 fallback 후보에서 제외한다")
+    @Test
+    void findRecommendableResumeIds_excludesProposalOwnerResume() {
+        // given
+        Resume proposalOwnerResume = saveResume("recommend-owner", (byte) 10, true, true, true);
+        Resume otherResume = saveResume("recommend-other", (byte) 7, true, true, true);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(
+                createProposalPosition(null, proposalOwnerResume.getMember()),
+                10
+        );
+
+        // then
+        assertThat(result).containsExactly(otherResume.getId());
     }
 
     @DisplayName("findRecommendableResumeIds는 fallback 조회 경로에서도 근무 형태 정책 조합을 적용한다")
@@ -454,8 +510,12 @@ class ResumeQueryRepositoryTest {
     }
 
     private ProposalPosition createProposalPosition(ProposalWorkType workType) {
+        return createProposalPosition(workType, saveProposalOwnerMember(UUID.randomUUID().toString()));
+    }
+
+    private ProposalPosition createProposalPosition(ProposalWorkType workType, Member proposalOwner) {
         Proposal proposal = Proposal.create(
-                createMember(),
+                proposalOwner,
                 "추천 요청",
                 "raw-input",
                 null,
@@ -477,6 +537,17 @@ class ResumeQueryRepositoryTest {
                 null,
                 workPlace
         );
+    }
+
+    private Member saveProposalOwnerMember(String suffix) {
+        String phone = "010-2222-" + String.format("%04d", Math.abs(suffix.hashCode() % 10_000));
+        return memberRepository.save(createMember(
+                "proposal-owner-" + suffix + "@example.com",
+                "hashed-password",
+                "proposal-owner-" + suffix,
+                "proposal-owner-" + suffix,
+                phone
+        ));
     }
 
     private record SkillAssignment(Skill skill, Proficiency proficiency) {


### PR DESCRIPTION
## 🔎 What

추천 후보 풀 구성 시 제안서 작성자 본인의 이력서가 포함되는 문제를 해결하기 위해,
DB 조회 단계(Repository)에서 작성자 제외 조건을 pre-filter로 적용했습니다.

- `ResumeQueryRepositoryImpl`의 후보 조회 쿼리에 `resume.member.id != proposalOwnerId` 조건 추가
- `findCandidatePool(...)`, `findRecommendableResumeIds(...)` 두 경로 모두 동일 정책 적용
- `excludeProposalOwner(...)` predicate로 분리하여 기존 조건들과 조합
- Repository 테스트를 통해 작성자 제외 정책이 정상 동작하는지 검증

이를 통해 후보 슬롯 낭비를 방지하고, 불필요한 스코어링/임베딩/LLM 처리 비용을 줄이며,
추천 결과의 일관성과 신뢰도를 개선했습니다.

## 🔗 Issue

- Closes: #97 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?