### PR TITLE
 [Feat] 추천 진행 및 결과 보기 화면 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -2,6 +2,7 @@ package com.generic4.itda.controller;
 
 import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
+import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.recommend.RecommendationEntryService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -102,6 +104,30 @@ public class RecommendationController {
         }
     }
 
+    @GetMapping("/proposals/{proposalId}/recommendations/results")
+    public String results(
+            @PathVariable Long proposalId,
+            @RequestParam Long runId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model
+    ) {
+        try {
+            RecommendationResultsViewModel view = recommendationRunQueryService
+                    .getRecommendationResults(proposalId, runId, principal.getEmail());
+
+            model.addAttribute("view", view);
+            return "recommendation/results";
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("추천 결과 조회 실패. proposalId={}, runId={}, email={}",
+                    proposalId, runId, principal.getEmail(), e);
+
+            model.addAttribute("title", "추천 결과를 확인할 수 없습니다.");
+            model.addAttribute("message", toResultsUserMessage(e));
+            model.addAttribute("backUrl", "/proposals/" + proposalId + "/runs/" + runId);
+            return "recommendation/error";
+        }
+    }
+
     private static String toUserMessage(RuntimeException e) {
         if (e instanceof IllegalArgumentException) {
             return "추천 요청을 처리할 수 없습니다. 선택한 포지션을 다시 확인해주세요.";
@@ -110,6 +136,13 @@ public class RecommendationController {
             return "현재 상태에는 추천을 실행할 수 없습니다.";
         }
         return "추천 요청 처리 중 문제가 발생했습니다. 다시 시도해주세요.";
+    }
+
+    private static String toResultsUserMessage(RuntimeException e) {
+        if (e instanceof IllegalStateException) {
+            return "추천이 아직 완료되지 않았습니다. 잠시 후 다시 시도해주세요.";
+        }
+        return "추천 결과를 불러오는 중 문제가 발생했습니다.";
     }
 
     private static String toRunStatusUserMessage(IllegalArgumentException e) {

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationCandidateItem(
+        Long resultId,
+        int rank,
+        String maskedName,
+        String introduction,
+        int careerYears,
+        String preferredWorkTypeLabel,
+        int finalScorePercent,
+        int embeddingScorePercent,
+        List<String> matchedSkills,
+        List<String> highlights,
+        String llmReason,
+        String llmStatusLabel,
+        boolean llmReady
+) {}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResultsViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResultsViewModel.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationResultsViewModel(
+        Long proposalId,
+        Long runId,
+        String proposalTitle,
+        String positionTitle,
+        int topK,
+        Integer candidateCount,
+        List<RecommendationCandidateItem> candidates
+) {}

--- a/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
@@ -1,9 +1,19 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.RecommendationResult;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecommendationResultRepository extends JpaRepository<RecommendationResult, Long> {
 
     void deleteAllByRecommendationRun_ProposalPosition_Proposal_Id(Long proposalId);
+
+    @Query("SELECT r FROM RecommendationResult r " +
+            "JOIN FETCH r.resume res " +
+            "JOIN FETCH res.member " +
+            "WHERE r.recommendationRun.id = :runId " +
+            "ORDER BY r.rank ASC")
+    List<RecommendationResult> findByRunIdWithResume(@Param("runId") Long runId);
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -1,10 +1,20 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.LlmStatus;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
+import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import java.math.BigDecimal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecommendationRunQueryService {
 
     private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationResultRepository recommendationResultRepository;
 
     public RecommendationRunStatusViewModel getRecommendationRunStatus(Long proposalId, Long runId, String email) {
         RecommendationRun run = recommendationRunRepository.findDetailById(runId)
@@ -27,6 +38,99 @@ public class RecommendationRunQueryService {
         validateOwnership(proposal, email);
 
         return toViewModel(proposal, run);
+    }
+
+    public RecommendationResultsViewModel getRecommendationResults(Long proposalId, Long runId, String email) {
+        RecommendationRun run = recommendationRunRepository.findDetailById(runId)
+                .orElseThrow(() -> new IllegalArgumentException("추천 실행 정보를 찾을 수 없습니다."));
+
+        ProposalPosition proposalPosition = run.getProposalPosition();
+        Proposal proposal = proposalPosition.getProposal();
+
+        validateProposalMatches(proposal, proposalId);
+        validateOwnership(proposal, email);
+
+        if (!run.isComputed()) {
+            throw new IllegalStateException("추천 결과가 아직 준비되지 않았습니다.");
+        }
+
+        List<RecommendationResult> results = recommendationResultRepository.findByRunIdWithResume(runId);
+
+        List<RecommendationCandidateItem> candidates = results.stream()
+                .map(this::toCandidateItem)
+                .toList();
+
+        return new RecommendationResultsViewModel(
+                proposal.getId(),
+                run.getId(),
+                proposal.getTitle(),
+                resolvePositionTitle(proposalPosition),
+                run.getTopK(),
+                run.getCandidateCount(),
+                candidates
+        );
+    }
+
+    private RecommendationCandidateItem toCandidateItem(RecommendationResult result) {
+        Resume resume = result.getResume();
+        Member member = resume.getMember();
+        ReasonFacts facts = result.getReasonFacts();
+
+        String rawName = member.getNickname() != null && !member.getNickname().isBlank()
+                ? member.getNickname()
+                : member.getName();
+        String displayName = maskName(rawName);
+
+        String introduction = resume.getIntroduction() != null ? resume.getIntroduction() : "";
+
+        int careerYears = facts != null && facts.careerYears() != null
+                ? facts.careerYears()
+                : (resume.getCareerYears() != null ? (int) resume.getCareerYears() : 0);
+
+        String workTypeLabel = resume.getPreferredWorkType() != null
+                ? resume.getPreferredWorkType().getDescription()
+                : "미정";
+
+        int finalPct = result.getFinalScore() != null
+                ? result.getFinalScore().multiply(BigDecimal.valueOf(100)).intValue()
+                : 0;
+        int embedPct = result.getEmbeddingScore() != null
+                ? result.getEmbeddingScore().multiply(BigDecimal.valueOf(100)).intValue()
+                : 0;
+
+        List<String> matchedSkills = facts != null && facts.matchedSkills() != null
+                ? facts.matchedSkills() : List.of();
+        List<String> highlights = facts != null && facts.highlights() != null
+                ? facts.highlights() : List.of();
+
+        return new RecommendationCandidateItem(
+                result.getId(),
+                result.getRank(),
+                displayName,  // masked
+                introduction,
+                careerYears,
+                workTypeLabel,
+                finalPct,
+                embedPct,
+                matchedSkills,
+                highlights,
+                result.getLlmReason(),
+                result.getLlmStatus().getDescription(),
+                result.getLlmStatus() == LlmStatus.READY
+        );
+    }
+
+    private static String maskName(String name) {
+        if (name == null || name.length() <= 1) return name;
+        if (name.length() == 2) return name.charAt(0) + "*";
+        return name.charAt(0) + "*".repeat(name.length() - 2) + name.charAt(name.length() - 1);
+    }
+
+    private static String resolvePositionTitle(ProposalPosition position) {
+        if (position.getTitle() != null && !position.getTitle().isBlank()) {
+            return position.getTitle();
+        }
+        return position.getPosition().getName();
     }
 
     private void validateProposalMatches(Proposal proposal, Long proposalId) {

--- a/src/main/resources/templates/recommendation/entry.html
+++ b/src/main/resources/templates/recommendation/entry.html
@@ -3,191 +3,169 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-  <title>추천 진입</title>
+    <title th:text="${entry.proposalTitle} + ' | 추천 실행'">추천 실행 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
-  <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
-    <div class="mx-auto flex w-full max-w-5xl flex-col gap-6">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-4xl">
 
-      <!-- 헤더 -->
-      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <p class="text-xs font-black uppercase tracking-widest text-slate-400">
-              Recommendation Entry
-            </p>
-            <h1 class="mt-2 text-3xl font-black tracking-tight text-slate-950"
-                th:text="${entry.proposalTitle}">
-              제안서 제목
-            </h1>
-            <p class="mt-3 text-sm text-slate-500">
-              현재 제안서 상태:
-              <span class="font-semibold text-slate-800"
-                    th:text="${entry.proposalStatus}">
-                                매칭 진행
-                            </span>
-            </p>
-          </div>
+            <!-- ── 상단 액션 바 ── -->
+            <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div class="flex items-center gap-4">
+                        <a th:href="@{/proposals/{id}(id=${entry.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            제안서로
+                        </a>
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation</p>
+                            <h2 class="mt-1 text-xl font-bold tracking-tight text-slate-900"
+                                th:text="${entry.proposalTitle}">제안서 제목</h2>
+                        </div>
+                    </div>
 
-          <span th:classappend="${entry.runnable}
-                            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                            : 'border-amber-200 bg-amber-50 text-amber-700'"
-                class="rounded-full border px-3 py-1 text-xs font-bold"
-                th:text="${entry.runnable} ? '추천 실행 가능' : '추천 실행 불가'">
-                        추천 실행 가능
+                    <span th:classappend="${entry.runnable}
+                                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                                : 'border-amber-200 bg-amber-50 text-amber-700'"
+                          class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold">
+                        <i th:if="${entry.runnable}" data-lucide="circle-check" class="h-3.5 w-3.5"></i>
+                        <i th:unless="${entry.runnable}" data-lucide="circle-x" class="h-3.5 w-3.5"></i>
+                        <span th:text="${entry.runnable} ? '추천 실행 가능' : '추천 실행 불가'">추천 실행 가능</span>
                     </span>
-        </div>
-
-        <div th:if="${errorMessage}"
-             class="mt-5 rounded-2xl bor
-             der border-rose-200 bg-rose-50 px-4 py-4">
-          <p class="text-sm font-semibold text-rose-700"
-             th:text="${errorMessage}">
-            오류 메시지
-          </p>
-        </div>
-
-        <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-          <p class="text-sm leading-6 text-slate-600"
-             th:text="${entry.helperMessage}">
-            안내 문구
-          </p>
-        </div>
-      </section>
-
-      <!-- 추천 요청 폼 -->
-      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
-        <form th:action="@{/proposals/{proposalId}/recommendations(proposalId=${entry.proposalId})}"
-              th:object="${requestForm}"
-              method="post"
-              class="space-y-6">
-
-          <!-- 포지션 선택 -->
-          <div>
-            <label for="proposalPositionId"
-                   class="text-xs font-black uppercase tracking-widest text-slate-400">
-              추천 대상 포지션
-            </label>
-
-            <div class="relative mt-3">
-              <select id="proposalPositionId"
-                      th:field="*{proposalPositionId}"
-                      class="w-full appearance-none rounded-2xl border border-slate-200 bg-slate-50 py-3 pl-4 pr-10 text-sm font-semibold text-slate-900 outline-none transition focus:border-slate-400">
-                <option value="">포지션을 선택해주세요</option>
-                <option th:each="position : ${entry.positions}"
-                        th:value="${position.proposalPositionId}"
-                        th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
-                  백엔드 개발자
-                </option>
-              </select>
-              <div class="pointer-events-none absolute inset-y-0 right-4 flex items-center">
-                <svg class="h-4 w-4 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
-                </svg>
-              </div>
+                </div>
             </div>
 
-            <p th:if="${#fields.hasErrors('proposalPositionId')}"
-               th:errors="*{proposalPositionId}"
-               class="mt-2 text-sm font-semibold text-rose-600">
-              포지션을 선택해주세요.
-            </p>
-          </div>
+            <!-- ── 안내 메시지 ── -->
+            <div th:if="${errorMessage}"
+                 class="mb-4 flex items-center gap-3 rounded-2xl border border-rose-200 bg-rose-50 px-5 py-4">
+                <i data-lucide="triangle-alert" class="h-4 w-4 shrink-0 text-rose-500"></i>
+                <p class="text-sm font-semibold text-rose-700" th:text="${errorMessage}">오류 메시지</p>
+            </div>
 
-          <!-- 포지션 정보 카드 -->
-          <div class="space-y-4">
-            <div th:each="position : ${entry.positions}"
-                 th:classappend="${position.proposalPositionId == entry.selectedProposalPositionId}
-                                ? 'border-blue-200 bg-blue-50/40'
-                                : 'border-slate-200 bg-slate-50'"
-                 class="rounded-[24px] border p-5 transition">
+            <div class="mb-6 flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-5 py-4">
+                <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-slate-400"></i>
+                <p class="text-sm leading-relaxed text-slate-600" th:text="${entry.helperMessage}">안내 문구</p>
+            </div>
 
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <h2 class="text-xl font-black tracking-tight text-slate-950"
-                      th:text="${position.positionTitle}">
-                    백엔드 개발자
-                  </h2>
+            <!-- ── 추천 요청 폼 ── -->
+            <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
+                <form th:action="@{/proposals/{proposalId}/recommendations(proposalId=${entry.proposalId})}"
+                      th:object="${requestForm}"
+                      method="post"
+                      class="space-y-6">
+                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
 
-                  <p th:if="${position.positionCategoryName != null and position.positionCategoryName != position.positionTitle}"
-                     class="mt-2 inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-500"
-                     th:text="${position.positionCategoryName}">
-                    백엔드
-                  </p>
+                    <!-- 포지션 선택 -->
+                    <div>
+                        <div class="flex items-center gap-1.5 mb-3">
+                            <i data-lucide="layers" class="h-4 w-4 text-slate-400"></i>
+                            <label for="proposalPositionId"
+                                   class="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                                추천 대상 포지션
+                            </label>
+                        </div>
 
-                  <p class="mt-2 text-sm text-slate-500">
-                    모집 인원
-                    <span class="font-semibold text-slate-800"
-                          th:text="${position.headCount != null ? position.headCount + '명' : '미정'}">
-                                            2명
-                                        </span>
-                    <span class="mx-2 text-slate-300">•</span>
-                    예산
-                    <span class="font-semibold text-slate-800"
-                          th:text="${position.budgetText}">
-                                            5,000,000 ~ 9,000,000
-                                        </span>
-                    <span class="mx-2 text-slate-300">•</span>
-                    기간
-                    <span class="font-semibold text-slate-800"
-                          th:text="${position.expectedPeriod != null ? position.expectedPeriod + '주' : '미정'}">
-                                            8주
-                                        </span>
-                  </p>
-                </div>
+                        <div class="relative">
+                            <select id="proposalPositionId"
+                                    th:field="*{proposalPositionId}"
+                                    class="w-full appearance-none rounded-2xl border border-slate-200 bg-slate-50 py-3 pl-4 pr-10 text-sm font-semibold text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100">
+                                <option value="">포지션을 선택해주세요</option>
+                                <option th:each="position : ${entry.positions}"
+                                        th:value="${position.proposalPositionId}"
+                                        th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
+                                    백엔드 개발자
+                                </option>
+                            </select>
+                            <div class="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+                                <i data-lucide="chevron-down" class="h-4 w-4 text-slate-400"></i>
+                            </div>
+                        </div>
 
-                <span th:if="${position.proposalPositionId == entry.selectedProposalPositionId}"
-                      class="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700">
-                                    기본 선택 포지션
+                        <p th:if="${#fields.hasErrors('proposalPositionId')}"
+                           th:errors="*{proposalPositionId}"
+                           class="mt-2 text-sm font-semibold text-rose-600">
+                            포지션을 선택해주세요.
+                        </p>
+                    </div>
+
+                    <!-- 포지션 카드 목록 -->
+                    <div class="space-y-3">
+                        <article th:each="position : ${entry.positions}"
+                                 th:classappend="${position.proposalPositionId == entry.selectedProposalPositionId}
+                                    ? 'border-blue-200 bg-blue-50/40'
+                                    : 'border-slate-200 bg-slate-50'"
+                                 class="rounded-[24px] border p-5 transition">
+
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <h3 class="text-base font-bold tracking-tight text-slate-900"
+                                        th:text="${position.positionTitle}">백엔드 개발자</h3>
+                                    <p th:if="${position.positionCategoryName != null and position.positionCategoryName != position.positionTitle}"
+                                       class="mt-1 text-sm font-medium text-slate-500"
+                                       th:text="${position.positionCategoryName}">백엔드</p>
+                                </div>
+
+                                <span th:if="${position.proposalPositionId == entry.selectedProposalPositionId}"
+                                      class="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700">
+                                    기본 선택
                                 </span>
-              </div>
+                            </div>
 
-              <div class="mt-5">
-                <p class="text-xs font-black uppercase tracking-widest text-slate-400">
-                  요구 스킬
-                </p>
+                            <!-- 수치 -->
+                            <div class="mt-3 flex flex-wrap gap-4">
+                                <div>
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">인원</p>
+                                    <p class="mt-1 text-sm font-bold text-slate-900"
+                                       th:text="${position.headCount != null ? position.headCount + '명' : '미정'}">2명</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
+                                    <p class="mt-1 text-sm font-bold text-slate-900"
+                                       th:text="${position.budgetText != null ? position.budgetText : '미정'}">5,000,000 ~ 9,000,000</p>
+                                </div>
+                                <div>
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">기간</p>
+                                    <p class="mt-1 text-sm font-bold text-slate-900"
+                                       th:text="${position.expectedPeriod != null ? position.expectedPeriod + '주' : '미정'}">8주</p>
+                                </div>
+                            </div>
 
-                <div class="mt-3 flex flex-wrap gap-2"
-                     th:if="${!#lists.isEmpty(position.skills)}">
+                            <!-- 스킬 -->
+                            <div class="mt-4" th:if="${!#lists.isEmpty(position.skills)}">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">요구 스킬</p>
+                                <div class="mt-2 flex flex-wrap gap-2">
                                     <span th:each="skill : ${position.skills}"
-                                          class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
+                                          th:classappend="${skill.importanceLabel == '필수'} ? 'border-slate-200 bg-white text-slate-700' : 'border-blue-100 bg-blue-50 text-blue-700'"
+                                          class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold">
                                         <span th:text="${skill.skillName}">Java</span>
-                                        <span class="mx-1 text-slate-300">·</span>
-                                        <span class="text-slate-500"
-                                              th:text="${skill.importanceLabel}">
-                                            필수
-                                        </span>
+                                        <span class="text-slate-300">·</span>
+                                        <span th:text="${skill.importanceLabel}">필수</span>
                                     </span>
-                </div>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
 
-                <p th:if="${#lists.isEmpty(position.skills)}"
-                   class="mt-3 text-sm text-slate-500">
-                  등록된 스킬이 없습니다.
-                </p>
-              </div>
-            </div>
-          </div>
+                    <!-- 액션 -->
+                    <div class="flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-6">
+                        <p class="text-sm text-slate-500">추천 요청 후 실행 상태 페이지로 이동합니다.</p>
+                        <button type="submit"
+                                th:disabled="${!entry.runnable}"
+                                th:classappend="${entry.runnable}
+                                    ? 'bg-blue-600 text-white shadow-lg shadow-blue-100 hover:bg-blue-700'
+                                    : 'cursor-not-allowed bg-slate-100 text-slate-400'"
+                                class="inline-flex items-center gap-2 rounded-2xl px-6 py-3 text-sm font-bold transition">
+                            <i data-lucide="sparkles" class="h-4 w-4"></i>
+                            추천 시작
+                        </button>
+                    </div>
+                </form>
+            </section>
 
-          <!-- 액션 -->
-          <div class="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-6">
-            <p class="text-sm text-slate-500">
-              추천 요청 후 실행 상태 페이지로 이동합니다.
-            </p>
-
-            <button type="submit"
-                    th:disabled="${!entry.runnable}"
-                    th:classappend="${entry.runnable}
-                                    ? 'bg-slate-950 text-white hover:bg-slate-800'
-                                    : 'cursor-not-allowed bg-slate-200 text-slate-400'"
-                    class="rounded-2xl px-5 py-3 text-sm font-semibold transition">
-              추천 시작
-            </button>
-          </div>
-        </form>
-      </section>
-    </div>
-  </main>
+        </div>
+    </main>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/recommendation/error.html
+++ b/src/main/resources/templates/recommendation/error.html
@@ -3,71 +3,65 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-  <title>추천 실행 오류</title>
+    <title>추천 오류 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
-  <main class="min-h-screen bg-slate-50 px-6 py-10 lg:px-10">
-    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-3xl">
 
-      <!-- 헤더 -->
-      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <p class="text-xs font-black uppercase tracking-widest text-slate-400">
-              Recommendation Error
-            </p>
-            <h1 class="mt-2 text-3xl font-black tracking-tight text-slate-950"
-                th:text="${title}">
-              추천 실행 정보를 확인할 수 없습니다.
-            </h1>
-            <p class="mt-3 text-sm text-slate-500">
-              요청한 추천 실행을 불러오는 중 문제가 발생했습니다.
-            </p>
-          </div>
+            <!-- ── 상단 액션 바 ── -->
+            <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div class="flex items-center gap-4">
+                        <a th:href="${backUrl}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            이전으로
+                        </a>
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation</p>
+                            <h2 class="mt-1 text-xl font-bold tracking-tight text-slate-900">오류 발생</h2>
+                        </div>
+                    </div>
+                    <span class="inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-4 py-1.5 text-xs font-bold text-rose-600">
+                        <i data-lucide="circle-x" class="h-3.5 w-3.5"></i>
+                        접근 불가
+                    </span>
+                </div>
+            </div>
 
-          <span class="rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-bold text-rose-700">
-            접근 불가
-          </span>
+            <!-- ── 오류 카드 ── -->
+            <section class="rounded-[32px] border border-rose-200 bg-white p-12 shadow-sm shadow-rose-100/60 text-center">
+                <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-rose-50">
+                    <i data-lucide="shield-x" class="h-9 w-9 text-rose-400"></i>
+                </div>
+
+                <h1 class="mt-6 text-2xl font-bold tracking-tight text-slate-900"
+                    th:text="${title}">추천 실행 정보를 확인할 수 없습니다.</h1>
+
+                <p class="mt-3 text-base leading-relaxed text-slate-500"
+                   th:text="${message}">요청한 추천 실행에 접근할 수 없습니다.</p>
+
+                <p class="mt-2 text-sm text-slate-400">
+                    잘못된 실행 정보이거나 접근 권한이 없을 수 있습니다.
+                </p>
+
+                <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+                    <a th:href="${backUrl}"
+                       class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-700">
+                        <i data-lucide="refresh-cw" class="h-4 w-4"></i>
+                        다시 시도하기
+                    </a>
+                    <a th:href="@{/client/dashboard}"
+                       class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                        대시보드로 이동
+                    </a>
+                </div>
+            </section>
+
         </div>
-
-        <div class="mt-5 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4">
-          <p class="text-sm font-semibold text-rose-700"
-             th:text="${message}">
-            요청한 추천 실행에 접근할 수 없습니다.
-          </p>
-        </div>
-
-        <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-          <p class="text-sm leading-6 text-slate-600">
-            잘못된 실행 정보이거나 접근 권한이 없을 수 있습니다. 이전 페이지로 돌아가 다시 확인해 주세요.
-          </p>
-        </div>
-      </section>
-
-      <!-- 액션 -->
-      <section class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-sm shadow-slate-200/70">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <p class="text-sm text-slate-500">
-            추천 진입 페이지로 돌아가 다시 시도할 수 있습니다.
-          </p>
-
-          <div class="flex flex-wrap gap-3">
-            <a th:href="${backUrl}"
-               class="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800">
-              이전 페이지로 돌아가기
-            </a>
-
-            <a th:href="@{/proposals}"
-               class="rounded-2xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
-              제안서 목록으로 이동
-            </a>
-          </div>
-        </div>
-      </section>
-
-    </div>
-  </main>
+    </main>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${view.proposalTitle} + ' | 추천 결과'">추천 결과 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50">
+
+        <!-- ══════════════════════════════════════════
+             상단 바
+        ══════════════════════════════════════════ -->
+        <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
+            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
+
+                <div class="flex items-center gap-4">
+                    <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                       class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
+                        <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                    </a>
+                    <div>
+                        <div class="flex items-center gap-2">
+                            <h1 class="text-lg font-bold text-slate-900"
+                                th:text="${view.proposalTitle}">제안서 제목</h1>
+                            <span class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-[11px] font-bold text-blue-700">
+                                MATCHING
+                            </span>
+                        </div>
+                        <p class="mt-0.5 text-xs text-slate-400"
+                           th:text="${view.positionTitle} + ' · AI 추천 결과'">포지션 · AI 추천 결과</p>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                    <a th:href="@{/proposals/{id}/recommendations(id=${view.proposalId})}"
+                       class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
+                        <i data-lucide="refresh-cw" class="h-3.5 w-3.5"></i>
+                        추천 다시 실행
+                    </a>
+                    <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                       class="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+                        <i data-lucide="file-text" class="h-3.5 w-3.5"></i>
+                        제안서 보기
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <!-- ══════════════════════════════════════════
+             본문 2-column 레이아웃
+        ══════════════════════════════════════════ -->
+        <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+            <div class="grid gap-6 lg:grid-cols-5">
+
+                <!-- ────────────────────────────────────────
+                     좌측: AI 추천 카드 목록 (3/5)
+                ──────────────────────────────────────── -->
+                <section class="lg:col-span-3">
+
+                    <!-- 섹션 헤더 -->
+                    <div class="mb-4 flex items-center justify-between">
+                        <div class="flex items-center gap-2">
+                            <div class="flex h-7 w-7 items-center justify-center rounded-xl bg-blue-600">
+                                <i data-lucide="check" class="h-3.5 w-3.5 text-white"></i>
+                            </div>
+                            <h2 class="text-base font-bold text-slate-900">
+                                AI 추천 Top <span th:text="${#lists.size(view.candidates)}">3</span>
+                            </h2>
+                        </div>
+                        <p class="text-xs text-slate-400">프로젝트 요구사항 기반 자동 분석</p>
+                    </div>
+
+                    <!-- 후보 없음 -->
+                    <div th:if="${#lists.isEmpty(view.candidates)}"
+                         class="rounded-2xl border border-dashed border-slate-200 bg-white py-16 text-center">
+                        <i data-lucide="users" class="mx-auto mb-3 h-10 w-10 text-slate-200"></i>
+                        <p class="text-sm font-semibold text-slate-500">조건에 맞는 추천 결과가 없습니다</p>
+                        <p class="mt-1 text-xs text-slate-400">포지션 조건을 조정하거나 다시 시도해보세요.</p>
+                    </div>
+
+                    <!-- 후보 카드 목록 -->
+                    <div class="space-y-4" th:unless="${#lists.isEmpty(view.candidates)}">
+
+                        <article th:each="candidate : ${view.candidates}"
+                                 class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50">
+
+                            <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
+                            <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-4">
+
+                                <div class="flex items-start gap-3">
+                                    <!-- 아바타 -->
+                                    <div th:classappend="${candidate.rank == 1} ? 'bg-amber-50 text-amber-500 border-amber-100' :
+                                                          (${candidate.rank == 2} ? 'bg-slate-100 text-slate-400 border-slate-200' :
+                                                                                    'bg-orange-50 text-orange-400 border-orange-100')"
+                                         class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border">
+                                        <i data-lucide="user-plus" class="h-5 w-5"></i>
+                                    </div>
+
+                                    <div>
+                                        <div class="flex items-center gap-2">
+                                            <span class="text-base font-bold text-slate-900"
+                                                  th:text="${candidate.maskedName}">김*수</span>
+                                            <span class="text-sm font-medium text-slate-400"
+                                                  th:text="${view.positionTitle}">프론트엔드 개발자</span>
+                                        </div>
+                                        <!-- 스킬 칩 -->
+                                        <div class="mt-2 flex flex-wrap gap-1.5"
+                                             th:if="${!#lists.isEmpty(candidate.matchedSkills)}">
+                                            <span th:each="skill : ${candidate.matchedSkills}"
+                                                  class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                                                  th:text="${skill}">Java</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 점수 -->
+                                <div class="shrink-0 text-right">
+                                    <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
+                                                        (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
+                                       class="text-2xl font-black tracking-tight"
+                                       th:text="${candidate.finalScorePercent + '%'}">98%</p>
+                                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
+                                </div>
+                            </div>
+
+                            <!-- ── AI 추천 사유 ── -->
+                            <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+                                <div class="mb-1.5 flex items-center gap-1.5">
+                                    <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
+                                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
+                                </div>
+                                <p th:if="${candidate.llmReady and candidate.llmReason != null}"
+                                   class="text-sm leading-relaxed text-slate-700"
+                                   th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
+                                <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
+                                   class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
+                            </div>
+
+                            <!-- ── 주요 강점 (highlights) ── -->
+                            <div class="mx-5 mb-3 rounded-xl border border-emerald-50 bg-emerald-50/60 px-4 py-3"
+                                 th:if="${!#lists.isEmpty(candidate.highlights)}">
+                                <div class="mb-1.5 flex items-center gap-1.5">
+                                    <i data-lucide="star" class="h-3.5 w-3.5 text-emerald-500"></i>
+                                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">주요 강점</p>
+                                </div>
+                                <p class="text-sm leading-relaxed text-slate-700"
+                                   th:text="${candidate.highlights[0]}">강점 내용</p>
+                            </div>
+
+                            <!-- ── 매칭 요청 버튼 ── -->
+                            <div class="border-t border-slate-100 px-5 py-4">
+                                <button type="button"
+                                        class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
+                                    <i data-lucide="send" class="h-4 w-4"></i>
+                                    매칭 요청하기
+                                </button>
+                            </div>
+
+                        </article>
+                    </div>
+                </section>
+
+                <!-- ────────────────────────────────────────
+                     우측: 실행 요약 사이드바 (2/5)
+                ──────────────────────────────────────── -->
+                <aside class="lg:col-span-2 space-y-4">
+
+                    <!-- 실행 요약 카드 -->
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+                        <div class="mb-4 flex items-center justify-between">
+                            <h3 class="text-sm font-bold text-slate-900">추천 실행 요약</h3>
+                        </div>
+
+                        <div class="space-y-3">
+                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                                <div class="flex items-center gap-2 text-sm text-slate-500">
+                                    <i data-lucide="layers" class="h-4 w-4 text-slate-400"></i>
+                                    포지션
+                                </div>
+                                <span class="text-sm font-semibold text-slate-800"
+                                      th:text="${view.positionTitle}">백엔드 개발자</span>
+                            </div>
+
+                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                                <div class="flex items-center gap-2 text-sm text-slate-500">
+                                    <i data-lucide="users" class="h-4 w-4 text-slate-400"></i>
+                                    후보 풀
+                                </div>
+                                <span class="text-sm font-semibold text-slate-800">
+                                    <span th:text="${view.candidateCount != null ? view.candidateCount : '-'}">17</span>명
+                                </span>
+                            </div>
+
+                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                                <div class="flex items-center gap-2 text-sm text-slate-500">
+                                    <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>
+                                    추천 결과
+                                </div>
+                                <span class="text-sm font-semibold text-slate-800">
+                                    Top <span th:text="${view.topK}">3</span>
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 점수 범례 카드 -->
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+                        <h3 class="mb-3 text-sm font-bold text-slate-900">점수 기준</h3>
+                        <div class="space-y-2.5">
+                            <div class="flex items-center justify-between text-xs">
+                                <div class="flex items-center gap-2">
+                                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                                    <span class="font-semibold text-slate-600">80% 이상</span>
+                                </div>
+                                <span class="text-slate-400">매우 높은 적합도</span>
+                            </div>
+                            <div class="flex items-center justify-between text-xs">
+                                <div class="flex items-center gap-2">
+                                    <span class="h-2 w-2 rounded-full bg-blue-400"></span>
+                                    <span class="font-semibold text-slate-600">60 ~ 79%</span>
+                                </div>
+                                <span class="text-slate-400">높은 적합도</span>
+                            </div>
+                            <div class="flex items-center justify-between text-xs">
+                                <div class="flex items-center gap-2">
+                                    <span class="h-2 w-2 rounded-full bg-slate-300"></span>
+                                    <span class="font-semibold text-slate-600">60% 미만</span>
+                                </div>
+                                <span class="text-slate-400">보통 적합도</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 안내 카드 -->
+                    <div class="rounded-2xl border border-blue-100 bg-blue-50 p-5">
+                        <div class="flex items-start gap-3">
+                            <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-blue-400"></i>
+                            <div>
+                                <p class="text-xs font-bold text-blue-700">매칭 요청 안내</p>
+                                <p class="mt-1 text-xs leading-relaxed text-blue-600">
+                                    매칭 요청 후 프리랜서가 수락하면 상세 프로필과 연락처를 확인할 수 있습니다.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                </aside>
+            </div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/recommendation/status.html
+++ b/src/main/resources/templates/recommendation/status.html
@@ -1,21 +1,138 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
 <head>
-  <meta charset="UTF-8">
-  <title>추천 결과</title>
-  <meta http-equiv="refresh" content="5" th:if="${view.autoRefresh}">
+    <title th:text="${view.proposalTitle} + ' | 추천 결과'">추천 실행 | IT-da</title>
+    <!-- 진행 중일 때 5초마다 자동 새로고침 -->
+    <meta th:if="${view.autoRefresh}" http-equiv="refresh" content="5">
 </head>
 <body>
-<main>
-  <h1 th:text="${view.title}">추천 상태 제목</h1>
-  <p th:text="${view.proposalTitle}">제안서 제목</p>
-  <p th:text="${view.message}">상태 메시지</p>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-4xl">
 
-  <a th:if="${view.nextActionUrl != null}"
-     th:href="${view.nextActionUrl}"
-     th:text="${view.nextActionLabel}">
-    다음 액션
-  </a>
-</main>
+            <!-- ── 상단 액션 바 ── -->
+            <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div class="flex items-center gap-4">
+                        <a th:href="@{/proposals/{id}/recommendations(id=${view.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            추천 진입으로
+                        </a>
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation</p>
+                            <h2 class="mt-1 text-xl font-bold tracking-tight text-slate-900"
+                                th:text="${view.proposalTitle}">제안서 제목</h2>
+                        </div>
+                    </div>
+
+                    <!-- 상태 배지 -->
+                    <span th:classappend="${
+                              view.status.name() == 'COMPUTED' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
+                              (view.status.name() == 'FAILED'  ? 'border-rose-200 bg-rose-50 text-rose-600' :
+                                                                  'border-blue-200 bg-blue-50 text-blue-700')
+                          }"
+                          class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold">
+                        <i th:if="${view.status.name() == 'COMPUTED'}" data-lucide="circle-check" class="h-3.5 w-3.5"></i>
+                        <i th:if="${view.status.name() == 'FAILED'}" data-lucide="circle-x" class="h-3.5 w-3.5"></i>
+                        <i th:if="${view.status.name() == 'PENDING' or view.status.name() == 'RUNNING'}"
+                           data-lucide="loader" class="h-3.5 w-3.5 animate-spin"></i>
+                        <span th:text="${view.status.description}">실행 중</span>
+                    </span>
+                </div>
+            </div>
+
+            <!-- ══ PENDING / RUNNING: 진행 중 ══ -->
+            <th:block th:if="${view.status.name() == 'PENDING' or view.status.name() == 'RUNNING'}">
+                <section class="rounded-[32px] border border-slate-200 bg-white p-12 shadow-sm shadow-slate-200/70 text-center">
+                    <!-- 스피너 -->
+                    <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-blue-50">
+                        <i data-lucide="sparkles" class="h-9 w-9 animate-pulse text-blue-500"></i>
+                    </div>
+
+                    <h1 class="mt-6 text-2xl font-bold tracking-tight text-slate-900"
+                        th:text="${view.title}">추천을 실행하고 있습니다</h1>
+                    <p class="mt-3 text-base leading-relaxed text-slate-500"
+                       th:text="${view.message}">잠시만 기다려 주세요.</p>
+
+                    <!-- 진행 표시 점 -->
+                    <div class="mt-8 flex items-center justify-center gap-2">
+                        <span class="h-2 w-2 rounded-full bg-blue-400 animate-bounce" style="animation-delay: 0ms"></span>
+                        <span class="h-2 w-2 rounded-full bg-blue-400 animate-bounce" style="animation-delay: 150ms"></span>
+                        <span class="h-2 w-2 rounded-full bg-blue-400 animate-bounce" style="animation-delay: 300ms"></span>
+                    </div>
+
+                    <p class="mt-6 text-xs text-slate-400">5초마다 자동으로 새로고침됩니다.</p>
+
+                    <!-- 수동 새로고침 -->
+                    <div class="mt-6">
+                        <a th:href="@{/proposals/{proposalId}/runs/{runId}(proposalId=${view.proposalId}, runId=${view.runId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">
+                            <i data-lucide="refresh-cw" class="h-4 w-4"></i>
+                            지금 새로고침
+                        </a>
+                    </div>
+                </section>
+            </th:block>
+
+            <!-- ══ COMPUTED: 추천 완료 ══ -->
+            <th:block th:if="${view.status.name() == 'COMPUTED'}">
+                <section class="rounded-[32px] border border-emerald-200 bg-white p-12 shadow-sm shadow-emerald-100/60 text-center">
+                    <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-emerald-50">
+                        <i data-lucide="circle-check-big" class="h-9 w-9 text-emerald-500"></i>
+                    </div>
+
+                    <h1 class="mt-6 text-2xl font-bold tracking-tight text-slate-900"
+                        th:text="${view.title}">추천이 완료되었습니다</h1>
+                    <p class="mt-3 text-base leading-relaxed text-slate-500"
+                       th:text="${view.message}">추천 결과를 확인해보세요.</p>
+
+                    <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+                        <a th:if="${view.nextActionUrl != null}"
+                           th:href="${view.nextActionUrl}"
+                           class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                            <i data-lucide="users" class="h-4 w-4"></i>
+                            <span th:text="${view.nextActionLabel}">추천 결과 보기</span>
+                        </a>
+                        <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                            제안서로 돌아가기
+                        </a>
+                    </div>
+                </section>
+            </th:block>
+
+            <!-- ══ FAILED: 실패 ══ -->
+            <th:block th:if="${view.status.name() == 'FAILED'}">
+                <section class="rounded-[32px] border border-rose-200 bg-white p-12 shadow-sm shadow-rose-100/60 text-center">
+                    <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-rose-50">
+                        <i data-lucide="circle-x" class="h-9 w-9 text-rose-400"></i>
+                    </div>
+
+                    <h1 class="mt-6 text-2xl font-bold tracking-tight text-slate-900"
+                        th:text="${view.title}">추천 실행에 실패했습니다</h1>
+                    <p class="mt-3 text-base leading-relaxed text-slate-500"
+                       th:text="${view.message}">오류가 발생했습니다. 다시 시도해주세요.</p>
+
+                    <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+                        <a th:if="${view.nextActionUrl != null}"
+                           th:href="${view.nextActionUrl}"
+                           class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-700">
+                            <i data-lucide="refresh-cw" class="h-4 w-4"></i>
+                            <span th:text="${view.nextActionLabel}">다시 시도</span>
+                        </a>
+                        <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                            제안서로 돌아가기
+                        </a>
+                    </div>
+                </section>
+            </th:block>
+
+        </div>
+    </main>
+</div>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -14,6 +14,7 @@ import com.generic4.itda.annotation.ControllerTest;
 import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.recommend.RecommendationEntryService;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
@@ -43,6 +44,9 @@ class RecommendationControllerTest {
 
     @MockitoBean
     private RecommendationRunQueryService recommendationRunQueryService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("추천 결과 조회가 성공하면 results 화면을 렌더링한다")

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -1,0 +1,127 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
+import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.recommend.RecommendationEntryService;
+import com.generic4.itda.service.recommend.RecommendationRunQueryService;
+import com.generic4.itda.service.recommend.RecommendationRunService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(RecommendationController.class)
+class RecommendationControllerTest {
+
+    private static final Long PROPOSAL_ID = 10L;
+    private static final Long RUN_ID = 301L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RecommendationEntryService recommendationEntryService;
+
+    @MockitoBean
+    private RecommendationRunService recommendationRunService;
+
+    @MockitoBean
+    private RecommendationRunQueryService recommendationRunQueryService;
+
+    @Test
+    @DisplayName("추천 결과 조회가 성공하면 results 화면을 렌더링한다")
+    void renderResults() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationResultsViewModel viewModel = new RecommendationResultsViewModel(
+                PROPOSAL_ID,
+                RUN_ID,
+                "추천 테스트 제안서",
+                "백엔드 개발자",
+                3,
+                3,
+                List.of(new RecommendationCandidateItem(
+                        100L,
+                        1,
+                        "닉*임",
+                        "",
+                        5,
+                        "원격",
+                        95,
+                        88,
+                        List.of("Java"),
+                        List.of("대규모 트래픽 처리 경험"),
+                        null,
+                        "대기 중",
+                        false
+                ))
+        );
+
+        given(recommendationRunQueryService.getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(viewModel);
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results", PROPOSAL_ID)
+                        .param("runId", String.valueOf(RUN_ID))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/results"))
+                .andExpect(model().attributeExists("view"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 결과가 아직 준비되지 않으면 error 화면을 렌더링한다")
+    void renderErrorWhenNotReady() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunQueryService.getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willThrow(new IllegalStateException("추천 결과가 아직 준비되지 않았습니다."));
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results", PROPOSAL_ID)
+                        .param("runId", String.valueOf(RUN_ID))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/error"))
+                .andExpect(model().attribute("title", "추천 결과를 확인할 수 없습니다."))
+                .andExpect(model().attribute("message", "추천이 아직 완료되지 않았습니다. 잠시 후 다시 시도해주세요."))
+                .andExpect(model().attribute("backUrl", "/proposals/10/runs/301"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+}
+

--- a/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
@@ -19,6 +19,7 @@ import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -149,6 +150,42 @@ class RecommendationResultRepositoryTest {
         // then
         assertThatThrownBy(() -> recommendationResultRepository.saveAndFlush(second))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("runId로 결과를 조회하면 rank 오름차순으로 정렬되고 resume/member를 fetch join 한다")
+    void runId로_결과를_조회하면_rank_오름차순으로_정렬되고_resume_member를_fetch_join_한다() {
+        // given
+        Member anotherMember = memberRepository.save(
+                createMember("another2@test.com", "pw", "지원자2", "010-0000-0004"));
+        Resume anotherResume = resumeRepository.saveAndFlush(
+                Resume.create(anotherMember, "두번째 자기소개", (byte) 2, new CareerPayload(),
+                        WorkType.SITE, ResumeWritingStatus.WRITING, null));
+
+        ReasonFacts reasonFacts = new ReasonFacts(List.of(), List.of(), 0, List.of());
+        RecommendationResult rank2 = RecommendationResult.create(
+                run, anotherResume, 2, new BigDecimal("0.8000"), new BigDecimal("0.8000"), reasonFacts);
+        RecommendationResult rank1 = RecommendationResult.create(
+                run, resume, 1, new BigDecimal("0.9000"), new BigDecimal("0.9000"), reasonFacts);
+
+        recommendationResultRepository.saveAndFlush(rank2);
+        recommendationResultRepository.saveAndFlush(rank1);
+        em.clear();
+
+        // when
+        List<RecommendationResult> found = recommendationResultRepository.findByRunIdWithResume(run.getId());
+
+        // then
+        assertThat(found).hasSize(2);
+        assertThat(found.get(0).getRank()).isEqualTo(1);
+        assertThat(found.get(1).getRank()).isEqualTo(2);
+
+        PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(util.isLoaded(found.get(0), "resume")).isTrue();
+        assertThat(util.isLoaded(found.get(0).getResume(), "member")).isTrue();
+
+        assertThat(found.get(0).getResume().getMember().getEmail().getValue()).isEqualTo("applicant@test.com");
+        assertThat(found.get(1).getResume().getMember().getEmail().getValue()).isEqualTo("another2@test.com");
     }
 
     private Position persistPosition(String name) {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -224,6 +224,116 @@ class RecommendationRunQueryServiceTest {
     }
 
     @Test
+    @DisplayName("RUNNING 상태면 추천 결과 조회 시 IllegalStateException이 발생한다")
+    void getRecommendationResults_throwsWhenRunIsRunning() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("FAILED 상태면 추천 결과 조회 시 IllegalStateException이 발생한다")
+    void getRecommendationResults_throwsWhenRunIsFailed() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.FAILED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("추천 실행(run)이 존재하지 않으면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
+    void getRecommendationResults_throwsWhenRunNotFound() {
+        // given
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("추천 실행 정보를 찾을 수 없습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("run이 다른 proposal에 속하면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
+    void getRecommendationResults_throwsWhenProposalDoesNotMatch() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(999L, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 추천 실행 접근입니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("제안서 소유자 이메일과 다르면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
+    void getRecommendationResults_throwsWhenEmailDoesNotMatchOwner() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, "other@example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("접근 권한이 없습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태에서도 결과가 없으면 빈 후보 리스트를 반환한다")
+    void getRecommendationResults_returnsEmptyCandidatesWhenNoResults() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of());
+
+        // when
+        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(view.runId()).isEqualTo(RUN_ID);
+        assertThat(view.proposalTitle()).isEqualTo("추천 테스트 제안서");
+        assertThat(view.positionTitle()).isEqualTo("백엔드 개발자");
+        assertThat(view.topK()).isEqualTo(3);
+        assertThat(view.candidateCount()).isEqualTo(3);
+        assertThat(view.candidates()).isEmpty();
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
     @DisplayName("COMPUTED 상태면 추천 결과 ViewModel을 조립하고 후보 정보를 마스킹하여 반환한다")
     void getRecommendationResults_returnsViewModelWithCandidates() {
         // given

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -11,12 +11,21 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.LlmStatus;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +52,9 @@ class RecommendationRunQueryServiceTest {
 
     @Mock
     private RecommendationRunRepository recommendationRunRepository;
+
+    @Mock
+    private RecommendationResultRepository recommendationResultRepository;
 
     @InjectMocks
     private RecommendationRunQueryService service;
@@ -192,6 +204,89 @@ class RecommendationRunQueryServiceTest {
 
         verify(recommendationRunRepository).findDetailById(RUN_ID);
         verifyNoMoreInteractions(recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태가 아니면 추천 결과 조회 시 IllegalStateException이 발생한다")
+    void getRecommendationResults_throwsWhenRunIsNotComputed() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태면 추천 결과 ViewModel을 조립하고 후보 정보를 마스킹하여 반환한다")
+    void getRecommendationResults_returnsViewModelWithCandidates() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        Member candidateMember = org.mockito.Mockito.mock(Member.class);
+        given(candidateMember.getNickname()).willReturn("닉네임");
+
+        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
+        given(candidateResume.getMember()).willReturn(candidateMember);
+        given(candidateResume.getIntroduction()).willReturn(null);
+        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.REMOTE);
+
+        ReasonFacts facts = new ReasonFacts(
+                List.of("Java", "Spring"),
+                List.of("플랫폼"),
+                7,
+                List.of("대규모 트래픽 처리 경험")
+        );
+
+        RecommendationResult result = RecommendationResult.create(
+                run,
+                candidateResume,
+                1,
+                new BigDecimal("0.9500"),
+                new BigDecimal("0.8800"),
+                facts
+        );
+        result.markLlmReady("추천 사유입니다.");
+
+        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
+
+        // when
+        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(view.runId()).isEqualTo(RUN_ID);
+        assertThat(view.proposalTitle()).isEqualTo("추천 테스트 제안서");
+        assertThat(view.positionTitle()).isEqualTo("백엔드 개발자");
+        assertThat(view.topK()).isEqualTo(3);
+        assertThat(view.candidateCount()).isEqualTo(3);
+        assertThat(view.candidates()).hasSize(1);
+
+        var item = view.candidates().get(0);
+        assertThat(item.rank()).isEqualTo(1);
+        assertThat(item.maskedName()).isEqualTo("닉*임");
+        assertThat(item.introduction()).isEmpty();
+        assertThat(item.careerYears()).isEqualTo(7);
+        assertThat(item.preferredWorkTypeLabel()).isEqualTo(WorkType.REMOTE.getDescription());
+        assertThat(item.finalScorePercent()).isEqualTo(95);
+        assertThat(item.embeddingScorePercent()).isEqualTo(88);
+        assertThat(item.matchedSkills()).containsExactly("Java", "Spring");
+        assertThat(item.highlights()).containsExactly("대규모 트래픽 처리 경험");
+        assertThat(item.llmReason()).isEqualTo("추천 사유입니다.");
+        assertThat(item.llmStatusLabel()).isEqualTo(LlmStatus.READY.getDescription());
+        assertThat(item.llmReady()).isTrue();
+
+        verify(recommendationRunRepository).findDetailById(RUN_ID);
+        verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
     }
 
     private void assertViewModel(


### PR DESCRIPTION
## 🔎 What

- 추천 진입 화면 구현: recommendation/entry.html (포지션 선택 + 추천 실행 요청)
- 추천 상태 화면 구현: recommendation/status.html (진행/완료/실패 상태 및 자동 새로고침 UX)
- 추천 오류 화면 구현: recommendation/error.html
- 추천 결과 목록 화면 구현: recommendation/results.html (후보 카드 UI)
- 추천 결과 보기 라우트 및 조회 로직 추가: 
      - /proposals/{proposalId}/recommendations/results
      - RecommendationRunQueryService#getRecommendationResults
- 결과 조회용 fetch-join 쿼리/DTO 및 테스트 보강 
      - RecommendationResultRepository#findByRunIdWithResume
      - RecommendationResultsViewModel 등

## 🔗 Issue

- Closes: #96

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?