### PR TITLE
[Feat] 추천 결과 기반 매칭 요청 생성 및 프리랜서 수락/거절 처리

### DIFF
--- a/src/main/java/com/generic4/itda/controller/MatchingController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingController.java
@@ -1,0 +1,100 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.MatchingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+public class MatchingController {
+
+    private final MatchingService matchingService;
+
+    @PostMapping("/recommendation-results/{recommendationResultId}/matchings")
+    public String request(
+            @PathVariable Long recommendationResultId,
+            @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Matching matching = matchingService.request(recommendationResultId, principal.getEmail());
+            redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 보냈습니다.");
+            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            return redirectTo(redirectTo, fallback);
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "요청한 추천 결과를 찾을 수 없습니다.");
+            return redirectTo(redirectTo, "/client/dashboard");
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/client/dashboard");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/client/dashboard");
+        }
+    }
+
+    @PostMapping("/matchings/{matchingId}/accept")
+    public String accept(
+            @PathVariable Long matchingId,
+            @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Matching matching = matchingService.accept(matchingId, principal.getEmail());
+            redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 수락했습니다.");
+            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            return redirectTo(redirectTo, fallback);
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다.");
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        }
+    }
+
+    @PostMapping("/matchings/{matchingId}/reject")
+    public String reject(
+            @PathVariable Long matchingId,
+            @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Matching matching = matchingService.reject(matchingId, principal.getEmail());
+            redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 거절했습니다.");
+            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            return redirectTo(redirectTo, fallback);
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다.");
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return redirectTo(redirectTo, "/freelancers/dashboard");
+        }
+    }
+
+    private String redirectTo(String redirectTo, String fallback) {
+        if (StringUtils.hasText(redirectTo) && redirectTo.startsWith("/") && !redirectTo.startsWith("//")) {
+            return "redirect:" + redirectTo;
+        }
+        return "redirect:" + fallback;
+    }
+}

--- a/src/main/java/com/generic4/itda/controller/MatchingController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingController.java
@@ -4,6 +4,7 @@ import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.MatchingService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -15,6 +16,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class MatchingController {
 
     private final MatchingService matchingService;
@@ -31,14 +33,10 @@ public class MatchingController {
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 보냈습니다.");
             String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
             return redirectTo(redirectTo, fallback);
-        } catch (IllegalArgumentException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", "요청한 추천 결과를 찾을 수 없습니다.");
-            return redirectTo(redirectTo, "/client/dashboard");
-        } catch (AccessDeniedException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
-            return redirectTo(redirectTo, "/client/dashboard");
-        } catch (IllegalStateException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
+            log.warn("매칭 요청 생성 실패. recommendationResultId={}, email={}",
+                    recommendationResultId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", toRequestUserMessage(e));
             return redirectTo(redirectTo, "/client/dashboard");
         }
     }
@@ -55,14 +53,10 @@ public class MatchingController {
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 수락했습니다.");
             String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
             return redirectTo(redirectTo, fallback);
-        } catch (IllegalArgumentException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다.");
-            return redirectTo(redirectTo, "/freelancers/dashboard");
-        } catch (AccessDeniedException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
-            return redirectTo(redirectTo, "/freelancers/dashboard");
-        } catch (IllegalStateException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
+            log.warn("매칭 요청 수락 실패. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", toResponseUserMessage(e));
             return redirectTo(redirectTo, "/freelancers/dashboard");
         }
     }
@@ -79,16 +73,55 @@ public class MatchingController {
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 거절했습니다.");
             String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
             return redirectTo(redirectTo, fallback);
-        } catch (IllegalArgumentException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다.");
-            return redirectTo(redirectTo, "/freelancers/dashboard");
-        } catch (AccessDeniedException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
-            return redirectTo(redirectTo, "/freelancers/dashboard");
-        } catch (IllegalStateException e) {
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
+            log.warn("매칭 요청 거절 실패. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", toResponseUserMessage(e));
             return redirectTo(redirectTo, "/freelancers/dashboard");
         }
+    }
+
+    private static String toRequestUserMessage(RuntimeException e) {
+        if (e instanceof IllegalArgumentException) {
+            return "요청한 추천 결과를 찾을 수 없습니다.";
+        }
+        if (e instanceof AccessDeniedException) {
+            return "본인 제안서에 대해서만 매칭 요청을 보낼 수 있습니다.";
+        }
+        if (e instanceof IllegalStateException) {
+            return switch (e.getMessage()) {
+                case "MATCHING 상태의 제안서에 대해서만 매칭 요청을 보낼 수 있습니다." ->
+                        "추천이 진행 중인 제안서에서만 매칭 요청을 보낼 수 있습니다.";
+                case "OPEN 상태의 모집 포지션에 대해서만 매칭 요청을 보낼 수 있습니다." ->
+                        "모집 중인 포지션에서만 매칭 요청을 보낼 수 있습니다.";
+                case "이미 요청했거나 진행 중인 매칭입니다." ->
+                        "이미 요청했거나 진행 중인 후보입니다.";
+                default -> "현재 상태에서는 매칭 요청을 보낼 수 없습니다.";
+            };
+        }
+        return "매칭 요청 처리 중 문제가 발생했습니다.";
+    }
+
+    private static String toResponseUserMessage(RuntimeException e) {
+        if (e instanceof IllegalArgumentException) {
+            return "응답할 매칭 요청을 찾을 수 없습니다.";
+        }
+        if (e instanceof AccessDeniedException) {
+            return "본인에게 온 매칭 요청에만 응답할 수 있습니다.";
+        }
+        if (e instanceof IllegalStateException) {
+            return switch (e.getMessage()) {
+                case "정원이 이미 찬 모집 포지션입니다." ->
+                        "이미 정원이 마감된 포지션입니다.";
+                case "종료된 모집 포지션에는 응답할 수 없습니다." ->
+                        "모집이 종료된 포지션에는 응답할 수 없습니다.";
+                case "제안 상태의 매칭만 수락할 수 있습니다.",
+                        "제안 상태의 매칭만 거절할 수 있습니다." ->
+                        "이미 처리된 매칭 요청입니다.";
+                default -> "현재 상태에서는 매칭 요청에 응답할 수 없습니다.";
+            };
+        }
+        return "매칭 요청 응답 처리 중 문제가 발생했습니다.";
     }
 
     private String redirectTo(String redirectTo, String fallback) {

--- a/src/main/java/com/generic4/itda/repository/MatchingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepository.java
@@ -4,7 +4,9 @@ import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
 
@@ -14,5 +16,27 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
 
     boolean existsByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
 
+    boolean existsByProposalPosition_IdAndResume_IdAndStatusIn(
+            Long proposalPositionId,
+            Long resumeId,
+            Collection<MatchingStatus> statuses
+    );
+
+    long countByProposalPosition_IdAndStatusIn(Long proposalPositionId, Collection<MatchingStatus> statuses);
+
     List<Matching> findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
+
+    @Query("""
+            select m
+            from Matching m
+            join fetch m.proposalPosition pp
+            join fetch pp.proposal p
+            join fetch p.member proposalOwner
+            join fetch m.resume resume
+            join fetch resume.member resumeOwner
+            join fetch m.clientMember clientMember
+            join fetch m.freelancerMember freelancerMember
+            where m.id = :matchingId
+            """)
+    Optional<Matching> findDetailById(Long matchingId);
 }

