### PR TITLE
[Feat] 추천 결과 LLM 이유 생성 MVP 연동

### DIFF
--- a/src/main/java/com/generic4/itda/config/ai/RecommendationReasonProperties.java
+++ b/src/main/java/com/generic4/itda/config/ai/RecommendationReasonProperties.java
@@ -20,6 +20,4 @@ public class RecommendationReasonProperties {
     private String model = "gpt-5-mini";
 
     private Integer maxOutputTokens = 500;
-
-    private Double temperature = 0.2;
 }

--- a/src/main/java/com/generic4/itda/config/ai/RecommendationReasonProperties.java
+++ b/src/main/java/com/generic4/itda/config/ai/RecommendationReasonProperties.java
@@ -1,0 +1,25 @@
+package com.generic4.itda.config.ai;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "ai.recommend-reason")
+public class RecommendationReasonProperties {
+
+    private boolean enabled = false;
+
+    private String apiUrl = "https://api.openai.com/v1/responses";
+
+    private String apiKey;
+
+    private String model = "gpt-5-mini";
+
+    private Integer maxOutputTokens = 500;
+
+    private Double temperature = 0.2;
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
@@ -8,6 +8,7 @@ import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import com.generic4.itda.service.recommend.RecommendationCandidate.CandidateSkill;
+import com.generic4.itda.service.recommend.reason.RecommendationReasonProcessor;
 import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
 import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
 import com.generic4.itda.service.recommend.scoring.model.ScoredCandidate;
@@ -30,6 +31,7 @@ public class RecommendationRunProcessor {
     private final RecommendationCandidateFinder recommendationCandidateFinder;
     private final HeuristicV1RecommendationScorer recommendationScorer;
     private final RecommendationResultCreator recommendationResultCreator;
+    private final RecommendationReasonProcessor recommendationReasonProcessor;
 
     public void process(Long runId) {
         RecommendationRun run = recommendationRunRepository.findById(runId)
@@ -79,8 +81,18 @@ public class RecommendationRunProcessor {
         );
 
         recommendationResultRepository.saveAll(results);
+        processRecommendationReasonsSafely(results);
+
         HardFilterStat hardFilterStat = new HardFilterStat(candidates.size(), results.size());
         run.markCompleted(hardFilterStat);
+    }
+
+    private void processRecommendationReasonsSafely(List<RecommendationResult> results) {
+        try {
+            recommendationReasonProcessor.process(results);
+        } catch (Exception e) {
+            log.warn("추천 이유 생성 중 오류가 발생했지만 추천 실행은 계속 진행합니다.", e);
+        }
     }
 
     private String resolveErrorMessage(Exception e) {

--- a/src/main/java/com/generic4/itda/service/recommend/reason/DisabledRecommendationReasonGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/DisabledRecommendationReasonGenerator.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.service.recommend.reason;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "ai.recommend-reason", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class DisabledRecommendationReasonGenerator implements RecommendationReasonGenerator {
+
+    @Override
+    public String generate(RecommendationReasonContext context) {
+        throw new UnsupportedOperationException("추천 이유 생성이 비활성화되어있습니다.");
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGenerator.java
@@ -1,0 +1,199 @@
+package com.generic4.itda.service.recommend.reason;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.RecommendationReasonProperties;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "ai.recommend-reason", name = "enabled", havingValue = "true")
+public class OpenAiRecommendationReasonGenerator implements RecommendationReasonGenerator {
+
+    private final RecommendationReasonProperties properties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String generate(RecommendationReasonContext context) {
+        Assert.notNull(context, "추천 이유 생성 컨텍스트는 필수입니다.");
+        validateProperties();
+
+        RestClient restClient = RestClient.builder()
+                .baseUrl(properties.getApiUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getApiKey())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        Map<String, Object> requestBody = createRequestBody(context);
+
+        String responseBody = restClient.post()
+                .uri("")
+                .body(requestBody)
+                .retrieve()
+                .body(String.class);
+
+        if (!StringUtils.hasText(responseBody)) {
+            throw new IllegalStateException("추천 이유 생성 응답이 비어있습니다.");
+        }
+
+        return extractReason(responseBody);
+    }
+
+    private void validateProperties() {
+        Assert.hasText(properties.getApiUrl(), "추천 이유 API URL은 필수입니다.");
+        Assert.hasText(properties.getApiKey(), "추천 이유 API Key는 필수입니다.");
+        Assert.hasText(properties.getModel(), "추천 이유 모델명은 필수입니다.");
+        Assert.notNull(properties.getMaxOutputTokens(), "추천 이유 maxOutputTokens는 필수입니다.");
+    }
+
+    private Map<String, Object> createRequestBody(RecommendationReasonContext context) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", properties.getModel());
+        body.put("max_output_tokens", properties.getMaxOutputTokens());
+
+        body.put("reasoning", Map.of(
+                "effort", "minimal"
+        ));
+
+        body.put("text", Map.of(
+                "verbosity", "low",
+                "format", Map.of(
+                        "type", "json_object"
+                )
+        ));
+
+        body.put("input", List.of(
+                Map.of(
+                        "role", "system",
+                        "content", List.of(
+                                Map.of(
+                                        "type", "input_text",
+                                        "text", createSystemPrompt()
+                                )
+                        )
+                ),
+                Map.of(
+                        "role", "user",
+                        "content", List.of(
+                                Map.of(
+                                        "type", "input_text",
+                                        "text", createUserPrompt(context)
+                                )
+                        )
+                )
+        ));
+
+        return body;
+    }
+
+    private String createSystemPrompt() {
+        return """
+                당신은 추천 결과 설명 생성기입니다.
+                반드시 입력으로 주어진 정보만 사용하세요.
+                없는 사실을 추론하거나 과장하지 마세요.
+                출력은 한국어 2~3문장 이내의 추천 설명이어야 합니다.
+                응답은 반드시 JSON 객체 형식이어야 하며, reason 필드 하나만 포함하세요.
+                """;
+    }
+
+    private String createUserPrompt(RecommendationReasonContext context) {
+        return """
+                아래 추천 결과 정보를 바탕으로, 왜 이 후보가 해당 포지션에 적합한지 한국어 2~3문장으로 설명하세요.
+                
+                [제안서 제목]
+                %s
+                
+                [포지션명]
+                %s
+                
+                [최종 점수]
+                %s
+                
+                [매칭 스킬]
+                %s
+                
+                [경력 연차]
+                %d
+                
+                [하이라이트]
+                %s
+                """.formatted(
+                context.proposalTitle(),
+                context.positionName(),
+                normalizeScore(context.finalScore()),
+                joinList(context.reasonFacts().matchedSkills()),
+                context.reasonFacts().careerYears(),
+                joinList(context.reasonFacts().highlights())
+        );
+    }
+
+    private String extractReason(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+
+            JsonNode outputTextNode = root.path("output_text");
+            if (outputTextNode.isTextual() && StringUtils.hasText(outputTextNode.asText())) {
+                return extractReasonFromJsonText(outputTextNode.asText());
+            }
+
+            JsonNode outputArray = root.path("output");
+            if (outputArray.isArray()) {
+                for (JsonNode outputItem : outputArray) {
+                    JsonNode contentArray = outputItem.path("content");
+                    if (!contentArray.isArray()) {
+                        continue;
+                    }
+
+                    for (JsonNode contentItem : contentArray) {
+                        JsonNode textNode = contentItem.path("text");
+                        if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
+                            return extractReasonFromJsonText(textNode.asText());
+                        }
+                    }
+                }
+            }
+
+            throw new IllegalStateException("추천 이유 생성 응답에서 텍스트를 찾을 수 없습니다.");
+        } catch (IOException e) {
+            throw new IllegalStateException("추천 이유 생성 응답 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private String extractReasonFromJsonText(String jsonText) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonText);
+            String reason = jsonNode.path("reason").asText(null);
+
+            if (!StringUtils.hasText(reason)) {
+                throw new IllegalStateException("추천 이유(reason) 필드가 비어 있습니다.");
+            }
+
+            return reason.trim();
+        } catch (IOException e) {
+            throw new IllegalStateException("추천 이유 JSON 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private String normalizeScore(BigDecimal score) {
+        return score == null ? "-" : score.stripTrailingZeros().toPlainString();
+    }
+
+    private String joinList(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return "-";
+        }
+        return String.join(", ", values);
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.service.recommend.reason;
+
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import java.math.BigDecimal;
+
+public record RecommendationReasonContext(
+        String proposalTitle,
+        String positionName,
+        ReasonFacts reasonFacts,
+        BigDecimal finalScore
+) {
+
+}

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
@@ -1,6 +1,10 @@
 package com.generic4.itda.service.recommend.reason;
 
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.mysema.commons.lang.Assert;
 import java.math.BigDecimal;
 
 public record RecommendationReasonContext(
@@ -10,4 +14,17 @@ public record RecommendationReasonContext(
         BigDecimal finalScore
 ) {
 
+    public static RecommendationReasonContext from(RecommendationResult result) {
+        Assert.notNull(result, "추천 결과는 필수입니다.");
+
+        RecommendationRun run = result.getRecommendationRun();
+        ProposalPosition proposalPosition = run.getProposalPosition();
+
+        return new RecommendationReasonContext(
+                proposalPosition.getProposal().getTitle(),
+                proposalPosition.getTitle(),
+                result.getReasonFacts(),
+                result.getFinalScore()
+        );
+    }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonGenerator.java
@@ -1,0 +1,6 @@
+package com.generic4.itda.service.recommend.reason;
+
+public interface RecommendationReasonGenerator {
+
+    String generate(RecommendationReasonContext context);
+}

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessor.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.service.recommend.reason;
 
+import com.generic4.itda.config.ai.RecommendationReasonProperties;
 import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.constant.LlmStatus;
 import java.util.List;
@@ -13,9 +14,14 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class RecommendationReasonProcessor {
 
+    private final RecommendationReasonProperties properties;
     private final RecommendationReasonGenerator recommendationReasonGenerator;
 
     public void process(List<RecommendationResult> results) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
         if (results == null || results.isEmpty()) {
             return;
         }

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessor.java
@@ -1,0 +1,45 @@
+package com.generic4.itda.service.recommend.reason;
+
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.constant.LlmStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecommendationReasonProcessor {
+
+    private final RecommendationReasonGenerator recommendationReasonGenerator;
+
+    public void process(List<RecommendationResult> results) {
+        if (results == null || results.isEmpty()) {
+            return;
+        }
+
+        for (RecommendationResult result : results) {
+            if (result.getLlmStatus() != LlmStatus.PENDING) {
+                continue;
+            }
+
+            try {
+                RecommendationReasonContext context = RecommendationReasonContext.from(result);
+                String llmReason = recommendationReasonGenerator.generate(context);
+
+                if (!StringUtils.hasText(llmReason)) {
+                    result.markLlmFailed();
+                    log.warn("추천 이유 생성 결과가 비어있습니다. resultId={}", result.getId());
+                    continue;
+                }
+
+                result.markLlmReady(llmReason);
+            } catch (Exception e) {
+                result.markLlmFailed();
+                log.warn("추천 이유 생성에 실패했습니다. resultId={}", result.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,12 @@ ai:
     api-key: ${OPENAI_API_KEY}
     model: text-embedding-3-small
     timeout-millis: 5000
+  recommend-reason:
+    api-key: ${OPEN_API_KEY}
+    enabled: ${AI_RECOMMEND_REASON_ENABLED:false}
+    model: ${AI_RECOMMEND_REASON_MODEL:gpt-5-mini}
+    max-output-tokens: ${AI_RECOMMEND_REASON_MAX_OUTPUT_TOKENS:300}
+    temperature: ${AI_RECOMMEND_REASON_TEMPERATURE:0.2}
 
 app:
   seed:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,8 +50,7 @@ ai:
     api-key: ${OPEN_API_KEY}
     enabled: ${AI_RECOMMEND_REASON_ENABLED:false}
     model: ${AI_RECOMMEND_REASON_MODEL:gpt-5-mini}
-    max-output-tokens: ${AI_RECOMMEND_REASON_MAX_OUTPUT_TOKENS:300}
-    temperature: ${AI_RECOMMEND_REASON_TEMPERATURE:0.2}
+    max-output-tokens: ${AI_RECOMMEND_REASON_MAX_OUTPUT_TOKENS:400}
 
 app:
   seed:

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -17,6 +17,7 @@ import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.LlmStatus;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
@@ -30,6 +31,7 @@ import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.reason.RecommendationReasonGenerator;
 import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
 import com.generic4.itda.service.recommend.scoring.model.RecommendationScorableCandidate;
 import com.generic4.itda.service.recommend.scoring.model.ScoreBreakdown;
@@ -78,44 +80,23 @@ class RecommendationRunProcessorIntegrationTest {
     @MockitoBean
     private RecommendationResultCreator recommendationResultCreator;
 
+    @MockitoBean
+    private RecommendationReasonGenerator recommendationReasonGenerator;
+
     @Test
-    @DisplayName("RUNNING 상태 run 처리 완료 후 RecommendationResult가 DB에 저장되고 status가 COMPUTED로 변경된다")
+    @DisplayName("RUNNING 상태 run 처리 완료 후 RecommendationResult가 DB에 저장되고 추천 이유까지 반영되며 status가 COMPUTED로 변경된다")
     void process_happyPath_savesResultsAndMarksComputed() {
         // given
         RunFixture fixture = createRunningRunFixture("proc-happy@test.com", "fp-happy");
-
-        Member resumeOwner = memberRepository.save(createMember("resume-owner-happy@test.com", "pw", "이력서소유자", "010-1111-2222"));
-        Resume resume = persist(Resume.create(resumeOwner, "백엔드 개발 경험", (byte) 3, new CareerPayload(), null, ResumeWritingStatus.DONE, null));
-        RecommendationCandidate stubbedCandidate = new RecommendationCandidate(
-                resume.getId(),
-                ResumeStatus.ACTIVE,
-                true,
-                true,
-                (byte) 3,
-                List.of(new RecommendationCandidate.CandidateSkill(1L, "Java", com.generic4.itda.domain.resume.Proficiency.ADVANCED))
-        );
-        RecommendationScorableCandidate stubbedScorableCandidate = new RecommendationScorableCandidate(
-                resume.getId(),
-                3,
-                Set.of("Java")
-        );
-        ScoredCandidate stubbedScoredCandidate = new ScoredCandidate(
-                stubbedScorableCandidate,
-                new ScoreBreakdown(0.7000, 0.1000, 0.0500, 0.8500)
+        PreparedRecommendationFixture prepared = createSingleCandidateResultFixture(
+                fixture,
+                "resume-owner-happy@test.com"
         );
 
-        RecommendationResult stubbedResult = RecommendationResult.create(
-                fixture.run(),
-                resume,
-                1,
-                BigDecimal.valueOf(0.8500),
-                BigDecimal.valueOf(0.7000),
-                new ReasonFacts(List.of("Java"), List.of(), 3, List.of())
-        );
-
-        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(stubbedCandidate));
-        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(stubbedScoredCandidate));
-        given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(stubbedResult));
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(prepared.candidate()));
+        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(prepared.scoredCandidate()));
+        given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(prepared.result()));
+        given(recommendationReasonGenerator.generate(any())).willReturn("  Java 경험이 적합합니다.  ");
 
         entityManager.flush();
         entityManager.clear();
@@ -144,8 +125,10 @@ class RecommendationRunProcessorIntegrationTest {
         assertThat(savedResults).hasSize(1);
         RecommendationResult savedResult = savedResults.get(0);
         assertThat(savedResult.getRecommendationRun().getId()).isEqualTo(fixture.runId());
-        assertThat(savedResult.getResume().getId()).isEqualTo(resume.getId());
+        assertThat(savedResult.getResume().getId()).isEqualTo(prepared.resume().getId());
         assertThat(savedResult.getRank()).isEqualTo(1);
+        assertThat(savedResult.getLlmStatus()).isEqualTo(LlmStatus.READY);
+        assertThat(savedResult.getLlmReason()).isEqualTo("Java 경험이 적합합니다.");
     }
 
     @Test
@@ -176,6 +159,45 @@ class RecommendationRunProcessorIntegrationTest {
         assertThat(recommendationResultRepository.count()).isZero();
     }
 
+    @Test
+    @DisplayName("추천 이유 생성에 실패해도 RecommendationResult는 저장되고 run status는 COMPUTED로 유지된다")
+    void process_reasonGenerationFails_savesResultAndKeepsComputed() {
+        // given
+        RunFixture fixture = createRunningRunFixture("proc-reason-fail@test.com", "fp-reason-fail");
+        PreparedRecommendationFixture prepared = createSingleCandidateResultFixture(
+                fixture,
+                "resume-owner-reason-fail@test.com"
+        );
+
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(prepared.candidate()));
+        given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(prepared.scoredCandidate()));
+        given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(prepared.result()));
+        given(recommendationReasonGenerator.generate(any())).willThrow(new RuntimeException("추천 이유 생성 실패"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        assertThatCode(() -> recommendationRunProcessor.process(fixture.runId()))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        RecommendationRun persistedRun = recommendationRunRepository.findById(fixture.runId()).orElseThrow();
+        assertThat(persistedRun.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(persistedRun.getErrorMessage()).isNull();
+        assertThat(persistedRun.getHardFilterStats()).isEqualTo(new HardFilterStat(1, 1));
+
+        List<RecommendationResult> savedResults = recommendationResultRepository.findAll();
+        assertThat(savedResults).hasSize(1);
+        RecommendationResult savedResult = savedResults.get(0);
+        assertThat(savedResult.getResume().getId()).isEqualTo(prepared.resume().getId());
+        assertThat(savedResult.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+        assertThat(savedResult.getLlmReason()).isNull();
+    }
+
     private RunFixture createRunningRunFixture(String ownerEmail, String fingerprint) {
         Member owner = memberRepository.save(createMember(ownerEmail, "pw", "제안자", "010-0000-0001"));
         Position position = persist(Position.create("백엔드 개발자"));
@@ -194,10 +216,58 @@ class RecommendationRunProcessorIntegrationTest {
         return new RunFixture(run.getId(), run);
     }
 
+    private PreparedRecommendationFixture createSingleCandidateResultFixture(RunFixture fixture, String resumeOwnerEmail) {
+        Member resumeOwner = memberRepository.save(createMember(resumeOwnerEmail, "pw", "이력서소유자", "010-1111-2222"));
+        Resume resume = persist(Resume.create(
+                resumeOwner,
+                "백엔드 개발 경험",
+                (byte) 3,
+                new CareerPayload(),
+                null,
+                ResumeWritingStatus.DONE,
+                null
+        ));
+
+        RecommendationCandidate candidate = new RecommendationCandidate(
+                resume.getId(),
+                ResumeStatus.ACTIVE,
+                true,
+                true,
+                (byte) 3,
+                List.of(new RecommendationCandidate.CandidateSkill(1L, "Java", com.generic4.itda.domain.resume.Proficiency.ADVANCED))
+        );
+        RecommendationScorableCandidate scorableCandidate = new RecommendationScorableCandidate(
+                resume.getId(),
+                3,
+                Set.of("Java")
+        );
+        ScoredCandidate scoredCandidate = new ScoredCandidate(
+                scorableCandidate,
+                new ScoreBreakdown(0.7000, 0.1000, 0.0500, 0.8500)
+        );
+        RecommendationResult result = RecommendationResult.create(
+                fixture.run(),
+                resume,
+                1,
+                BigDecimal.valueOf(0.8500),
+                BigDecimal.valueOf(0.7000),
+                new ReasonFacts(List.of("Java"), List.of(), 3, List.of())
+        );
+
+        return new PreparedRecommendationFixture(resume, candidate, scoredCandidate, result);
+    }
+
     private <T> T persist(T entity) {
         entityManager.persist(entity);
         return entity;
     }
 
     private record RunFixture(Long runId, RecommendationRun run) {}
+
+    private record PreparedRecommendationFixture(
+            Resume resume,
+            RecommendationCandidate candidate,
+            ScoredCandidate scoredCandidate,
+            RecommendationResult result
+    ) {}
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -44,10 +44,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 @IntegrationTest
 @Transactional
+@TestPropertySource(properties = "ai.recommend-reason.enabled=true")
 class RecommendationRunProcessorIntegrationTest {
 
     private static final RecommendationAlgorithm DEFAULT_ALGORITHM = RecommendationAlgorithm.HEURISTIC_V1;

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -29,6 +29,7 @@ import com.generic4.itda.exception.QueryEmbeddingGenerationException;
 import com.generic4.itda.config.ai.AiEmbeddingProperties;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import com.generic4.itda.service.recommend.reason.RecommendationReasonProcessor;
 import com.generic4.itda.service.recommend.scoring.CareerAdjustmentCalculator;
 import com.generic4.itda.service.recommend.scoring.CosineSimilarityCalculator;
 import com.generic4.itda.service.recommend.scoring.HeuristicV1RecommendationScorer;
@@ -68,6 +69,9 @@ class RecommendationRunProcessorTest {
 
     @Mock
     private RecommendationResultCreator recommendationResultCreator;
+
+    @Mock
+    private RecommendationReasonProcessor recommendationReasonProcessor;
 
     @Mock
     private RecommendationQueryTextGenerator recommendationQueryTextGenerator;
@@ -178,6 +182,7 @@ class RecommendationRunProcessorTest {
                     Set.of("Java")
             );
             then(recommendationResultRepository).should().saveAll(results);
+            then(recommendationReasonProcessor).should().process(results);
         }
     }
 
@@ -429,6 +434,49 @@ class RecommendationRunProcessorTest {
         assertThat(run.getErrorMessage()).isEqualTo("저장 실패");
     }
 
+    @Test
+    @DisplayName("추천 이유 생성 중 예외가 발생해도 추천 실행은 COMPUTED 상태로 완료된다")
+    void 추천_이유_생성_중_예외가_발생해도_추천_실행은_COMPUTED_상태로_완료된다() {
+        RecommendationRun run = createRun(true);
+
+        List<RecommendationCandidate> candidates = List.of(
+                createCandidate(10L, 3,
+                        createCandidateSkill(1L, "Java", Proficiency.ADVANCED))
+        );
+        List<ScoredCandidate> scoredCandidates = List.of();
+        List<RecommendationResult> results = List.of(org.mockito.Mockito.mock(RecommendationResult.class));
+
+        given(recommendationRunRepository.findById(1L))
+                .willReturn(Optional.of(run));
+        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+                .willReturn(candidates);
+        given(recommendationScorer.score(
+                any(),
+                any(),
+                anySet(),
+                anySet(),
+                anyList()
+        )).willReturn(scoredCandidates);
+        given(recommendationResultCreator.create(
+                run,
+                scoredCandidates,
+                run.getTopK(),
+                Set.of()
+        )).willReturn(results);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("추천 이유 생성 실패"))
+                .given(recommendationReasonProcessor).process(results);
+
+        assertThatCode(() -> recommendationRunProcessor.process(1L))
+                .doesNotThrowAnyException();
+
+        assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(run.getErrorMessage()).isNull();
+        assertThat(run.getHardFilterStats()).isEqualTo(new HardFilterStat(1, 1));
+        assertThat(run.getCandidateCount()).isEqualTo(1);
+        then(recommendationResultRepository).should().saveAll(results);
+        then(recommendationReasonProcessor).should().process(results);
+    }
+
     private RecommendationRun createRun(boolean running) {
         return createRun(createProposalPosition(), running);
     }
@@ -584,7 +632,8 @@ class RecommendationRunProcessorTest {
                 recommendationResultRepository,
                 recommendationCandidateFinder,
                 realScorer,
-                recommendationResultCreator
+                recommendationResultCreator,
+                recommendationReasonProcessor
         );
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorLiveTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorLiveTest.java
@@ -1,0 +1,60 @@
+package com.generic4.itda.service.recommend.reason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.annotation.IntegrationTest;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * OpenAiRecommendationReasonGenerator 실제 API 연동 검증 테스트
+ * <p>
+ * [실행 전 필수 조건] 1. 환경 변수 또는 설정 파일에 아래 값이 반드시 설정되어야 합니다: - OPENAI_API_KEY=sk-... (OpenAI API 키)
+ * <p>
+ * 2. 실행 방법 (예시): OPENAI_API_KEY=sk-xxx ./gradlew test --tests "*.OpenAiRecommendationReasonGeneratorLiveTest"
+ * <p>
+ * [주의 사항] - 실제 OpenAI API를 호출하므로 API 비용이 발생합니다. - CI/CD 파이프라인에서는 실행되지 않도록 @Disabled가 유지되어야 합니다.
+ */
+@Disabled("OpenAI 실제 API 호출 테스트 (수동 실행 전용)")
+@IntegrationTest
+@TestPropertySource(properties = {
+        "ai.recommend-reason.enabled=true",
+        "ai.recommend-reason.model=gpt-5-mini",
+        "ai.recommend-reason.api-key=${OPENAI_API_KEY:}"
+})
+@DisplayName("OpenAiRecommendationReasonGenerator 실제 API 연동 테스트")
+class OpenAiRecommendationReasonGeneratorLiveTest {
+
+    @Autowired
+    private OpenAiRecommendationReasonGenerator generator;
+
+    @Test
+    @DisplayName("실제 OpenAI API 호출 시 추천 이유를 정상적으로 반환한다")
+    void generate_실제API호출_추천이유반환() {
+        // given
+        RecommendationReasonContext context = new RecommendationReasonContext(
+                "이커머스 플랫폼 고도화",
+                "Java 백엔드 개발자",
+                new ReasonFacts(
+                        List.of("Java", "Spring Boot", "PostgreSQL"),
+                        List.of("E-commerce"),
+                        5,
+                        List.of("MSA 운영 경험", "대용량 트래픽 처리", "결제 시스템 유지보수")
+                ),
+                new BigDecimal("0.9200")
+        );
+
+        // when
+        String reason = generator.generate(context);
+
+        // then
+        assertThat(reason).isNotBlank();
+        System.out.println("recommendation reason = " + reason);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorTest.java
@@ -141,6 +141,23 @@ class OpenAiRecommendationReasonGeneratorTest {
     }
 
     @Test
+    @DisplayName("reason 필드 앞뒤 공백은 trim 처리된다")
+    void generate_reason앞뒤공백_trim처리() throws JsonProcessingException {
+        // given
+        responseBody.set(objectMapper.writeValueAsString(
+                java.util.Map.of("output_text", objectMapper.writeValueAsString(
+                        java.util.Map.of("reason", "  핵심 기술과 하이라이트가 포지션 요구사항과 맞습니다.  ")
+                ))
+        ));
+
+        // when
+        String reason = generator.generate(createContext());
+
+        // then
+        assertThat(reason).isEqualTo("핵심 기술과 하이라이트가 포지션 요구사항과 맞습니다.");
+    }
+
+    @Test
     @DisplayName("응답 본문이 비어 있으면 예외가 발생한다")
     void generate_응답본문비어있음_예외발생() {
         // given
@@ -164,6 +181,18 @@ class OpenAiRecommendationReasonGeneratorTest {
         assertThatThrownBy(() -> generator.generate(createContext()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("reason");
+    }
+
+    @Test
+    @DisplayName("응답에 output_text와 output 배열이 모두 없으면 예외가 발생한다")
+    void generate_텍스트응답없음_예외발생() {
+        // given
+        responseBody.set("{}");
+
+        // when / then
+        assertThatThrownBy(() -> generator.generate(createContext()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 이유 생성 응답에서 텍스트를 찾을 수 없습니다.");
     }
 
     private void handleExchange(HttpExchange exchange) throws IOException {

--- a/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/OpenAiRecommendationReasonGeneratorTest.java
@@ -1,0 +1,210 @@
+package com.generic4.itda.service.recommend.reason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic4.itda.config.ai.RecommendationReasonProperties;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+class OpenAiRecommendationReasonGeneratorTest {
+
+    private static final String API_KEY = "test-api-key";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private HttpServer server;
+    private String apiUrl;
+    private AtomicReference<CapturedRequest> capturedRequest;
+    private AtomicInteger responseStatus;
+    private AtomicReference<String> responseBody;
+    private OpenAiRecommendationReasonGenerator generator;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        capturedRequest = new AtomicReference<>();
+        responseStatus = new AtomicInteger(200);
+        responseBody = new AtomicReference<>("{}");
+
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/responses", this::handleExchange);
+        server.start();
+
+        apiUrl = "http://127.0.0.1:%d/v1/responses".formatted(server.getAddress().getPort());
+
+        RecommendationReasonProperties properties = new RecommendationReasonProperties();
+        properties.setEnabled(true);
+        properties.setApiUrl(apiUrl);
+        properties.setApiKey(API_KEY);
+        properties.setModel("gpt-5-mini");
+        properties.setMaxOutputTokens(500);
+
+        generator = new OpenAiRecommendationReasonGenerator(properties, objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @DisplayName("정상 응답이면 OpenAI 요청 본문을 구성하고 추천 이유를 반환한다")
+    void generate_정상응답_요청본문검증후추천이유반환() throws JsonProcessingException {
+        // given
+        String expectedReason = "Java와 Spring Boot 경험이 포지션 요구사항과 직접 맞닿아 있습니다. 관련 하이라이트도 뚜렷해 우선 검토 가치가 높습니다.";
+        responseBody.set(objectMapper.writeValueAsString(
+                java.util.Map.of("output_text", objectMapper.writeValueAsString(java.util.Map.of("reason", expectedReason)))
+        ));
+
+        // when
+        String reason = generator.generate(createContext());
+
+        // then
+        assertThat(reason).isEqualTo(expectedReason);
+
+        CapturedRequest request = capturedRequest.get();
+        assertThat(request).isNotNull();
+        assertThat(request.method()).isEqualTo("POST");
+        assertThat(request.path()).isEqualTo("/v1/responses");
+        assertThat(request.authorization()).isEqualTo("Bearer " + API_KEY);
+        assertThat(request.contentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+
+        JsonNode requestBody = objectMapper.readTree(request.body());
+        assertThat(requestBody.path("model").asText()).isEqualTo("gpt-5-mini");
+        assertThat(requestBody.path("max_output_tokens").asInt()).isEqualTo(500);
+        assertThat(requestBody.has("temperature")).isFalse();
+        assertThat(requestBody.path("reasoning").path("effort").asText()).isEqualTo("minimal");
+        assertThat(requestBody.path("text").path("verbosity").asText()).isEqualTo("low");
+        assertThat(requestBody.path("text").path("format").path("type").asText()).isEqualTo("json_object");
+        assertThat(requestBody.path("input")).hasSize(2);
+
+        String systemPrompt = requestBody.path("input").get(0).path("content").get(0).path("text").asText();
+        String userPrompt = requestBody.path("input").get(1).path("content").get(0).path("text").asText();
+
+        assertThat(systemPrompt).contains("응답은 반드시 JSON 객체 형식이어야 하며, reason 필드 하나만 포함하세요.");
+        assertThat(userPrompt).contains("[제안서 제목]");
+        assertThat(userPrompt).contains("이커머스 플랫폼 고도화");
+        assertThat(userPrompt).contains("[포지션명]");
+        assertThat(userPrompt).contains("Java 백엔드 개발자");
+        assertThat(userPrompt).contains("[최종 점수]");
+        assertThat(userPrompt).contains("0.85");
+        assertThat(userPrompt).contains("Java, Spring Boot");
+        assertThat(userPrompt).contains("MSA 운영 경험, 대용량 트래픽 처리");
+    }
+
+    @Test
+    @DisplayName("output_text가 없으면 output 배열의 content text에서 추천 이유를 추출한다")
+    void generate_output배열본문에서추천이유추출() throws JsonProcessingException {
+        // given
+        String expectedReason = "추천 포지션과 맞는 기술 경험이 확인됩니다. 실무 하이라이트도 포지션의 핵심 요구사항과 맞습니다.";
+        responseBody.set("""
+                {
+                  "output": [
+                    {
+                      "content": [
+                        {
+                          "text": %s
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """.formatted(objectMapper.writeValueAsString(
+                objectMapper.writeValueAsString(java.util.Map.of("reason", expectedReason))
+        )));
+
+        // when
+        String reason = generator.generate(createContext());
+
+        // then
+        assertThat(reason).isEqualTo(expectedReason);
+    }
+
+    @Test
+    @DisplayName("응답 본문이 비어 있으면 예외가 발생한다")
+    void generate_응답본문비어있음_예외발생() {
+        // given
+        responseBody.set("");
+
+        // when / then
+        assertThatThrownBy(() -> generator.generate(createContext()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 이유 생성 응답이 비어있습니다.");
+    }
+
+    @Test
+    @DisplayName("reason 필드가 비어 있으면 예외가 발생한다")
+    void generate_reason필드없음_예외발생() throws JsonProcessingException {
+        // given
+        responseBody.set(objectMapper.writeValueAsString(
+                java.util.Map.of("output_text", objectMapper.writeValueAsString(java.util.Map.of()))
+        ));
+
+        // when / then
+        assertThatThrownBy(() -> generator.generate(createContext()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("reason");
+    }
+
+    private void handleExchange(HttpExchange exchange) throws IOException {
+        byte[] requestBytes = exchange.getRequestBody().readAllBytes();
+        capturedRequest.set(new CapturedRequest(
+                exchange.getRequestMethod(),
+                exchange.getRequestURI().getPath(),
+                exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION),
+                exchange.getRequestHeaders().getFirst(HttpHeaders.CONTENT_TYPE),
+                new String(requestBytes, StandardCharsets.UTF_8)
+        ));
+
+        byte[] responseBytes = responseBody.get().getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        exchange.sendResponseHeaders(responseStatus.get(), responseBytes.length);
+
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(responseBytes);
+        }
+    }
+
+    private RecommendationReasonContext createContext() {
+        return new RecommendationReasonContext(
+                "이커머스 플랫폼 고도화",
+                "Java 백엔드 개발자",
+                new ReasonFacts(
+                        List.of("Java", "Spring Boot"),
+                        List.of("E-commerce"),
+                        5,
+                        List.of("MSA 운영 경험", "대용량 트래픽 처리")
+                ),
+                new BigDecimal("0.8500")
+        );
+    }
+
+    private record CapturedRequest(
+            String method,
+            String path,
+            String authorization,
+            String contentType,
+            String body
+    ) {
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContextTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContextTest.java
@@ -1,0 +1,63 @@
+package com.generic4.itda.service.recommend.reason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RecommendationReasonContextTest {
+
+    @Test
+    @DisplayName("추천 결과로부터 컨텍스트 생성 시 정보가 올바르게 매핑된다")
+    void from_mapsFieldsCorrectly() {
+        // given
+        String proposalTitle = "백엔드 개발자 모집";
+        String positionTitle = "Java 백엔드";
+        BigDecimal finalScore = new BigDecimal("0.8500");
+        ReasonFacts reasonFacts = new ReasonFacts(
+                List.of("Java", "Spring"),
+                List.of("E-commerce"),
+                5,
+                List.of("High performance code")
+        );
+
+        RecommendationResult result = mock(RecommendationResult.class);
+        RecommendationRun run = mock(RecommendationRun.class);
+        ProposalPosition position = mock(ProposalPosition.class);
+        Proposal proposal = mock(Proposal.class);
+
+        when(result.getRecommendationRun()).thenReturn(run);
+        when(result.getReasonFacts()).thenReturn(reasonFacts);
+        when(result.getFinalScore()).thenReturn(finalScore);
+        when(run.getProposalPosition()).thenReturn(position);
+        when(position.getProposal()).thenReturn(proposal);
+        when(proposal.getTitle()).thenReturn(proposalTitle);
+        when(position.getTitle()).thenReturn(positionTitle);
+
+        // when
+        RecommendationReasonContext context = RecommendationReasonContext.from(result);
+
+        // then
+        assertThat(context.proposalTitle()).isEqualTo(proposalTitle);
+        assertThat(context.positionName()).isEqualTo(positionTitle);
+        assertThat(context.reasonFacts()).isEqualTo(reasonFacts);
+        assertThat(context.finalScore()).isEqualTo(finalScore);
+    }
+
+    @Test
+    @DisplayName("추천 결과가 null이면 예외가 발생한다")
+    void from_throwsException_whenResultIsNull() {
+        assertThatThrownBy(() -> RecommendationReasonContext.from(null))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessorTest.java
@@ -1,0 +1,280 @@
+package com.generic4.itda.service.recommend.reason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.LlmStatus;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Resume;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationReasonProcessorTest {
+
+    @Mock
+    private RecommendationReasonGenerator recommendationReasonGenerator;
+
+    @InjectMocks
+    private RecommendationReasonProcessor recommendationReasonProcessor;
+
+    @Captor
+    private ArgumentCaptor<RecommendationReasonContext> contextCaptor;
+
+    @Test
+    @DisplayName("results가 null이면 예외 없이 종료되고 generator는 호출되지 않는다")
+    void process_whenResultsIsNull_doesNothing() {
+        // when & then
+        assertThatCode(() -> recommendationReasonProcessor.process(null))
+                .doesNotThrowAnyException();
+
+        verify(recommendationReasonGenerator, times(0)).generate(any());
+    }
+
+    @Test
+    @DisplayName("results가 빈 리스트면 예외 없이 종료되고 generator는 호출되지 않는다")
+    void process_whenResultsIsEmpty_doesNothing() {
+        // when & then
+        assertThatCode(() -> recommendationReasonProcessor.process(List.of()))
+                .doesNotThrowAnyException();
+
+        verify(recommendationReasonGenerator, times(0)).generate(any());
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 result에 대해 generator가 정상 문자열을 반환하면 READY 상태가 되고 이유가 저장된다")
+    void process_whenSuccess_marksReady() {
+        // given
+        RecommendationResult result = createPendingResult();
+        String expectedReason = "적합한 후보자입니다.";
+        when(recommendationReasonGenerator.generate(any())).thenReturn(expectedReason);
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.READY);
+        assertThat(result.getLlmReason()).isEqualTo(expectedReason);
+    }
+
+    @Test
+    @DisplayName("generator가 앞뒤 공백이 있는 문자열을 반환하면 최종 저장된 이유는 trim 처리된다")
+    void process_whenReasonHasSpaces_trimsReason() {
+        // given
+        RecommendationResult result = createPendingResult();
+        String reasonWithSpaces = "  공백이 있는 이유  ";
+        when(recommendationReasonGenerator.generate(any())).thenReturn(reasonWithSpaces);
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.READY);
+        assertThat(result.getLlmReason()).isEqualTo("공백이 있는 이유");
+    }
+
+    @Test
+    @DisplayName("generator가 null을 반환하면 FAILED 처리된다")
+    void process_whenGeneratorReturnsNull_marksFailed() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any())).thenReturn(null);
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+        assertThat(result.getLlmReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("generator가 빈 문자열을 반환하면 FAILED 처리된다")
+    void process_whenGeneratorReturnsEmpty_marksFailed() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any())).thenReturn("");
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("generator가 공백 문자열을 반환하면 FAILED 처리된다")
+    void process_whenGeneratorReturnsBlank_marksFailed() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any())).thenReturn("   ");
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("generator 호출 중 예외 발생 시 FAILED 처리된다")
+    void process_whenGeneratorThrowsException_marksFailed() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any())).thenThrow(new RuntimeException("LLM Error"));
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("여러 result 중 하나가 실패해도 나머지는 계속 처리된다")
+    void process_handlesMultipleResultsIndependently() {
+        // given
+        RecommendationResult successResult = createPendingResult();
+        RecommendationResult failResult = createPendingResult();
+
+        when(recommendationReasonGenerator.generate(any()))
+                .thenReturn("성공 이유") // 첫 번째 호출
+                .thenThrow(new RuntimeException("실패")); // 두 번째 호출
+
+        // when
+        recommendationReasonProcessor.process(List.of(successResult, failResult));
+
+        // then
+        assertThat(successResult.getLlmStatus()).isEqualTo(LlmStatus.READY);
+        assertThat(failResult.getLlmStatus()).isEqualTo(LlmStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("이미 READY 상태인 result는 skip 되어 generator가 호출되지 않는다")
+    void process_skipsReadyResults() {
+        // given
+        RecommendationResult readyResult = createPendingResult();
+        readyResult.markLlmReady("이미 완료됨");
+
+        // when
+        recommendationReasonProcessor.process(List.of(readyResult));
+
+        // then
+        verify(recommendationReasonGenerator, times(0)).generate(any());
+    }
+
+    @Test
+    @DisplayName("이미 FAILED 상태인 result는 skip 되어 generator가 호출되지 않는다")
+    void process_skipsFailedResults() {
+        // given
+        RecommendationResult failedResult = createPendingResult();
+        failedResult.markLlmFailed();
+
+        // when
+        recommendationReasonProcessor.process(List.of(failedResult));
+
+        // then
+        verify(recommendationReasonGenerator, times(0)).generate(any());
+    }
+
+    @Test
+    @DisplayName("processor는 generator 내부 예외를 바깥으로 전파하지 않는다")
+    void process_doesNotPropagateGeneratorExceptions() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any()))
+                .thenThrow(new RuntimeException("LLM Error"));
+
+        // when & then
+        assertThatCode(() -> recommendationReasonProcessor.process(List.of(result)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("generator가 받은 RecommendationReasonContext의 내용이 기대대로 매핑되는지 검증한다")
+    void process_verifiesContextMapping() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(recommendationReasonGenerator.generate(any())).thenReturn("이유");
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        verify(recommendationReasonGenerator).generate(contextCaptor.capture());
+        RecommendationReasonContext capturedContext = contextCaptor.getValue();
+
+        assertThat(capturedContext.proposalTitle()).isEqualTo("AI 매칭 플랫폼 구축");
+        assertThat(capturedContext.positionName()).isEqualTo("백엔드 개발자");
+        assertThat(capturedContext.reasonFacts().matchedSkills()).containsExactly("Java", "Spring");
+        assertThat(capturedContext.reasonFacts().careerYears()).isEqualTo(3);
+        assertThat(capturedContext.finalScore()).isEqualByComparingTo("0.8500");
+        assertThat(capturedContext.reasonFacts().highlights()).containsExactly("공통 스킬 2개 보유", "관련 경력 3년");
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 개수만큼 generator가 호출된다")
+    void process_callsGeneratorOnlyForPending() {
+        // given
+        RecommendationResult r1 = createPendingResult();
+        RecommendationResult r2 = createPendingResult();
+        RecommendationResult r3 = createPendingResult();
+
+        r2.markLlmReady("이미 완료");
+
+        when(recommendationReasonGenerator.generate(any()))
+                .thenReturn("이유");
+
+        // when
+        recommendationReasonProcessor.process(List.of(r1, r2, r3));
+
+        // then
+        verify(recommendationReasonGenerator, times(2)).generate(any());
+    }
+
+    private RecommendationResult createPendingResult() {
+        RecommendationRun run = mock(RecommendationRun.class);
+        ProposalPosition position = mock(ProposalPosition.class);
+        Proposal proposal = mock(Proposal.class);
+        Resume resume = mock(Resume.class);
+
+        lenient().when(run.getProposalPosition()).thenReturn(position);
+        lenient().when(position.getProposal()).thenReturn(proposal);
+        lenient().when(proposal.getTitle()).thenReturn("AI 매칭 플랫폼 구축");
+        lenient().when(position.getTitle()).thenReturn("백엔드 개발자");
+
+        ReasonFacts reasonFacts = new ReasonFacts(
+                List.of("Java", "Spring"),
+                List.of(),
+                3,
+                List.of("공통 스킬 2개 보유", "관련 경력 3년")
+        );
+
+        return RecommendationResult.create(
+                run,
+                resume,
+                1,
+                new BigDecimal("0.8500"),
+                new BigDecimal("0.8000"),
+                reasonFacts
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/reason/RecommendationReasonProcessorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.generic4.itda.config.ai.RecommendationReasonProperties;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.recommendation.RecommendationResult;
@@ -18,6 +19,7 @@ import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.Resume;
 import java.math.BigDecimal;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RecommendationReasonProcessorTest {
 
     @Mock
+    private RecommendationReasonProperties properties;
+
+    @Mock
     private RecommendationReasonGenerator recommendationReasonGenerator;
 
     @InjectMocks
@@ -38,6 +43,11 @@ class RecommendationReasonProcessorTest {
 
     @Captor
     private ArgumentCaptor<RecommendationReasonContext> contextCaptor;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(properties.isEnabled()).thenReturn(true);
+    }
 
     @Test
     @DisplayName("results가 null이면 예외 없이 종료되고 generator는 호출되지 않는다")
@@ -56,6 +66,22 @@ class RecommendationReasonProcessorTest {
         assertThatCode(() -> recommendationReasonProcessor.process(List.of()))
                 .doesNotThrowAnyException();
 
+        verify(recommendationReasonGenerator, times(0)).generate(any());
+    }
+
+    @Test
+    @DisplayName("추천 이유 생성 옵션이 꺼져 있으면 PENDING result를 skip 하고 generator를 호출하지 않는다")
+    void process_whenRecommendationReasonDisabled_skipsPendingResults() {
+        // given
+        RecommendationResult result = createPendingResult();
+        when(properties.isEnabled()).thenReturn(false);
+
+        // when
+        recommendationReasonProcessor.process(List.of(result));
+
+        // then
+        assertThat(result.getLlmStatus()).isEqualTo(LlmStatus.PENDING);
+        assertThat(result.getLlmReason()).isNull();
         verify(recommendationReasonGenerator, times(0)).generate(any());
     }
 


### PR DESCRIPTION
## 🔎 What

* 추천 실행 완료 후 저장된 `RecommendationResult`에 대해 LLM 기반 추천 이유를 생성하는 후처리 흐름을 추가했습니다.
* `RecommendationReasonGenerator`(OpenAI/Disabled) 구조를 도입하고, `@ConditionalOnProperty`로 분기되도록 구성했습니다.
* `RecommendationReasonProcessor`를 통해 PENDING 상태의 결과에 한해 추천 이유를 생성하고, 성공 시 `READY`, 실패 시 `FAILED`로 상태를 전이하도록 구현했습니다.
* 추천 실행(`RecommendationRun`)과 LLM 후처리를 분리하여, 추천 이유 생성 실패가 있어도 run은 `COMPUTED` 상태를 유지하도록 설계했습니다.
* `RecommendationRunProcessor`에 reason 후처리를 안전하게 연결하고, 예외 발생 시에도 전체 실행이 실패로 전이되지 않도록 보호 로직을 추가했습니다.
* 단위 테스트(`RecommendationReasonProcessorTest`)와 통합 테스트(`RecommendationRunProcessorIntegrationTest`)를 통해 정상/실패/skip/다건 처리 시나리오를 검증했습니다.

## 🔗 Issue

* Closes: #99 

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