--- a/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.domain.recommendation.RecommendationResult;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,17 @@ public interface RecommendationResultRepository extends JpaRepository<Recommenda
             "WHERE r.recommendationRun.id = :runId " +
             "ORDER BY r.rank ASC")
     List<RecommendationResult> findByRunIdWithResume(@Param("runId") Long runId);
+
+    @Query("""
+            select rr
+            from RecommendationResult rr
+            join fetch rr.recommendationRun run
+            join fetch run.proposalPosition pp
+            join fetch pp.proposal p
+            join fetch p.member proposalMember
+            join fetch rr.resume resume
+            join fetch resume.member resumeMember
+            where rr.id = :resultId
+            """)
+    Optional<RecommendationResult> findDetailById(Long resultId);
 }

--- a/src/main/java/com/generic4/itda/service/MatchingService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingService.java
@@ -26,6 +26,10 @@ public class MatchingService {
             MatchingStatus.ACCEPTED,
             MatchingStatus.IN_PROGRESS
     );
+    private static final EnumSet<MatchingStatus> OCCUPIED_MATCHING_STATUSES = EnumSet.of(
+            MatchingStatus.ACCEPTED,
+            MatchingStatus.IN_PROGRESS
+    );
 
     private final RecommendationResultRepository recommendationResultRepository;
     private final MatchingRepository matchingRepository;
@@ -50,6 +54,28 @@ public class MatchingService {
                 resume.getMember()
         );
         return matchingRepository.save(matching);
+    }
+
+    public Matching accept(Long matchingId, String freelancerEmail) {
+        Matching matching = matchingRepository.findDetailById(matchingId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다. id=" + matchingId));
+
+        validateFreelancerOwnership(matching, freelancerEmail);
+        validatePositionRespondable(matching.getProposalPosition());
+        validateCapacityAvailable(matching.getProposalPosition());
+
+        matching.accept();
+        updatePositionStatusAfterAccept(matching.getProposalPosition());
+        return matching;
+    }
+
+    public Matching reject(Long matchingId, String freelancerEmail) {
+        Matching matching = matchingRepository.findDetailById(matchingId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 요청을 찾을 수 없습니다. id=" + matchingId));
+
+        validateFreelancerOwnership(matching, freelancerEmail);
+        matching.reject();
+        return matching;
     }
 
     private void validateOwnership(Proposal proposal, String clientEmail) {
@@ -79,6 +105,53 @@ public class MatchingService {
 
         if (hasActiveMatching) {
             throw new IllegalStateException("이미 요청했거나 진행 중인 매칭입니다.");
+        }
+    }
+
+    private void validateFreelancerOwnership(Matching matching, String freelancerEmail) {
+        if (!matching.getFreelancerMember().getEmail().getValue().equals(freelancerEmail)) {
+            throw new AccessDeniedException("본인에게 온 매칭 요청에만 응답할 수 있습니다.");
+        }
+    }
+
+    private void validatePositionRespondable(ProposalPosition proposalPosition) {
+        if (proposalPosition.getStatus() == ProposalPositionStatus.CLOSED) {
+            throw new IllegalStateException("종료된 모집 포지션에는 응답할 수 없습니다.");
+        }
+        if (proposalPosition.getStatus() == ProposalPositionStatus.FULL) {
+            throw new IllegalStateException("정원이 이미 찬 모집 포지션입니다.");
+        }
+    }
+
+    private void validateCapacityAvailable(ProposalPosition proposalPosition) {
+        Long headCount = proposalPosition.getHeadCount();
+        if (headCount == null) {
+            return;
+        }
+
+        long occupiedCount = matchingRepository.countByProposalPosition_IdAndStatusIn(
+                proposalPosition.getId(),
+                OCCUPIED_MATCHING_STATUSES
+        );
+
+        if (occupiedCount >= headCount) {
+            throw new IllegalStateException("정원이 이미 찬 모집 포지션입니다.");
+        }
+    }
+
+    private void updatePositionStatusAfterAccept(ProposalPosition proposalPosition) {
+        Long headCount = proposalPosition.getHeadCount();
+        if (headCount == null) {
+            return;
+        }
+
+        long occupiedCount = matchingRepository.countByProposalPosition_IdAndStatusIn(
+                proposalPosition.getId(),
+                OCCUPIED_MATCHING_STATUSES
+        );
+
+        if (occupiedCount >= headCount) {
+            proposalPosition.changeStatus(ProposalPositionStatus.FULL);
         }
     }
 }

--- a/src/main/java/com/generic4/itda/service/MatchingService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingService.java
@@ -1,0 +1,84 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
+import java.util.EnumSet;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchingService {
+
+    private static final EnumSet<MatchingStatus> ACTIVE_MATCHING_STATUSES = EnumSet.of(
+            MatchingStatus.PROPOSED,
+            MatchingStatus.ACCEPTED,
+            MatchingStatus.IN_PROGRESS
+    );
+
+    private final RecommendationResultRepository recommendationResultRepository;
+    private final MatchingRepository matchingRepository;
+
+    public Matching request(Long recommendationResultId, String clientEmail) {
+        RecommendationResult recommendationResult = recommendationResultRepository.findDetailById(recommendationResultId)
+                .orElseThrow(() -> new IllegalArgumentException("추천 결과를 찾을 수 없습니다. id=" + recommendationResultId));
+
+        ProposalPosition proposalPosition = recommendationResult.getRecommendationRun().getProposalPosition();
+        Proposal proposal = proposalPosition.getProposal();
+        Resume resume = recommendationResult.getResume();
+
+        validateOwnership(proposal, clientEmail);
+        validateProposalStatus(proposal);
+        validatePositionStatus(proposalPosition);
+        validateNoActiveMatching(proposalPosition, resume);
+
+        Matching matching = Matching.create(
+                resume,
+                proposalPosition,
+                proposal.getMember(),
+                resume.getMember()
+        );
+        return matchingRepository.save(matching);
+    }
+
+    private void validateOwnership(Proposal proposal, String clientEmail) {
+        if (!proposal.getMember().getEmail().getValue().equals(clientEmail)) {
+            throw new AccessDeniedException("본인 제안서에 대해서만 매칭 요청을 보낼 수 있습니다.");
+        }
+    }
+
+    private void validateProposalStatus(Proposal proposal) {
+        if (proposal.getStatus() != ProposalStatus.MATCHING) {
+            throw new IllegalStateException("MATCHING 상태의 제안서에 대해서만 매칭 요청을 보낼 수 있습니다.");
+        }
+    }
+
+    private void validatePositionStatus(ProposalPosition proposalPosition) {
+        if (proposalPosition.getStatus() != ProposalPositionStatus.OPEN) {
+            throw new IllegalStateException("OPEN 상태의 모집 포지션에 대해서만 매칭 요청을 보낼 수 있습니다.");
+        }
+    }
+
+    private void validateNoActiveMatching(ProposalPosition proposalPosition, Resume resume) {
+        boolean hasActiveMatching = matchingRepository.existsByProposalPosition_IdAndResume_IdAndStatusIn(
+                proposalPosition.getId(),
+                resume.getId(),
+                ACTIVE_MATCHING_STATUSES
+        );
+
+        if (hasActiveMatching) {
+            throw new IllegalStateException("이미 요청했거나 진행 중인 매칭입니다.");
+        }
+    }
+}

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -10,6 +10,15 @@
     <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
         <div class="mx-auto max-w-5xl">
 
+            <section th:if="${errorMessage != null}"
+                     class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+                <p th:text="${errorMessage}">오류 메시지</p>
+            </section>
+            <section th:if="${noticeMessage != null}"
+                     class="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+                <p th:text="${noticeMessage}">안내 메시지</p>
+            </section>
+
             
             <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
                 <div class="flex flex-wrap items-center justify-between gap-4">
@@ -69,6 +78,7 @@
                                      <th:block th:if="${myMatching != null and myMatching.status.name() == 'PROPOSED'}">
                                          <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                              <button type="submit"
                                                      class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
                                                  <i data-lucide="check" class="h-4 w-4"></i>
@@ -77,6 +87,7 @@
                                          </form>
                                          <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                              <button type="submit"
                                                      class="inline-flex items-center gap-2 rounded-2xl border border-red-200 bg-white px-5 py-3 text-sm font-bold text-red-500 transition hover:bg-red-50">
                                                  <i data-lucide="x" class="h-4 w-4"></i>
@@ -99,6 +110,7 @@
                                                      <div class="flex items-center gap-2">
                                                          <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
                                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                              <button type="submit"
                                                                      class="inline-flex items-center gap-1.5 rounded-xl bg-blue-600 px-3 py-2 text-xs font-bold text-white transition hover:bg-blue-700">
                                                                  수락
@@ -106,6 +118,7 @@
                                                          </form>
                                                          <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
                                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                              <button type="submit"
                                                                      class="inline-flex items-center gap-1.5 rounded-xl border border-red-200 bg-white px-3 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
                                                                  거절
@@ -441,7 +454,6 @@
 </div>
 </body>
 </html>
-
 
 
 

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -11,6 +11,15 @@
 <main class="min-h-screen bg-slate-50 py-10 px-6">
 <div class="max-w-6xl mx-auto space-y-8">
 
+    <section th:if="${errorMessage != null}"
+             class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+        <p th:text="${errorMessage}">오류 메시지</p>
+    </section>
+    <section th:if="${noticeMessage != null}"
+             class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+        <p th:text="${noticeMessage}">안내 메시지</p>
+    </section>
+
     <!-- 헤더 -->
     <div class="flex items-start justify-between">
         <div>

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -1,0 +1,191 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.MatchingService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(MatchingController.class)
+class MatchingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MatchingService matchingService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("클라이언트가 추천 결과로 매칭 요청을 보내면 지정한 화면으로 돌아간다")
+    void requestMatchingAndRedirectToProvidedPath() throws Exception {
+        Matching matching = createMatching();
+        given(matchingService.request(101L, "client@example.com")).willReturn(matching);
+
+        mockMvc.perform(post("/recommendation-results/101/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/recommendation-results/101/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트")))
+                        .with(csrf())
+                        .param("redirectTo", "/proposals/200/recommendations/results?runId=501"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/200/recommendations/results?runId=501"))
+                .andExpect(flash().attribute("noticeMessage", "매칭 요청을 보냈습니다."));
+
+        then(matchingService).should().request(101L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("매칭 요청 생성에 실패하면 안전한 경로로 리다이렉트하며 오류 메시지를 남긴다")
+    void redirectWithErrorWhenRequestMatchingFails() throws Exception {
+        given(matchingService.request(101L, "client@example.com"))
+                .willThrow(new IllegalStateException("이미 요청했거나 진행 중인 매칭입니다."));
+
+        mockMvc.perform(post("/recommendation-results/101/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트")))
+                        .with(csrf())
+                        .param("redirectTo", "/proposals/200/recommendations/results?runId=501"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/200/recommendations/results?runId=501"))
+                .andExpect(flash().attribute("errorMessage", "이미 요청했거나 진행 중인 매칭입니다."));
+    }
+
+    @Test
+    @DisplayName("프리랜서가 수락하면 기본적으로 제안서 상세로 돌아간다")
+    void acceptMatchingAndRedirectToProposalDetail() throws Exception {
+        Matching matching = createMatching();
+        given(matchingService.accept(401L, "freelancer@example.com")).willReturn(matching);
+
+        mockMvc.perform(post("/matchings/401/accept")
+                        .with(authentication(authToken("freelancer@example.com", "프리랜서")))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/200"))
+                .andExpect(flash().attribute("noticeMessage", "매칭 요청을 수락했습니다."));
+
+        then(matchingService).should().accept(401L, "freelancer@example.com");
+    }
+
+    @Test
+    @DisplayName("프리랜서가 거절하면 지정한 화면으로 돌아간다")
+    void rejectMatchingAndRedirectToProvidedPath() throws Exception {
+        Matching matching = createMatching();
+        given(matchingService.reject(401L, "freelancer@example.com")).willReturn(matching);
+
+        mockMvc.perform(post("/matchings/401/reject")
+                        .with(authentication(authToken("freelancer@example.com", "프리랜서")))
+                        .with(csrf())
+                        .param("redirectTo", "/proposals/200"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/200"))
+                .andExpect(flash().attribute("noticeMessage", "매칭 요청을 거절했습니다."));
+
+        then(matchingService).should().reject(401L, "freelancer@example.com");
+    }
+
+    @Test
+    @DisplayName("없는 매칭 요청에 응답하면 프리랜서 대시보드로 돌아간다")
+    void redirectDashboardWhenMatchingNotFound() throws Exception {
+        given(matchingService.accept(999L, "freelancer@example.com"))
+                .willThrow(new IllegalArgumentException("매칭 요청을 찾을 수 없습니다. id=999"));
+
+        mockMvc.perform(post("/matchings/999/accept")
+                        .with(authentication(authToken("freelancer@example.com", "프리랜서")))
+                        .with(csrf())
+                        .param("redirectTo", "https://example.com/outside"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/freelancers/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("본인에게 온 요청이 아니면 오류 메시지와 함께 프리랜서 대시보드로 돌아간다")
+    void redirectDashboardWhenMatchingAccessDenied() throws Exception {
+        given(matchingService.reject(401L, "freelancer@example.com"))
+                .willThrow(new AccessDeniedException("본인에게 온 매칭 요청에만 응답할 수 있습니다."));
+
+        mockMvc.perform(post("/matchings/401/reject")
+                        .with(authentication(authToken("freelancer@example.com", "프리랜서")))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/freelancers/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "본인에게 온 매칭 요청에만 응답할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 매칭 응답 시 로그인 페이지로 이동한다")
+    void redirectToLoginWhenUnauthenticated() throws Exception {
+        mockMvc.perform(post("/matchings/401/accept").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(String email, String name) {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember(email, "hashed-password", name, "010-1234-5678")
+        );
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private Matching createMatching() {
+        Member client = createMember("client@example.com", "hashed-password", "클라이언트", "010-0000-0001");
+        Member freelancer = createMember("freelancer@example.com", "hashed-password", "프리랜서", "010-0000-0002");
+
+        Position position = Position.create("백엔드 개발자");
+        Proposal proposal = Proposal.create(client, "AI 매칭 플랫폼", "", "설명", null, null, 8L);
+        proposal.startMatching();
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "플랫폼 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_000_000L,
+                5_000_000L,
+                4L,
+                null,
+                null,
+                null
+        );
+
+        ReflectionTestUtils.setField(proposal, "id", 200L);
+        ReflectionTestUtils.setField(proposalPosition, "id", 201L);
+
+        Matching matching = Matching.create(null, proposalPosition, client, freelancer);
+        ReflectionTestUtils.setField(matching, "id", 401L);
+        return matching;
+    }
+}

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -77,7 +77,7 @@ class MatchingControllerTest {
                         .param("redirectTo", "/proposals/200/recommendations/results?runId=501"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/proposals/200/recommendations/results?runId=501"))
-                .andExpect(flash().attribute("errorMessage", "이미 요청했거나 진행 중인 매칭입니다."));
+                .andExpect(flash().attribute("errorMessage", "이미 요청했거나 진행 중인 후보입니다."));
     }
 
     @Test
@@ -140,6 +140,20 @@ class MatchingControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/freelancers/dashboard"))
                 .andExpect(flash().attribute("errorMessage", "본인에게 온 매칭 요청에만 응답할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("정원이 찬 포지션 수락 실패는 사용자용 메시지로 변환한다")
+    void redirectDashboardWithMappedMessageWhenCapacityFull() throws Exception {
+        given(matchingService.accept(401L, "freelancer@example.com"))
+                .willThrow(new IllegalStateException("정원이 이미 찬 모집 포지션입니다."));
+
+        mockMvc.perform(post("/matchings/401/accept")
+                        .with(authentication(authToken("freelancer@example.com", "프리랜서")))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/freelancers/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "이미 정원이 마감된 포지션입니다."));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
@@ -1,70 +1,217 @@
 package com.generic4.itda.repository;
 
-import com.generic4.itda.config.TestContainerConfig;
-import com.generic4.itda.config.TestQuerydslConfig;
-import com.generic4.itda.domain.matching.constant.MatchingStatus;
-import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-
-import java.util.List;
-
+import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@Import({TestContainerConfig.class, TestQuerydslConfig.class}) // 두 설정 모두 임포트
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 컨테이너 DB 사용
+import com.generic4.itda.annotation.RepositoryTest;
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RepositoryTest
 class MatchingRepositoryTest {
 
     @Autowired
     private MatchingRepository matchingRepository;
 
-    @Test
-    @DisplayName("전체 데이터 조회 및 통계 카운트 검증")
-    void getDashboardItems_Statistics() {
-        // Given
-        String email = "freelancer@test.com";
-        // 실제 테스트 시에는 EntityManager 등을 사용해 데이터를 INSERT 하는 로직이 선행되어야 함
+    @Autowired
+    private MemberRepository memberRepository;
 
-        // When
-        List<FreelancerDashboardItem> results = matchingRepository.getDashboardItems(email, null, null);
+    @Autowired
+    private ProposalRepository proposalRepository;
 
-        // Then
-        assertThat(results).isNotNull();
-        // 결과가 비어있더라도 쿼리 자체에 오류가 없는지 확인됨
-    }
+    @Autowired
+    private ResumeRepository resumeRepository;
 
-    @Test
-    @DisplayName("상태값이 'PROPOSED'인 데이터만 필터링 조회")
-    void getDashboardItems_StatusFilter() {
-        // Given
-        String email = "freelancer@test.com";
-        String status = "PROPOSED";
+    @Autowired
+    private EntityManager em;
 
-        // When
-        List<FreelancerDashboardItem> results = matchingRepository.getDashboardItems(email, status, null);
+    private Proposal proposal;
+    private ProposalPosition backendPosition;
+    private Resume freelancerResume;
+    private Member clientMember;
+    private Member freelancerMember;
 
-        // Then
-        assertThat(results).allMatch(item -> item.matchingStatus() == MatchingStatus.PROPOSED);
-    }
+    @BeforeEach
+    void setUp() {
+        clientMember = memberRepository.save(
+                createMember("client@test.com", "pw", "클라이언트", "010-0000-0001"));
+        freelancerMember = memberRepository.save(
+                createMember("freelancer@test.com", "pw", "프리랜서", "010-0000-0002"));
 
-    @Test
-    @DisplayName("검색어가 포함된 제목의 제안서 조회")
-    void getDashboardItems_SearchKeyword() {
-        // Given
-        String email = "freelancer@test.com";
-        String keyword = "Backend";
+        Position backend = persistPosition("백엔드 개발자");
 
-        // When
-        List<FreelancerDashboardItem> results = matchingRepository.getDashboardItems(email, null, keyword);
-
-        // Then
-        assertThat(results).allMatch(item ->
-                item.proposalTitle().contains(keyword) || item.companyName().contains(keyword)
+        proposal = Proposal.create(clientMember, "AI 매칭 플랫폼", "원문", null, null, null, null);
+        backendPosition = proposal.addPosition(
+                backend,
+                "플랫폼 백엔드 개발자",
+                null,
+                2L,
+                3_000_000L,
+                5_000_000L,
+                null,
+                null,
+                null,
+                null
         );
+        proposalRepository.saveAndFlush(proposal);
+
+        freelancerResume = resumeRepository.saveAndFlush(
+                Resume.create(
+                        freelancerMember,
+                        "자기소개입니다.",
+                        (byte) 3,
+                        new CareerPayload(),
+                        WorkType.REMOTE,
+                        ResumeWritingStatus.DONE,
+                        null
+                )
+        );
+    }
+
+    @Nested
+    @DisplayName("existsByProposalPosition_IdAndResume_IdAndStatusIn")
+    class ExistsActiveMatching {
+
+        @Test
+        @DisplayName("같은 포지션과 이력서 조합의 활성 매칭이 있으면 true를 반환한다")
+        void returnsTrueWhenActiveMatchingExists() {
+            Matching matching = saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+
+            boolean result = matchingRepository.existsByProposalPosition_IdAndResume_IdAndStatusIn(
+                    backendPosition.getId(),
+                    freelancerResume.getId(),
+                    EnumSet.of(MatchingStatus.PROPOSED, MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS)
+            );
+
+            assertThat(result).isTrue();
+            assertThat(matching.getId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("같은 조합이어도 종료 상태만 있으면 false를 반환한다")
+        void returnsFalseWhenOnlyTerminalMatchingExists() {
+            saveMatching(backendPosition, freelancerResume, MatchingStatus.REJECTED);
+
+            boolean result = matchingRepository.existsByProposalPosition_IdAndResume_IdAndStatusIn(
+                    backendPosition.getId(),
+                    freelancerResume.getId(),
+                    EnumSet.of(MatchingStatus.PROPOSED, MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS)
+            );
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("정원 점유 상태만 countByProposalPosition_IdAndStatusIn으로 집계할 수 있다")
+    void countByProposalPositionIdAndStatusIn_countsOnlyRequestedStatuses() {
+        saveMatching(backendPosition, freelancerResume, MatchingStatus.ACCEPTED);
+
+        Member secondFreelancer = memberRepository.save(
+                createMember("freelancer2@test.com", "pw", "프리랜서2", "010-0000-0003"));
+        Resume secondResume = resumeRepository.saveAndFlush(
+                Resume.create(
+                        secondFreelancer,
+                        "또 다른 자기소개입니다.",
+                        (byte) 5,
+                        new CareerPayload(),
+                        WorkType.REMOTE,
+                        ResumeWritingStatus.DONE,
+                        null
+                )
+        );
+        saveMatching(backendPosition, secondResume, MatchingStatus.IN_PROGRESS);
+
+        Member thirdFreelancer = memberRepository.save(
+                createMember("freelancer3@test.com", "pw", "프리랜서3", "010-0000-0004"));
+        Resume thirdResume = resumeRepository.saveAndFlush(
+                Resume.create(
+                        thirdFreelancer,
+                        "세 번째 자기소개입니다.",
+                        (byte) 1,
+                        new CareerPayload(),
+                        WorkType.SITE,
+                        ResumeWritingStatus.DONE,
+                        null
+                )
+        );
+        saveMatching(backendPosition, thirdResume, MatchingStatus.PROPOSED);
+
+        long occupiedCount = matchingRepository.countByProposalPosition_IdAndStatusIn(
+                backendPosition.getId(),
+                EnumSet.of(MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS)
+        );
+
+        assertThat(occupiedCount).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("findDetailById는 매칭 생성/응답에 필요한 연관 그래프를 함께 조회한다")
+    void findDetailById_fetchesMatchingGraph() {
+        Matching matching = saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+        em.clear();
+
+        Matching found = matchingRepository.findDetailById(matching.getId()).orElseThrow();
+
+        PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+        assertThat(util.isLoaded(found, "proposalPosition")).isTrue();
+        assertThat(util.isLoaded(found, "resume")).isTrue();
+        assertThat(util.isLoaded(found, "clientMember")).isTrue();
+        assertThat(util.isLoaded(found, "freelancerMember")).isTrue();
+
+        ProposalPosition foundPosition = found.getProposalPosition();
+        assertThat(util.isLoaded(foundPosition, "proposal")).isTrue();
+        assertThat(foundPosition.getProposal().getId()).isEqualTo(proposal.getId());
+
+        assertThat(util.isLoaded(found.getResume(), "member")).isTrue();
+        assertThat(found.getResume().getMember().getId()).isEqualTo(freelancerMember.getId());
+    }
+
+    @Test
+    @DisplayName("getDashboardItems는 프리랜서가 받은 매칭 목록을 최신순으로 반환한다")
+    void getDashboardItems_returnsFreelancerDashboardItems() {
+        Matching matching = saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+        em.flush();
+        em.clear();
+
+        List<?> items = matchingRepository.getDashboardItems(freelancerMember.getEmail().getValue(), null, null);
+
+        assertThat(items).hasSize(1);
+        assertThat(matching.getId()).isNotNull();
+    }
+
+    private Matching saveMatching(ProposalPosition proposalPosition, Resume resume, MatchingStatus status) {
+        Matching matching = Matching.create(
+                resume,
+                proposalPosition,
+                clientMember,
+                resume.getMember()
+        );
+        ReflectionTestUtils.setField(matching, "status", status);
+        return matchingRepository.saveAndFlush(matching);
+    }
+
+    private Position persistPosition(String name) {
+        Position position = Position.create(name);
+        em.persist(position);
+        return position;
     }
 }

--- a/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -186,6 +187,43 @@ class RecommendationResultRepositoryTest {
 
         assertThat(found.get(0).getResume().getMember().getEmail().getValue()).isEqualTo("applicant@test.com");
         assertThat(found.get(1).getResume().getMember().getEmail().getValue()).isEqualTo("another2@test.com");
+    }
+
+    @Nested
+    @DisplayName("findDetailById")
+    class FindDetailById {
+
+        @Test
+        @DisplayName("추천 결과에서 매칭 생성에 필요한 상위 그래프를 함께 조회한다")
+        void fetchesRecommendationResultGraphForMatchingRequest() {
+            ReasonFacts reasonFacts = new ReasonFacts(List.of("Java"), List.of("백엔드"), 3, List.of("Spring 경험"));
+            RecommendationResult result = recommendationResultRepository.saveAndFlush(
+                    RecommendationResult.create(
+                            run,
+                            resume,
+                            1,
+                            new BigDecimal("0.9500"),
+                            new BigDecimal("0.8800"),
+                            reasonFacts
+                    )
+            );
+            em.clear();
+
+            RecommendationResult found = recommendationResultRepository.findDetailById(result.getId()).orElseThrow();
+
+            PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+            assertThat(util.isLoaded(found, "recommendationRun")).isTrue();
+            assertThat(util.isLoaded(found, "resume")).isTrue();
+            assertThat(util.isLoaded(found.getRecommendationRun(), "proposalPosition")).isTrue();
+            assertThat(util.isLoaded(found.getRecommendationRun().getProposalPosition(), "proposal")).isTrue();
+            assertThat(util.isLoaded(found.getRecommendationRun().getProposalPosition().getProposal(), "member")).isTrue();
+            assertThat(util.isLoaded(found.getResume(), "member")).isTrue();
+
+            assertThat(found.getRecommendationRun().getId()).isEqualTo(run.getId());
+            assertThat(found.getRecommendationRun().getProposalPosition().getProposal().getMember().getEmail().getValue())
+                    .isEqualTo("proposer@test.com");
+            assertThat(found.getResume().getMember().getEmail().getValue()).isEqualTo("applicant@test.com");
+        }
     }
 
     private Position persistPosition(String name) {

--- a/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
@@ -177,6 +177,135 @@ class MatchingServiceTest {
         verify(matchingRepository, never()).save(any(Matching.class));
     }
 
+    @Test
+    @DisplayName("프리랜서는 본인에게 온 PROPOSED 매칭을 수락할 수 있다")
+    void accept_marksMatchingAcceptedAndPositionFullWhenCapacityReached() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+        given(matchingRepository.countByProposalPosition_IdAndStatusIn(
+                eq(201L),
+                eq(EnumSet.of(MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS))
+        )).willReturn(0L, 1L);
+
+        Matching accepted = matchingService.accept(401L, "freelancer@example.com");
+
+        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.FULL);
+    }
+
+    @Test
+    @DisplayName("정원이 남아 있으면 수락 후에도 모집 포지션은 OPEN 상태를 유지한다")
+    void accept_keepsPositionOpenWhenCapacityRemains() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                2L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+        given(matchingRepository.countByProposalPosition_IdAndStatusIn(
+                eq(201L),
+                eq(EnumSet.of(MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS))
+        )).willReturn(0L, 1L);
+
+        Matching accepted = matchingService.accept(401L, "freelancer@example.com");
+
+        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("이미 정원이 찬 포지션의 매칭은 수락할 수 없다")
+    void accept_throwsWhenCapacityAlreadyFull() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+        given(matchingRepository.countByProposalPosition_IdAndStatusIn(
+                eq(201L),
+                eq(EnumSet.of(MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS))
+        )).willReturn(1L);
+
+        assertThatThrownBy(() -> matchingService.accept(401L, "freelancer@example.com"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("정원이 이미 찬 모집 포지션입니다.");
+
+        assertThat(matching.getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+    }
+
+    @Test
+    @DisplayName("FULL 상태 포지션의 매칭은 수락할 수 없다")
+    void accept_throwsWhenPositionStatusIsFull() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.FULL,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        assertThatThrownBy(() -> matchingService.accept(401L, "freelancer@example.com"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("정원이 이미 찬 모집 포지션입니다.");
+    }
+
+    @Test
+    @DisplayName("다른 프리랜서는 매칭 요청을 수락할 수 없다")
+    void accept_throwsWhenFreelancerDoesNotOwnMatching() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        assertThatThrownBy(() -> matchingService.accept(401L, "other@example.com"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("본인에게 온 매칭 요청에만 응답할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("프리랜서는 본인에게 온 PROPOSED 매칭을 거절할 수 있다")
+    void reject_marksMatchingRejected() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        Matching rejected = matchingService.reject(401L, "freelancer@example.com");
+
+        assertThat(rejected.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(rejected.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("다른 프리랜서는 매칭 요청을 거절할 수 없다")
+    void reject_throwsWhenFreelancerDoesNotOwnMatching() {
+        Matching matching = createMatching(
+                MatchingStatus.PROPOSED,
+                ProposalPositionStatus.OPEN,
+                1L
+        );
+
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        assertThatThrownBy(() -> matchingService.reject(401L, "other@example.com"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("본인에게 온 매칭 요청에만 응답할 수 있습니다.");
+    }
+
     private RecommendationResult createRecommendationResult(
             ProposalStatus proposalStatus,
             ProposalPositionStatus positionStatus,
@@ -253,5 +382,30 @@ class MatchingServiceTest {
         );
         ReflectionTestUtils.setField(recommendationResult, "id", RESULT_ID);
         return recommendationResult;
+    }
+
+    private Matching createMatching(
+            MatchingStatus matchingStatus,
+            ProposalPositionStatus positionStatus,
+            Long headCount
+    ) {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.MATCHING,
+                positionStatus,
+                CLIENT_EMAIL
+        );
+
+        ProposalPosition proposalPosition = recommendationResult.getRecommendationRun().getProposalPosition();
+        ReflectionTestUtils.setField(proposalPosition, "headCount", headCount);
+
+        Matching matching = Matching.create(
+                recommendationResult.getResume(),
+                proposalPosition,
+                proposalPosition.getProposal().getMember(),
+                recommendationResult.getResume().getMember()
+        );
+        ReflectionTestUtils.setField(matching, "id", 401L);
+        ReflectionTestUtils.setField(matching, "status", matchingStatus);
+        return matching;
     }
 }

--- a/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
@@ -1,0 +1,257 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
+import java.math.BigDecimal;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingServiceTest {
+
+    private static final Long RESULT_ID = 101L;
+    private static final String CLIENT_EMAIL = "client@example.com";
+
+    @InjectMocks
+    private MatchingService matchingService;
+
+    @Mock
+    private RecommendationResultRepository recommendationResultRepository;
+
+    @Mock
+    private MatchingRepository matchingRepository;
+
+    @Test
+    @DisplayName("클라이언트는 추천 결과를 기준으로 PROPOSED 매칭 요청을 생성할 수 있다")
+    void request_createsProposedMatchingWhenValid() {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.MATCHING,
+                ProposalPositionStatus.OPEN,
+                CLIENT_EMAIL
+        );
+
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(recommendationResult));
+        given(matchingRepository.existsByProposalPosition_IdAndResume_IdAndStatusIn(
+                eq(201L),
+                eq(301L),
+                eq(EnumSet.of(MatchingStatus.PROPOSED, MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS))
+        )).willReturn(false);
+        given(matchingRepository.save(any(Matching.class))).willAnswer(invocation -> {
+            Matching matching = invocation.getArgument(0);
+            ReflectionTestUtils.setField(matching, "id", 401L);
+            return matching;
+        });
+
+        Matching saved = matchingService.request(RESULT_ID, CLIENT_EMAIL);
+
+        assertThat(saved.getId()).isEqualTo(401L);
+        assertThat(saved.getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+        assertThat(saved.getProposalPosition().getId()).isEqualTo(201L);
+        assertThat(saved.getResume().getId()).isEqualTo(301L);
+        assertThat(saved.getClientMember().getEmail().getValue()).isEqualTo(CLIENT_EMAIL);
+        assertThat(saved.getFreelancerMember().getEmail().getValue()).isEqualTo("freelancer@example.com");
+
+        ArgumentCaptor<Matching> captor = ArgumentCaptor.forClass(Matching.class);
+        verify(matchingRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+    }
+
+    @Test
+    @DisplayName("추천 결과가 없으면 매칭 요청을 생성할 수 없다")
+    void request_throwsWhenRecommendationResultNotFound() {
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> matchingService.request(RESULT_ID, CLIENT_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("추천 결과를 찾을 수 없습니다. id=" + RESULT_ID);
+
+        verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    @Test
+    @DisplayName("본인 제안서가 아니면 매칭 요청을 생성할 수 없다")
+    void request_throwsWhenClientDoesNotOwnProposal() {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.MATCHING,
+                ProposalPositionStatus.OPEN,
+                "owner@example.com"
+        );
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(recommendationResult));
+
+        assertThatThrownBy(() -> matchingService.request(RESULT_ID, CLIENT_EMAIL))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("본인 제안서에 대해서만 매칭 요청을 보낼 수 있습니다.");
+
+        verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    @Test
+    @DisplayName("MATCHING 상태가 아닌 제안서에는 매칭 요청을 생성할 수 없다")
+    void request_throwsWhenProposalStatusIsNotMatching() {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.WRITING,
+                ProposalPositionStatus.OPEN,
+                CLIENT_EMAIL
+        );
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(recommendationResult));
+
+        assertThatThrownBy(() -> matchingService.request(RESULT_ID, CLIENT_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("MATCHING 상태의 제안서에 대해서만 매칭 요청을 보낼 수 있습니다.");
+
+        verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    @Test
+    @DisplayName("OPEN 상태가 아닌 모집 포지션에는 매칭 요청을 생성할 수 없다")
+    void request_throwsWhenPositionStatusIsNotOpen() {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.MATCHING,
+                ProposalPositionStatus.FULL,
+                CLIENT_EMAIL
+        );
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(recommendationResult));
+
+        assertThatThrownBy(() -> matchingService.request(RESULT_ID, CLIENT_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("OPEN 상태의 모집 포지션에 대해서만 매칭 요청을 보낼 수 있습니다.");
+
+        verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    @Test
+    @DisplayName("같은 포지션과 이력서에 활성 매칭이 있으면 중복 요청할 수 없다")
+    void request_throwsWhenActiveMatchingAlreadyExists() {
+        RecommendationResult recommendationResult = createRecommendationResult(
+                ProposalStatus.MATCHING,
+                ProposalPositionStatus.OPEN,
+                CLIENT_EMAIL
+        );
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(recommendationResult));
+        given(matchingRepository.existsByProposalPosition_IdAndResume_IdAndStatusIn(
+                eq(201L),
+                eq(301L),
+                eq(EnumSet.of(MatchingStatus.PROPOSED, MatchingStatus.ACCEPTED, MatchingStatus.IN_PROGRESS))
+        )).willReturn(true);
+
+        assertThatThrownBy(() -> matchingService.request(RESULT_ID, CLIENT_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 요청했거나 진행 중인 매칭입니다.");
+
+        verify(matchingRepository, never()).save(any(Matching.class));
+    }
+
+    private RecommendationResult createRecommendationResult(
+            ProposalStatus proposalStatus,
+            ProposalPositionStatus positionStatus,
+            String proposalOwnerEmail
+    ) {
+        Member clientMember = createMember(proposalOwnerEmail, "hashed-password", "클라이언트", "010-0000-0001");
+        Member freelancerMember = createMember("freelancer@example.com", "hashed-password", "프리랜서", "010-0000-0002");
+
+        Position position = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(position, "id", 101L);
+
+        Proposal proposal = Proposal.create(
+                clientMember,
+                "AI 매칭 플랫폼",
+                "원본 입력",
+                "설명",
+                null,
+                null,
+                8L
+        );
+        if (proposalStatus == ProposalStatus.MATCHING) {
+            proposal.startMatching();
+        }
+        if (proposalStatus == ProposalStatus.COMPLETE) {
+            proposal.startMatching();
+            proposal.complete();
+        }
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "플랫폼 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                3_000_000L,
+                5_000_000L,
+                4L,
+                null,
+                null,
+                null
+        );
+        if (positionStatus != ProposalPositionStatus.OPEN) {
+            proposalPosition.changeStatus(positionStatus);
+        }
+
+        ReflectionTestUtils.setField(proposal, "id", 200L);
+        ReflectionTestUtils.setField(proposalPosition, "id", 201L);
+
+        Resume resume = Resume.create(
+                freelancerMember,
+                "자기소개입니다.",
+                (byte) 3,
+                new CareerPayload(),
+                WorkType.REMOTE,
+                ResumeWritingStatus.DONE,
+                null
+        );
+        ReflectionTestUtils.setField(resume, "id", 301L);
+
+        RecommendationRun run = RecommendationRun.create(
+                proposalPosition,
+                "fp-001",
+                RecommendationAlgorithm.HEURISTIC_V1,
+                3
+        );
+        ReflectionTestUtils.setField(run, "id", 501L);
+
+        RecommendationResult recommendationResult = RecommendationResult.create(
+                run,
+                resume,
+                1,
+                new BigDecimal("0.9100"),
+                new BigDecimal("0.8800"),
+                new ReasonFacts(List.of("Java"), List.of("플랫폼"), 3, List.of("Spring Boot"))
+        );
+        ReflectionTestUtils.setField(recommendationResult, "id", RESULT_ID);
+        return recommendationResult;
+    }
+}


### PR DESCRIPTION
## 🔎 What

- 추천 결과 기반 매칭 요청 생성 서비스 구현
- `RecommendationResult`로부터 `Resume`, `ProposalPosition`, `clientMember`, `freelancerMember`를 찾아 `Matching.create(...)` 연결
- 클라이언트 본인 제안서에 대해서만 매칭 요청을 보낼 수 있도록 소유권 검증 추가
- `proposal.status = MATCHING` 인 경우에만 매칭 요청 가능하도록 검증
- `proposal_position.status = OPEN` 인 경우에만 매칭 요청 가능하도록 검증
- 동일 `proposal_position` + `resume` 조합에 대해 활성 매칭(`PROPOSED`, `ACCEPTED`, `IN_PROGRESS`) 중복 생성 방지
- 매칭 요청 생성 엔드포인트 추가
- 프리랜서의 매칭 수락 엔드포인트 추가
- 프리랜서의 매칭 거절 엔드포인트 추가
- 프리랜서 본인에게 온 요청만 응답할 수 있도록 권한 검증 추가
- `PROPOSED -> ACCEPTED`, `PROPOSED -> REJECTED` 상태 전이 규칙 적용
- 수락 시 정원 점유 규칙 반영
- 수락 결과에 따라 필요 시 `proposal_position.status = FULL` 반영
- 제안서 상세 화면의 기존 수락/거절 버튼과 서버 흐름 연결
- 프리랜서 대시보드에서 매칭 상태가 자연스럽게 반영되는지 확인
- 서비스 테스트 작성
- 컨트롤러 테스트 작성
- 수동 검증

## 🔗 Issue

- Closes: #104 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?