### PR TITLE
[Feat] 추천 결과 시드 데이터 정비 및 추천 후보 상세 보기 페이지 구현

### DIFF
--- a/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
+++ b/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
@@ -9,6 +9,11 @@ import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.recommendation.RecommendationResult;
+import com.generic4.itda.domain.recommendation.RecommendationRun;
+import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
+import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.CareerEmploymentType;
 import com.generic4.itda.domain.resume.CareerItemPayload;
 import com.generic4.itda.domain.resume.CareerPayload;
@@ -23,8 +28,12 @@ import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
+import com.generic4.itda.repository.RecommendationRunRepository;
 import com.generic4.itda.repository.ResumeRepository;
 import com.generic4.itda.repository.SkillRepository;
+import com.generic4.itda.service.recommend.RecommendationFingerprintGenerator;
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +72,9 @@ public class SeedDataInitializer implements ApplicationRunner {
     private final ResumeRepository resumeRepository;
     private final ProposalRepository proposalRepository;
     private final MatchingRepository matchingRepository;
+    private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationResultRepository recommendationResultRepository;
+    private final RecommendationFingerprintGenerator recommendationFingerprintGenerator;
     private final PasswordEncoder passwordEncoder;
 
     @Value("${app.seed.default-password:demo1234}")
@@ -289,9 +301,21 @@ public class SeedDataInitializer implements ApplicationRunner {
         // → seed.backend / seed.ai 로그인 시 해당 제안서 상세 페이지 접근 가능
         Resume backendResume = resumeRepository.findByMemberId(backend.getId()).orElseThrow();
         Resume aiResume      = resumeRepository.findByMemberId(aiEngineer.getId()).orElseThrow();
+        Resume fullstackResume = resumeRepository.findByMemberId(fullstack.getId()).orElseThrow();
 
         ensureMatching(backendResume, backendPos1, client, backend,    MatchingStatus.PROPOSED);
         ensureMatching(aiResume,      aiPos,       client, aiEngineer, MatchingStatus.ACCEPTED);
+
+        // ── Recommendation 시드 ────────────────────────────────
+        // backendPos1 기준 추천 결과 Top 3가 항상 노출되도록 실행(run) + 결과(result)를 준비한다.
+        ensureComputedRecommendationResults(
+                backendPos1,
+                List.of(
+                        backendResume,
+                        fullstackResume,
+                        aiResume
+                )
+        );
 
         log.info(
                 """
@@ -584,6 +608,205 @@ public class SeedDataInitializer implements ApplicationRunner {
             matching.accept();
         }
         return matching;
+    }
+
+    private void ensureComputedRecommendationResults(
+            ProposalPosition proposalPosition,
+            List<Resume> candidateResumes
+    ) {
+        List<Resume> uniqueCandidates = deduplicateResumesById(candidateResumes);
+
+        RecommendationAlgorithm algorithm = RecommendationAlgorithm.HEURISTIC_V1;
+        int topK = 3;
+        String fingerprint = recommendationFingerprintGenerator.generate(proposalPosition, algorithm, topK);
+
+        RecommendationRun run = recommendationRunRepository
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        proposalPosition.getId(),
+                        fingerprint,
+                        algorithm
+                )
+                .orElse(null);
+
+        if (run != null && run.isFailed()) {
+            recommendationResultRepository.deleteAll(recommendationResultRepository.findByRunIdWithResume(run.getId()));
+            recommendationRunRepository.delete(run);
+            run = null;
+        }
+
+        if (run == null) {
+            run = recommendationRunRepository.save(
+                    RecommendationRun.create(proposalPosition, fingerprint, algorithm, topK)
+            );
+        }
+
+        if (!run.isComputed()) {
+            if (run.isPending()) {
+                run.markRunning();
+            }
+            if (run.isRunning()) {
+                run.markCompleted(new HardFilterStat(20, uniqueCandidates.size()));
+            }
+            run = recommendationRunRepository.save(run);
+        }
+
+        // 결과는 매번 같은 형태로 유지(시드 idempotency 목적)
+        // 주의: insert/delete flush 순서에 따라 unique constraint가 터질 수 있어 bulk delete로 먼저 정리한다.
+        recommendationResultRepository.deleteAllByRecommendationRun_Id(run.getId());
+        recommendationResultRepository.flush();
+
+        for (int i = 0; i < Math.min(topK, uniqueCandidates.size()); i++) {
+            Resume resume = uniqueCandidates.get(i);
+            int rank = i + 1;
+
+            BigDecimal finalScore = switch (rank) {
+                case 1 -> new BigDecimal("0.9500");
+                case 2 -> new BigDecimal("0.8700");
+                default -> new BigDecimal("0.7900");
+            };
+            BigDecimal embeddingScore = switch (rank) {
+                case 1 -> new BigDecimal("0.9100");
+                case 2 -> new BigDecimal("0.8400");
+                default -> new BigDecimal("0.7700");
+            };
+
+            List<String> requiredSkillNames = proposalPosition.getSkills().stream()
+                    .map(ProposalPositionSkill::getSkill)
+                    .map(Skill::getName)
+                    .distinct()
+                    .toList();
+
+            List<String> matchedSkills = resume.getSkills().stream()
+                    .map(ResumeSkill::getSkill)
+                    .map(Skill::getName)
+                    .filter(requiredSkillNames::contains)
+                    .distinct()
+                    .sorted()
+                    .toList();
+
+            SeedRecommendationNarrative narrative = seedNarrativeFor(rank, resume, proposalPosition.getTitle());
+            List<String> highlights = createSeedHighlights(matchedSkills, resume, embeddingScore);
+
+            ReasonFacts facts = new ReasonFacts(
+                    matchedSkills,
+                    narrative.matchedDomains(),
+                    resume.getCareerYears() != null ? resume.getCareerYears().intValue() : 0,
+                    highlights
+            );
+
+            RecommendationResult result = RecommendationResult.create(
+                    run,
+                    resume,
+                    rank,
+                    finalScore,
+                    embeddingScore,
+                    facts
+            );
+
+            result.markLlmReady(narrative.llmReason());
+            recommendationResultRepository.save(result);
+        }
+    }
+
+    private List<Resume> deduplicateResumesById(List<Resume> candidateResumes) {
+        if (candidateResumes == null || candidateResumes.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Resume> deduplicated = new LinkedHashMap<>();
+        for (Resume resume : candidateResumes) {
+            if (resume == null) {
+                continue;
+            }
+            if (resume.getId() == null) {
+                continue;
+            }
+            deduplicated.putIfAbsent(resume.getId(), resume);
+        }
+        return List.copyOf(deduplicated.values());
+    }
+
+    private List<String> createSeedHighlights(
+            List<String> matchedSkills,
+            Resume resume,
+            BigDecimal embeddingScore
+    ) {
+        List<String> highlights = new java.util.ArrayList<>();
+
+        if (matchedSkills != null && !matchedSkills.isEmpty()) {
+            highlights.add("공통 스킬 " + matchedSkills.size() + "개 보유");
+        }
+
+        int careerYears = resume != null && resume.getCareerYears() != null ? resume.getCareerYears().intValue() : 0;
+        if (careerYears > 0) {
+            highlights.add("관련 경력 " + careerYears + "년");
+        }
+
+        if (embeddingScore != null && embeddingScore.compareTo(new BigDecimal("0.8000")) >= 0) {
+            highlights.add("요구 조건과 높은 유사도");
+        }
+
+        return highlights;
+    }
+
+    private SeedRecommendationNarrative seedNarrativeFor(int rank, Resume resume, String positionTitle) {
+        String name = resume.getMember().getNickname() != null && !resume.getMember().getNickname().isBlank()
+                ? resume.getMember().getNickname()
+                : resume.getMember().getName();
+        String years = resume.getCareerYears() != null ? resume.getCareerYears().toString() : "?";
+
+        if (rank == 1) {
+            return new SeedRecommendationNarrative(
+                    List.of("추천/매칭", "백엔드", "운영"),
+                    List.of(
+                            "Spring 기반 추천/매칭 API 설계 및 운영 경험",
+                            "PostgreSQL/Redis로 조회 성능·캐시 최적화 경험",
+                            "장애 대응 및 지표 기반 성능 튜닝 경험"
+                    ),
+                    """
+                    %s 후보는 %s 포지션에 필요한 Java/Spring 기반의 백엔드 설계·운영 경험이 풍부합니다.
+                    특히 추천/매칭 API를 운영 환경에서 튜닝한 경험이 있어 트래픽 증가 구간에서도 안정적으로 대응할 가능성이 높습니다.
+                    PostgreSQL/Redis를 함께 사용한 이력이 있어 데이터 접근 패턴 설계와 캐시 전략 수립에도 강점이 있습니다. (경력 %s년)
+                    """.formatted(name, positionTitle, years).trim()
+            );
+        }
+
+        if (rank == 2) {
+            return new SeedRecommendationNarrative(
+                    List.of("백엔드", "관리자/대시보드", "DevOps"),
+                    List.of(
+                            "API 서버와 관리자 화면을 함께 구축한 풀스택 경험",
+                            "Docker 기반 배포/운영 경험으로 개발-배포 흐름 대응",
+                            "백엔드(Spring)와 프론트(React/TS) 협업 관점 강점"
+                    ),
+                    """
+                    %s 후보는 백엔드(Spring)와 프론트(React/TypeScript)를 모두 경험해 팀 협업/커뮤니케이션 비용을 낮출 수 있습니다.
+                    추천 API 자체 개발뿐 아니라 운영/배포 파이프라인(Docker) 관점에서도 도움을 줄 수 있어, 초기 고도화 단계에서 유연하게 역할을 확장할 수 있습니다.
+                    핵심 백엔드 스킬셋(Java/Spring)을 보유하고 있어 포지션 요구사항과의 기본 적합도도 충분합니다. (경력 %s년)
+                    """.formatted(name, years).trim()
+            );
+        }
+
+        return new SeedRecommendationNarrative(
+                List.of("데이터", "AI", "플랫폼"),
+                List.of(
+                        "LLM 기반 추천/설명 생성 파이프라인 구현 경험",
+                        "Python/AWS 기반 추론 서비스 운영 경험",
+                        "PostgreSQL 기반 데이터 모델링 및 분석 경험"
+                ),
+                """
+                %s 후보는 LLM/추천 파이프라인 경험이 있어, 추천 품질 개선(설명 생성/실험/지표 설계) 측면에서 강점을 보입니다.
+                이번 포지션이 순수 백엔드 중심이라면 매칭 강도는 다소 낮을 수 있으나, 추천 기능 고도화/실험을 병행한다면 기여도가 커질 수 있습니다.
+                데이터 저장소(PostgreSQL) 경험이 있어 백엔드팀과의 협업 접점도 확보 가능합니다. (경력 %s년)
+                """.formatted(name, years).trim()
+        );
+    }
+
+    private record SeedRecommendationNarrative(
+            List<String> matchedDomains,
+            List<String> highlights,
+            String llmReason
+    ) {
     }
 
     private Position ensurePosition(String name) {

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -2,6 +2,7 @@ package com.generic4.itda.controller;
 
 import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
+import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
@@ -124,6 +125,30 @@ public class RecommendationController {
             model.addAttribute("title", "추천 결과를 확인할 수 없습니다.");
             model.addAttribute("message", toResultsUserMessage(e));
             model.addAttribute("backUrl", "/proposals/" + proposalId + "/runs/" + runId);
+            return "recommendation/error";
+        }
+    }
+
+    @GetMapping("/proposals/{proposalId}/recommendations/results/{resultId}")
+    public String candidateResume(
+            @PathVariable Long proposalId,
+            @PathVariable Long resultId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model
+    ) {
+        try {
+            RecommendationResumeDetailViewModel view = recommendationRunQueryService
+                    .getRecommendationCandidateResume(proposalId, resultId, principal.getEmail());
+
+            model.addAttribute("view", view);
+            return "recommendation/resume";
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("추천 후보 이력서 조회 실패. proposalId={}, resultId={}, email={}",
+                    proposalId, resultId, principal.getEmail(), e);
+
+            model.addAttribute("title", "추천 후보 이력서를 확인할 수 없습니다.");
+            model.addAttribute("message", toResultsUserMessage(e));
+            model.addAttribute("backUrl", "/proposals/" + proposalId + "/recommendations");
             return "recommendation/error";
         }
     }

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
@@ -15,5 +15,10 @@ public record RecommendationCandidateItem(
         List<String> highlights,
         String llmReason,
         String llmStatusLabel,
-        boolean llmReady
+        boolean llmReady,
+        /**
+         * 현재 매칭 상태. null이면 매칭 요청이 없는 상태 (버튼 활성).
+         * 값이 있으면 MatchingStatus.name() 문자열 (예: "PROPOSED", "ACCEPTED", ...).
+         */
+        String matchingStatus
 ) {}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeCareerItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeCareerItem.java
@@ -1,0 +1,13 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationResumeCareerItem(
+        String companyName,
+        String position,
+        String employmentTypeLabel,
+        String periodLabel,
+        String summary,
+        List<String> techStack
+) {}
+

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationResumeDetailViewModel(
+        Long proposalId,
+        Long runId,
+        Long resultId,
+        String proposalTitle,
+        String positionTitle,
+        String backUrl,
+        RecommendationCandidateItem candidate,
+        String portfolioUrl,
+        List<RecommendationResumeSkillItem> resumeSkills,
+        List<RecommendationResumeCareerItem> careerItems
+) {}
+

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeSkillItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeSkillItem.java
@@ -1,0 +1,7 @@
+package com.generic4.itda.dto.recommend;
+
+public record RecommendationResumeSkillItem(
+        String name,
+        String proficiencyLabel
+) {}
+

--- a/src/main/java/com/generic4/itda/repository/MatchingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
 
@@ -25,6 +26,16 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     long countByProposalPosition_IdAndStatusIn(Long proposalPositionId, Collection<MatchingStatus> statuses);
 
     List<Matching> findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
+
+    /**
+     * 주어진 포지션에 대해 resume ID 목록에 해당하는 매칭 상태를 한 번에 조회한다.
+     * 추천 결과 페이지에서 후보별 매칭 상태를 N+1 없이 표시하기 위해 사용한다.
+     */
+    @Query("select m from Matching m where m.proposalPosition.id = :positionId and m.resume.id in :resumeIds")
+    List<Matching> findByProposalPositionIdAndResumeIdIn(
+            @Param("positionId") Long positionId,
+            @Param("resumeIds") Collection<Long> resumeIds
+    );
 
     @Query("""
             select m

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryCustom.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryCustom.java
@@ -1,9 +1,24 @@
 package com.generic4.itda.repository;
 
 import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public interface MatchingRepositoryCustom {
     List<FreelancerDashboardItem> getDashboardItems(String email, String status, String q);
+
+    /**
+     * 같은 (proposalPositionId, resumeId) 조합에 매칭 row가 여러 개 있을 수 있으므로,
+     * ACTIVE 상태를 우선하고(없으면 최신), 후보별 대표 매칭 상태를 resumeId 기준으로 집계한다.
+     */
+    Map<Long, MatchingStatus> getLatestMatchingStatusMap(Long proposalPositionId, Collection<Long> resumeIds);
+
+    /**
+     * 단일 후보의 대표 매칭 상태를 조회한다(ACTIVE 우선, 없으면 최신).
+     */
+    Optional<MatchingStatus> getLatestMatchingStatus(Long proposalPositionId, Long resumeId);
 }

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
@@ -22,6 +22,7 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
     private final QProposalPosition proposalPosition = QProposalPosition.proposalPosition;
     private final QProposal proposal = QProposal.proposal;
     private final QMember clientMember = new QMember("clientMember");
+    private final QMember freelancerMember = new QMember("freelancerMember");
 
     @Override
     public List<FreelancerDashboardItem> getDashboardItems(String email, String status, String q) {
@@ -40,8 +41,9 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .join(matching.proposalPosition, proposalPosition)
                 .join(proposalPosition.proposal, proposal)
                 .join(matching.clientMember, clientMember)
+                .join(matching.freelancerMember, freelancerMember)
                 .where(
-                        matching.freelancerMember.email.value.eq(email),
+                        freelancerMember.email.value.eq(email),
                         statusEq(status),
                         searchKw(q)
                 )

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
@@ -7,12 +7,19 @@ import com.generic4.itda.domain.proposal.QProposal;
 import com.generic4.itda.domain.proposal.QProposalPosition;
 import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
@@ -23,6 +30,12 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
     private final QProposal proposal = QProposal.proposal;
     private final QMember clientMember = new QMember("clientMember");
     private final QMember freelancerMember = new QMember("freelancerMember");
+
+    private static final EnumSet<MatchingStatus> ACTIVE_STATUSES = EnumSet.of(
+            MatchingStatus.PROPOSED,
+            MatchingStatus.ACCEPTED,
+            MatchingStatus.IN_PROGRESS
+    );
 
     @Override
     public List<FreelancerDashboardItem> getDashboardItems(String email, String status, String q) {
@@ -72,5 +85,69 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
         // 제안서 제목에 포함되어 있거나, 기업(clientMember)의 닉네임에 포함된 경우
         return proposal.title.containsIgnoreCase(cleanQ)
                 .or(clientMember.nickname.containsIgnoreCase(cleanQ));
+    }
+
+    @Override
+    public Map<Long, MatchingStatus> getLatestMatchingStatusMap(Long proposalPositionId, Collection<Long> resumeIds) {
+        if (proposalPositionId == null || resumeIds == null || resumeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        NumberExpression<Integer> activeFirst = new CaseBuilder()
+                .when(matching.status.in(ACTIVE_STATUSES)).then(0)
+                .otherwise(1);
+
+        List<com.querydsl.core.Tuple> rows = queryFactory
+                .select(matching.resume.id, matching.status)
+                .from(matching)
+                .where(
+                        matching.proposalPosition.id.eq(proposalPositionId),
+                        matching.resume.id.in(resumeIds)
+                )
+                // resumeId별로 묶고, ACTIVE 우선 + 최신 우선(createdAt/id desc)으로 정렬하여 "대표 1건"이 먼저 오게 한다.
+                .orderBy(
+                        matching.resume.id.asc(),
+                        activeFirst.asc(),
+                        matching.createdAt.desc(),
+                        matching.id.desc()
+                )
+                .fetch();
+
+        Map<Long, MatchingStatus> map = new LinkedHashMap<>();
+        for (com.querydsl.core.Tuple row : rows) {
+            Long resumeId = row.get(matching.resume.id);
+            MatchingStatus status = row.get(matching.status);
+            if (resumeId != null && status != null) {
+                map.putIfAbsent(resumeId, status);
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public Optional<MatchingStatus> getLatestMatchingStatus(Long proposalPositionId, Long resumeId) {
+        if (proposalPositionId == null || resumeId == null) {
+            return Optional.empty();
+        }
+
+        NumberExpression<Integer> activeFirst = new CaseBuilder()
+                .when(matching.status.in(ACTIVE_STATUSES)).then(0)
+                .otherwise(1);
+
+        MatchingStatus status = queryFactory
+                .select(matching.status)
+                .from(matching)
+                .where(
+                        matching.proposalPosition.id.eq(proposalPositionId),
+                        matching.resume.id.eq(resumeId)
+                )
+                .orderBy(
+                        activeFirst.asc(),
+                        matching.createdAt.desc(),
+                        matching.id.desc()
+                )
+                .fetchFirst();
+
+        return Optional.ofNullable(status);
     }
 }

--- a/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
@@ -11,23 +11,24 @@ public interface RecommendationResultRepository extends JpaRepository<Recommenda
 
     void deleteAllByRecommendationRun_ProposalPosition_Proposal_Id(Long proposalId);
 
+    void deleteAllByRecommendationRun_Id(Long runId);
+
+    @Query("SELECT DISTINCT r FROM RecommendationResult r " +
+            "JOIN FETCH r.recommendationRun run " +
+            "JOIN FETCH run.proposalPosition pp " +
+            "JOIN FETCH pp.proposal p " +
+            "JOIN FETCH p.member " +
+            "JOIN FETCH r.resume res " +
+            "JOIN FETCH res.member " +
+            "LEFT JOIN FETCH res.skills rs " +
+            "LEFT JOIN FETCH rs.skill " +
+            "WHERE r.id = :resultId")
+    Optional<RecommendationResult> findDetailById(@Param("resultId") Long resultId);
+
     @Query("SELECT r FROM RecommendationResult r " +
             "JOIN FETCH r.resume res " +
             "JOIN FETCH res.member " +
             "WHERE r.recommendationRun.id = :runId " +
             "ORDER BY r.rank ASC")
     List<RecommendationResult> findByRunIdWithResume(@Param("runId") Long runId);
-
-    @Query("""
-            select rr
-            from RecommendationResult rr
-            join fetch rr.recommendationRun run
-            join fetch run.proposalPosition pp
-            join fetch pp.proposal p
-            join fetch p.member proposalMember
-            join fetch rr.resume resume
-            join fetch resume.member resumeMember
-            where rr.id = :resultId
-            """)
-    Optional<RecommendationResult> findDetailById(Long resultId);
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -1,5 +1,7 @@
 package com.generic4.itda.service.recommend;
 
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
@@ -8,13 +10,22 @@ import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.LlmStatus;
 import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
 import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
+import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
+import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
+import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +37,7 @@ public class RecommendationRunQueryService {
 
     private final RecommendationRunRepository recommendationRunRepository;
     private final RecommendationResultRepository recommendationResultRepository;
+    private final MatchingRepository matchingRepository;
 
     public RecommendationRunStatusViewModel getRecommendationRunStatus(Long proposalId, Long runId, String email) {
         RecommendationRun run = recommendationRunRepository.findDetailById(runId)
@@ -56,8 +68,15 @@ public class RecommendationRunQueryService {
 
         List<RecommendationResult> results = recommendationResultRepository.findByRunIdWithResume(runId);
 
+        // 후보별 매칭 상태를 한 번의 쿼리로 배치 조회 (N+1 방지)
+        List<Long> resumeIds = results.stream()
+                .map(r -> r.getResume().getId())
+                .toList();
+        Map<Long, MatchingStatus> matchingStatusMap = loadMatchingStatusMap(
+                proposalPosition.getId(), resumeIds);
+
         List<RecommendationCandidateItem> candidates = results.stream()
-                .map(this::toCandidateItem)
+                .map(r -> toCandidateItem(r, matchingStatusMap.get(r.getResume().getId())))
                 .toList();
 
         return new RecommendationResultsViewModel(
@@ -71,7 +90,59 @@ public class RecommendationRunQueryService {
         );
     }
 
-    private RecommendationCandidateItem toCandidateItem(RecommendationResult result) {
+    public RecommendationResumeDetailViewModel getRecommendationCandidateResume(Long proposalId, Long resultId, String email) {
+        RecommendationResult result = recommendationResultRepository.findDetailById(resultId)
+                .orElseThrow(() -> new IllegalArgumentException("추천 결과를 찾을 수 없습니다."));
+
+        RecommendationRun run = result.getRecommendationRun();
+        ProposalPosition proposalPosition = run.getProposalPosition();
+        Proposal proposal = proposalPosition.getProposal();
+
+        validateProposalMatches(proposal, proposalId);
+        validateOwnership(proposal, email);
+
+        if (!run.isComputed()) {
+            throw new IllegalStateException("추천 결과가 아직 준비되지 않았습니다.");
+        }
+
+        Resume resume = result.getResume();
+
+        // 해당 후보의 매칭 상태 조회
+        MatchingStatus matchingStatus = matchingRepository
+                .findByProposalPositionIdAndResumeIdIn(proposalPosition.getId(), List.of(resume.getId()))
+                .stream()
+                .findFirst()
+                .map(Matching::getStatus)
+                .orElse(null);
+
+        return new RecommendationResumeDetailViewModel(
+                proposal.getId(),
+                run.getId(),
+                result.getId(),
+                proposal.getTitle(),
+                resolvePositionTitle(proposalPosition),
+                "/proposals/%d/recommendations/results?runId=%d".formatted(proposal.getId(), run.getId()),
+                toCandidateItem(result, matchingStatus),
+                resume.getPortfolioUrl(),
+                toSkillItems(resume.getSkills()),
+                toCareerItems(resume)
+        );
+    }
+
+    private Map<Long, MatchingStatus> loadMatchingStatusMap(Long positionId, Collection<Long> resumeIds) {
+        if (resumeIds.isEmpty()) {
+            return Map.of();
+        }
+        return matchingRepository.findByProposalPositionIdAndResumeIdIn(positionId, resumeIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        m -> m.getResume().getId(),
+                        Matching::getStatus,
+                        (a, b) -> a  // 동일 resume에 매칭이 여러 개면 첫 번째 유지
+                ));
+    }
+
+    private RecommendationCandidateItem toCandidateItem(RecommendationResult result, MatchingStatus matchingStatus) {
         Resume resume = result.getResume();
         Member member = resume.getMember();
         ReasonFacts facts = result.getReasonFacts();
@@ -116,7 +187,8 @@ public class RecommendationRunQueryService {
                 highlights,
                 result.getLlmReason(),
                 result.getLlmStatus().getDescription(),
-                result.getLlmStatus() == LlmStatus.READY
+                result.getLlmStatus() == LlmStatus.READY,
+                matchingStatus != null ? matchingStatus.name() : null
         );
     }
 
@@ -137,6 +209,46 @@ public class RecommendationRunQueryService {
         if (!proposal.getId().equals(proposalId)) {
             throw new IllegalArgumentException("잘못된 추천 실행 접근입니다.");
         }
+    }
+
+    private static List<RecommendationResumeSkillItem> toSkillItems(SortedSet<ResumeSkill> skills) {
+        if (skills == null || skills.isEmpty()) {
+            return List.of();
+        }
+
+        return skills.stream()
+                .map(skill -> new RecommendationResumeSkillItem(
+                        skill.getSkill().getName(),
+                        skill.getProficiency().getDescription()
+                ))
+                .toList();
+    }
+
+    private static List<RecommendationResumeCareerItem> toCareerItems(Resume resume) {
+        if (resume.getCareer() == null || resume.getCareer().getItems() == null || resume.getCareer().getItems().isEmpty()) {
+            return List.of();
+        }
+
+        return resume.getCareer().getItems().stream()
+                .map(item -> new RecommendationResumeCareerItem(
+                        item.getCompanyName(),
+                        item.getPosition(),
+                        item.getEmploymentType() != null ? item.getEmploymentType().getDescription() : "-",
+                        formatPeriod(item.getStartYearMonth(), item.getEndYearMonth(), item.getCurrentlyWorking()),
+                        item.getSummary(),
+                        item.getTechStack() == null ? List.of() : item.getTechStack()
+                ))
+                .toList();
+    }
+
+    private static String formatPeriod(String startYearMonth, String endYearMonth, Boolean currentlyWorking) {
+        String start = (startYearMonth == null || startYearMonth.isBlank()) ? "-" : startYearMonth;
+        if (currentlyWorking != null && currentlyWorking) {
+            return start + " ~ " + "\uD604\uC7AC";
+        }
+
+        String end = (endYearMonth == null || endYearMonth.isBlank()) ? "-" : endYearMonth;
+        return start + " ~ " + end;
     }
 
     private void validateOwnership(Proposal proposal, String email) {

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -1,6 +1,5 @@
 package com.generic4.itda.service.recommend;
 
-import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.Proposal;
@@ -25,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -109,10 +107,7 @@ public class RecommendationRunQueryService {
 
         // 해당 후보의 매칭 상태 조회
         MatchingStatus matchingStatus = matchingRepository
-                .findByProposalPositionIdAndResumeIdIn(proposalPosition.getId(), List.of(resume.getId()))
-                .stream()
-                .findFirst()
-                .map(Matching::getStatus)
+                .getLatestMatchingStatus(proposalPosition.getId(), resume.getId())
                 .orElse(null);
 
         return new RecommendationResumeDetailViewModel(
@@ -133,13 +128,7 @@ public class RecommendationRunQueryService {
         if (resumeIds.isEmpty()) {
             return Map.of();
         }
-        return matchingRepository.findByProposalPositionIdAndResumeIdIn(positionId, resumeIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        m -> m.getResume().getId(),
-                        Matching::getStatus,
-                        (a, b) -> a  // 동일 resume에 매칭이 여러 개면 첫 번째 유지
-                ));
+        return matchingRepository.getLatestMatchingStatusMap(positionId, resumeIds);
     }
 
     private RecommendationCandidateItem toCandidateItem(RecommendationResult result, MatchingStatus matchingStatus) {

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -61,8 +61,8 @@
             <p class="text-3xl font-bold text-slate-900 mt-0.5" th:text="${inProgressCount} + '건'">0건</p></div>
             <p class="text-xs text-slate-400">클라이언트와 협의 중인 프로젝트</p>
         </div>
-        <div data-stat-card data-status="MATCHED"
-             th:class="${statusFilter == 'MATCHED'} ? 'rounded-3xl p-6 flex flex-col gap-3 border-2 border-blue-500 bg-white shadow-md cursor-pointer transition-all' : 'rounded-3xl p-6 flex flex-col gap-3 border border-slate-200 bg-white shadow-sm hover:border-slate-300 cursor-pointer transition-all'">
+        <div data-stat-card data-status="COMPLETED"
+             th:class="${statusFilter == 'COMPLETED'} ? 'rounded-3xl p-6 flex flex-col gap-3 border-2 border-blue-500 bg-white shadow-md cursor-pointer transition-all' : 'rounded-3xl p-6 flex flex-col gap-3 border border-slate-200 bg-white shadow-sm hover:border-slate-300 cursor-pointer transition-all'">
             <div class="w-10 h-10 rounded-2xl bg-slate-100 flex items-center justify-center">
                 <i data-lucide="check-circle" class="w-5 h-5 text-slate-500"></i>
             </div>

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -152,7 +152,7 @@
                                        class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
                                 </div>
 
-<div class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
+                                <div class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
                                     <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
                                     이력서 및 상세 정보 보기
                                     <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -51,6 +51,17 @@
         <!-- ══════════════════════════════════════════
              본문 2-column 레이아웃
         ══════════════════════════════════════════ -->
+        <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
+            <section th:if="${errorMessage != null}"
+                     class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+                <p th:text="${errorMessage}">오류 메시지</p>
+            </section>
+            <section th:if="${noticeMessage != null}"
+                     class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+                <p th:text="${noticeMessage}">안내 메시지</p>
+            </section>
+        </div>
+
         <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
             <div class="grid gap-6 lg:grid-cols-5">
 
@@ -84,78 +95,117 @@
                     <div class="space-y-4" th:unless="${#lists.isEmpty(view.candidates)}">
 
                         <article th:each="candidate : ${view.candidates}"
-                                 class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50">
+                                 th:classappend="${candidate.matchingStatus == 'REJECTED' or candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'} ? 'opacity-60' : ''"
+                                 class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50 transition-all hover:border-slate-300 hover:shadow-md">
+                            <a th:href="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${candidate.resultId})}"
+                               class="block focus:outline-none">
 
-                            <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
-                            <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-4">
+                                <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
+                                <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-4">
 
-                                <div class="flex items-start gap-3">
-                                    <!-- 아바타 -->
-                                    <div th:classappend="${candidate.rank == 1} ? 'bg-amber-50 text-amber-500 border-amber-100' :
-                                                          (${candidate.rank == 2} ? 'bg-slate-100 text-slate-400 border-slate-200' :
-                                                                                    'bg-orange-50 text-orange-400 border-orange-100')"
-                                         class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border">
-                                        <i data-lucide="user-plus" class="h-5 w-5"></i>
+                                    <div class="flex items-start gap-3">
+                                        <!-- 아바타 -->
+                                        <div th:classappend="${candidate.rank == 1} ? 'bg-amber-50 text-amber-500 border-amber-100' :
+                                                              (${candidate.rank == 2} ? 'bg-slate-100 text-slate-400 border-slate-200' :
+                                                                                        'bg-orange-50 text-orange-400 border-orange-100')"
+                                             class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border">
+                                            <i data-lucide="user-plus" class="h-5 w-5"></i>
+                                        </div>
+
+                                        <div>
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-base font-bold text-slate-900"
+                                                      th:text="${candidate.maskedName}">김*수</span>
+                                                <span class="text-sm font-medium text-slate-400"
+                                                      th:text="${view.positionTitle}">프론트엔드 개발자</span>
+                                            </div>
+                                            <!-- 스킬 칩 -->
+                                            <div class="mt-2 flex flex-wrap gap-1.5"
+                                                 th:if="${!#lists.isEmpty(candidate.matchedSkills)}">
+                                                <span th:each="skill : ${candidate.matchedSkills}"
+                                                      class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                                                      th:text="${skill}">Java</span>
+                                            </div>
+                                        </div>
                                     </div>
 
-                                    <div>
-                                        <div class="flex items-center gap-2">
-                                            <span class="text-base font-bold text-slate-900"
-                                                  th:text="${candidate.maskedName}">김*수</span>
-                                            <span class="text-sm font-medium text-slate-400"
-                                                  th:text="${view.positionTitle}">프론트엔드 개발자</span>
-                                        </div>
-                                        <!-- 스킬 칩 -->
-                                        <div class="mt-2 flex flex-wrap gap-1.5"
-                                             th:if="${!#lists.isEmpty(candidate.matchedSkills)}">
-                                            <span th:each="skill : ${candidate.matchedSkills}"
-                                                  class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
-                                                  th:text="${skill}">Java</span>
-                                        </div>
+                                    <!-- 점수 -->
+                                    <div class="shrink-0 text-right">
+                                        <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
+                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
+                                           class="text-2xl font-black tracking-tight"
+                                           th:text="${candidate.finalScorePercent + '%'}">98%</p>
+                                        <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
                                     </div>
                                 </div>
 
-                                <!-- 점수 -->
-                                <div class="shrink-0 text-right">
-                                    <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
-                                                        (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
-                                       class="text-2xl font-black tracking-tight"
-                                       th:text="${candidate.finalScorePercent + '%'}">98%</p>
-                                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
+                                <!-- ── AI 추천 사유 ── -->
+                                <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+                                    <div class="mb-1.5 flex items-center gap-1.5">
+                                        <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
+                                        <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
+                                    </div>
+                                    <p th:if="${candidate.llmReady and candidate.llmReason != null}"
+                                       class="text-sm leading-relaxed text-slate-700"
+                                       th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
+                                    <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
+                                       class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
                                 </div>
-                            </div>
 
-                            <!-- ── AI 추천 사유 ── -->
-                            <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
-                                <div class="mb-1.5 flex items-center gap-1.5">
-                                    <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
-                                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
+<div class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
+                                    <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
+                                    이력서 및 상세 정보 보기
+                                    <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
                                 </div>
-                                <p th:if="${candidate.llmReady and candidate.llmReason != null}"
-                                   class="text-sm leading-relaxed text-slate-700"
-                                   th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
-                                <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
-                                   class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
-                            </div>
+                            </a>
 
-                            <!-- ── 주요 강점 (highlights) ── -->
-                            <div class="mx-5 mb-3 rounded-xl border border-emerald-50 bg-emerald-50/60 px-4 py-3"
-                                 th:if="${!#lists.isEmpty(candidate.highlights)}">
-                                <div class="mb-1.5 flex items-center gap-1.5">
-                                    <i data-lucide="star" class="h-3.5 w-3.5 text-emerald-500"></i>
-                                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">주요 강점</p>
-                                </div>
-                                <p class="text-sm leading-relaxed text-slate-700"
-                                   th:text="${candidate.highlights[0]}">강점 내용</p>
-                            </div>
-
-                            <!-- ── 매칭 요청 버튼 ── -->
+                            <!-- ── 매칭 액션 영역 ── -->
                             <div class="border-t border-slate-100 px-5 py-4">
-                                <button type="button"
-                                        class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
-                                    <i data-lucide="send" class="h-4 w-4"></i>
-                                    매칭 요청하기
-                                </button>
+
+                                <!-- 매칭 없음: 요청 버튼 -->
+                                <th:block th:if="${candidate.matchingStatus == null}">
+                                    <form th:action="@{/recommendation-results/{id}/matchings(id=${candidate.resultId})}"
+                                          method="post">
+                                        <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                        <input type="hidden" name="redirectTo"
+                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                        <button type="submit"
+                                                class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
+                                            <i data-lucide="send" class="h-4 w-4"></i>
+                                            매칭 요청하기
+                                        </button>
+                                    </form>
+                                </th:block>
+
+                                <!-- 수락 대기 중 (PROPOSED) -->
+                                <div th:if="${candidate.matchingStatus == 'PROPOSED'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
+                                    <i data-lucide="clock" class="h-4 w-4"></i>
+                                    수락 대기 중
+                                </div>
+
+                                <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
+                                <div th:if="${candidate.matchingStatus == 'ACCEPTED' or candidate.matchingStatus == 'IN_PROGRESS'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
+                                    <i data-lucide="check-circle" class="h-4 w-4"></i>
+                                    매칭 진행 중
+                                    <!-- TODO : 매칭 결과 페이지로 연결 하면 좋을듯 합니다-->
+                                </div>
+
+                                <!-- 거절됨 (REJECTED) -->
+                                <div th:if="${candidate.matchingStatus == 'REJECTED'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                                    <i data-lucide="x-circle" class="h-4 w-4"></i>
+                                    거절됨
+                                </div>
+
+                                <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
+                                <div th:if="${candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                                    <i data-lucide="archive" class="h-4 w-4"></i>
+                                    <span th:text="${candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
+                                </div>
+
                             </div>
 
                         </article>
@@ -201,6 +251,47 @@
                                 <span class="text-sm font-semibold text-slate-800">
                                     Top <span th:text="${view.topK}">3</span>
                                 </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 매칭 현황 카드 -->
+                    <div th:if="${not #lists.isEmpty(view.candidates)}"
+                         th:with="proposedCount=${#lists.size(view.candidates.?[matchingStatus == 'PROPOSED'])},
+                                  activeCount=${#lists.size(view.candidates.?[matchingStatus == 'ACCEPTED' or matchingStatus == 'IN_PROGRESS'])},
+                                  rejectedCount=${#lists.size(view.candidates.?[matchingStatus == 'REJECTED' or matchingStatus == 'COMPLETED' or matchingStatus == 'CANCELED'])},
+                                  noneCount=${#lists.size(view.candidates.?[matchingStatus == null])}"
+                         class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+                        <h3 class="mb-3 text-sm font-bold text-slate-900">매칭 현황</h3>
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
+                                <div class="flex items-center gap-2 text-xs text-slate-500">
+                                    <span class="h-2 w-2 rounded-full bg-slate-200"></span>
+                                    미요청
+                                </div>
+                                <span class="text-sm font-bold text-slate-700" th:text="${noneCount} + '명'">0명</span>
+                            </div>
+                            <div class="flex items-center justify-between rounded-xl bg-amber-50 px-3 py-2.5">
+                                <div class="flex items-center gap-2 text-xs text-amber-600">
+                                    <span class="h-2 w-2 rounded-full bg-amber-400"></span>
+                                    수락 대기 중
+                                </div>
+                                <span class="text-sm font-bold text-amber-700" th:text="${proposedCount} + '명'">0명</span>
+                            </div>
+                            <div class="flex items-center justify-between rounded-xl bg-emerald-50 px-3 py-2.5">
+                                <div class="flex items-center gap-2 text-xs text-emerald-600">
+                                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                                    매칭 진행 중
+                                </div>
+                                <span class="text-sm font-bold text-emerald-700" th:text="${activeCount} + '명'">0명</span>
+                            </div>
+                            <div th:if="${rejectedCount > 0}"
+                                 class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
+                                <div class="flex items-center gap-2 text-xs text-slate-400">
+                                    <span class="h-2 w-2 rounded-full bg-slate-300"></span>
+                                    거절 / 완료
+                                </div>
+                                <span class="text-sm font-bold text-slate-400" th:text="${rejectedCount} + '명'">0명</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/recommendation/resume.html
+++ b/src/main/resources/templates/recommendation/resume.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${view.proposalTitle} + ' | 추천 후보 이력서'">추천 후보 이력서 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50">
+
+        <!-- 상단 바 -->
+        <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
+            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
+                <div class="flex items-center gap-4">
+                    <a th:href="${view.backUrl}"
+                       class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
+                        <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                    </a>
+                    <div>
+                        <h1 class="text-lg font-bold text-slate-900">추천 후보 이력서</h1>
+                        <p class="mt-0.5 text-xs text-slate-400"
+                           th:text="${view.proposalTitle + ' · ' + view.positionTitle}">제안서 · 포지션</p>
+                        <p class="mt-0.5 text-[11px] font-semibold text-slate-400">상세보기 &gt;</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
+            <section th:if="${errorMessage != null}"
+                     class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+                <p th:text="${errorMessage}">오류 메시지</p>
+            </section>
+            <section th:if="${noticeMessage != null}"
+                     class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+                <p th:text="${noticeMessage}">안내 메시지</p>
+            </section>
+        </div>
+
+        <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+            <div class="grid gap-6 lg:grid-cols-5">
+
+                <!-- 좌측: 후보 요약 + 사유 -->
+                <section class="lg:col-span-2 space-y-6">
+                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <span class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-600"
+                                      th:text="${'TOP ' + view.candidate.rank}">TOP 1</span>
+                            </div>
+                            <p th:classappend="${view.candidate.finalScorePercent >= 80} ? 'text-blue-600' :
+                                                (${view.candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-600')"
+                               class="text-2xl font-black tracking-tight"
+                               th:text="${view.candidate.finalScorePercent + '%'}">92%</p>
+                        </div>
+
+                        <div class="mt-4">
+                            <p class="text-base font-bold text-slate-900" th:text="${view.candidate.maskedName}">김*수</p>
+                            <p class="mt-1 text-sm text-slate-500" th:text="${view.candidate.introduction}">자기소개</p>
+                        </div>
+
+                        <div class="mt-4 grid grid-cols-[1fr_1.6fr_1fr] gap-2">
+                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
+                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">경력</p>
+                                <p class="mt-1 text-sm font-bold text-slate-800" th:text="${view.candidate.careerYears} + '년'">5년</p>
+                            </div>
+                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
+                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">선호 근무 형태</p>
+                                <p class="mt-1 text-xs font-bold leading-tight text-slate-800"
+                                   th:text="${view.candidate.preferredWorkTypeLabel}">원격</p>
+                            </div>
+                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
+                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">매칭 점수</p>
+                                <p class="mt-1 text-sm font-bold text-slate-800" th:text="${view.candidate.embeddingScorePercent + '%'}">88%</p>
+                            </div>
+                        </div>
+
+                        <div class="mt-4 flex flex-wrap gap-1.5" th:if="${!#lists.isEmpty(view.candidate.matchedSkills)}">
+                            <span th:each="skill : ${view.candidate.matchedSkills}"
+                                  class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                                  th:text="${skill}">Java</span>
+                        </div>
+
+                        <!-- 매칭 없음: 요청 버튼 -->
+                        <th:block th:if="${view.candidate.matchingStatus == null}">
+                            <form class="mt-4"
+                                  th:action="@{/recommendation-results/{id}/matchings(id=${view.resultId})}"
+                                  method="post">
+                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                <input type="hidden" name="redirectTo"
+                                       th:value="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${view.resultId})}">
+                                <button type="submit"
+                                        class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
+                                    <i data-lucide="send" class="h-4 w-4"></i>
+                                    매칭 요청하기
+                                </button>
+                            </form>
+                        </th:block>
+
+                        <!-- 수락 대기 중 (PROPOSED) -->
+                        <div th:if="${view.candidate.matchingStatus == 'PROPOSED'}"
+                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
+                            <i data-lucide="clock" class="h-4 w-4"></i>
+                            수락 대기 중
+                        </div>
+
+                        <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
+                        <div th:if="${view.candidate.matchingStatus == 'ACCEPTED' or view.candidate.matchingStatus == 'IN_PROGRESS'}"
+                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
+                            <i data-lucide="check-circle" class="h-4 w-4"></i>
+                            매칭 진행 중
+                            <!-- TODO : 매칭 결과 페이지로 연결 하면 좋을듯 합니다-->
+                        </div>
+
+                        <!-- 거절됨 (REJECTED) -->
+                        <div th:if="${view.candidate.matchingStatus == 'REJECTED'}"
+                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                            <i data-lucide="x-circle" class="h-4 w-4"></i>
+                            거절됨
+                        </div>
+
+                        <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
+                        <div th:if="${view.candidate.matchingStatus == 'COMPLETED' or view.candidate.matchingStatus == 'CANCELED'}"
+                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                            <i data-lucide="archive" class="h-4 w-4"></i>
+                            <span th:text="${view.candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
+                        </div>
+                    </article>
+
+                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+                        <div class="mb-2 flex items-center gap-2">
+                            <i data-lucide="sparkles" class="h-4 w-4 text-blue-400"></i>
+                            <h2 class="text-sm font-bold text-slate-900">AI 추천 사유</h2>
+                        </div>
+                        <p th:if="${view.candidate.llmReady and view.candidate.llmReason != null}"
+                           class="text-sm leading-relaxed text-slate-700"
+                           th:text="${view.candidate.llmReason}">사유</p>
+                        <p th:unless="${view.candidate.llmReady and view.candidate.llmReason != null}"
+                           class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
+                    </article>
+
+                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50"
+                             th:if="${!#lists.isEmpty(view.candidate.highlights)}">
+                        <div class="mb-2 flex items-center gap-2">
+                            <i data-lucide="star" class="h-4 w-4 text-emerald-500"></i>
+                            <h2 class="text-sm font-bold text-slate-900">주요 강점</h2>
+                        </div>
+                        <ul class="space-y-2">
+                            <li th:each="h : ${view.candidate.highlights}"
+                                class="rounded-xl bg-emerald-50/70 px-4 py-3 text-sm text-slate-700"
+                                th:text="${h}">강점</li>
+                        </ul>
+                    </article>
+                </section>
+
+                <!-- 우측: 이력서 상세 -->
+                <section class="lg:col-span-3 space-y-6">
+                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+                        <div class="mb-3 flex items-center justify-between">
+                            <h2 class="text-base font-bold text-slate-900">이력서</h2>
+                            <a th:if="${view.portfolioUrl != null}"
+                               th:href="${view.portfolioUrl}"
+                               target="_blank" rel="noreferrer noopener"
+                               class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
+                                <i data-lucide="link" class="h-3.5 w-3.5"></i>
+                                포트폴리오
+                            </a>
+                        </div>
+
+                        <div class="space-y-3">
+                            <div class="rounded-xl bg-slate-50 px-4 py-3">
+                                <p class="text-xs font-bold text-slate-500">자기소개</p>
+                                <p class="mt-1 text-sm leading-relaxed text-slate-800"
+                                   th:text="${view.candidate.introduction}">소개</p>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+                        <h2 class="mb-3 text-base font-bold text-slate-900">보유 기술</h2>
+                        <div th:if="${#lists.isEmpty(view.resumeSkills)}"
+                             class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+                            등록된 기술이 없습니다.
+                        </div>
+                        <div th:unless="${#lists.isEmpty(view.resumeSkills)}"
+                             class="flex flex-wrap gap-2">
+                            <span th:each="skill : ${view.resumeSkills}"
+                                  class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                                <span class="font-semibold" th:text="${skill.name}">Spring</span>
+                                <span class="rounded-md bg-slate-50 px-2 py-0.5 text-xs font-bold text-slate-500"
+                                      th:text="${skill.proficiencyLabel}">중급</span>
+                            </span>
+                        </div>
+                    </article>
+
+                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+                        <h2 class="mb-3 text-base font-bold text-slate-900">경력</h2>
+                        <div th:if="${#lists.isEmpty(view.careerItems)}"
+                             class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+                            등록된 경력이 없습니다.
+                        </div>
+                        <div th:unless="${#lists.isEmpty(view.careerItems)}" class="space-y-4">
+                            <div th:each="c : ${view.careerItems}"
+                                 class="rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
+                                <div class="flex flex-wrap items-center justify-between gap-2">
+                                    <div>
+                                        <p class="text-sm font-bold text-slate-900"
+                                           th:text="${c.companyName + ' · ' + c.position}">회사 · 직무</p>
+                                        <p class="mt-0.5 text-xs text-slate-500"
+                                           th:text="${c.employmentTypeLabel + ' · ' + c.periodLabel}">고용형태 · 기간</p>
+                                    </div>
+                                </div>
+
+                                <p th:if="${c.summary != null and !#strings.isEmpty(c.summary)}"
+                                   class="mt-3 text-sm leading-relaxed text-slate-700"
+                                   th:text="${c.summary}">요약</p>
+
+                                <div class="mt-3 flex flex-wrap gap-1.5" th:if="${!#lists.isEmpty(c.techStack)}">
+                                    <span th:each="t : ${c.techStack}"
+                                          class="rounded-md border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                                          th:text="${t}">Java</span>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                </section>
+            </div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -12,6 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.generic4.itda.annotation.ControllerTest;
 import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
+import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
+import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
+import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
@@ -32,6 +35,7 @@ class RecommendationControllerTest {
 
     private static final Long PROPOSAL_ID = 10L;
     private static final Long RUN_ID = 301L;
+    private static final Long RESULT_ID = 100L;
 
     @Autowired
     private MockMvc mockMvc;
@@ -76,7 +80,8 @@ class RecommendationControllerTest {
                         List.of("대규모 트래픽 처리 경험"),
                         null,
                         "대기 중",
-                        false
+                        false,
+                        null  // 매칭 없음
                 ))
         );
 
@@ -126,6 +131,67 @@ class RecommendationControllerTest {
 
         then(recommendationRunQueryService).should()
                 .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 후보 이력서 조회가 성공하면 resume 화면을 렌더링한다")
+    void renderCandidateResume() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationResumeDetailViewModel viewModel = new RecommendationResumeDetailViewModel(
+                PROPOSAL_ID,
+                RUN_ID,
+                RESULT_ID,
+                "제안서",
+                "백엔드 개발자",
+                "/proposals/10/recommendations/results?runId=301",
+                new RecommendationCandidateItem(
+                        RESULT_ID,
+                        1,
+                        "김*수",
+                        "소개",
+                        5,
+                        "원격",
+                        95,
+                        88,
+                        List.of("Java"),
+                        List.of("강점"),
+                        "사유",
+                        "READY",
+                        true,
+                        "PROPOSED"  // 매칭 요청 후 대기 중 시나리오
+                ),
+                "https://example.com",
+                List.of(new RecommendationResumeSkillItem("Java", "고급")),
+                List.of(new RecommendationResumeCareerItem(
+                        "ACME",
+                        "Backend",
+                        "정규직",
+                        "2024-01 ~ 2025-12",
+                        "요약",
+                        List.of("Java")
+                ))
+        );
+
+        given(recommendationRunQueryService.getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com")))
+                .willReturn(viewModel);
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results/{resultId}", PROPOSAL_ID, RESULT_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/resume"))
+                .andExpect(model().attributeExists("view"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com"));
     }
 }
 

--- a/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
@@ -185,6 +185,88 @@ class MatchingRepositoryTest {
         assertThat(found.getResume().getMember().getId()).isEqualTo(freelancerMember.getId());
     }
 
+    @Nested
+    @DisplayName("findByProposalPositionIdAndResumeIdIn")
+    class FindByProposalPositionIdAndResumeIdIn {
+
+        @Test
+        @DisplayName("포지션 ID와 resume ID 목록에 일치하는 매칭을 반환한다")
+        void returnsMatchingForGivenPositionAndResumeIds() {
+            Matching matching = saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+            em.clear();
+
+            List<Matching> result = matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                    backendPosition.getId(),
+                    List.of(freelancerResume.getId())
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getId()).isEqualTo(matching.getId());
+            assertThat(result.get(0).getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+        }
+
+        @Test
+        @DisplayName("resume ID 목록에 없는 resume의 매칭은 반환하지 않는다")
+        void excludesMatchingsForUnlistedResumeIds() {
+            saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+            em.clear();
+
+            List<Matching> result = matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                    backendPosition.getId(),
+                    List.of(-999L)
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 포지션의 매칭은 반환하지 않는다")
+        void excludesMatchingsForDifferentPosition() {
+            // 다른 제안서와 포지션 생성
+            Member otherClient = memberRepository.save(
+                    createMember("other-client@test.com", "pw", "다른클라이언트", "010-0000-0099"));
+            Position frontend = persistPosition("프론트엔드 개발자");
+            Proposal otherProposal = Proposal.create(otherClient, "다른 제안서", "원문", null, null, null, null);
+            ProposalPosition frontendPosition = otherProposal.addPosition(
+                    frontend, "프론트엔드 개발자", null, 1L, 1_000_000L, 2_000_000L, null, null, null, null);
+            proposalRepository.saveAndFlush(otherProposal);
+
+            saveMatching(frontendPosition, freelancerResume, MatchingStatus.PROPOSED);
+            em.clear();
+
+            // backendPosition으로 조회하면 frontendPosition 매칭은 안 나와야 함
+            List<Matching> result = matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                    backendPosition.getId(),
+                    List.of(freelancerResume.getId())
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("여러 resume ID에 대한 매칭을 한 번에 반환한다")
+        void returnsMultipleMatchingsForBatchResumeIds() {
+            Member secondFreelancer = memberRepository.save(
+                    createMember("freelancer2@test.com", "pw", "프리랜서2", "010-0000-0010"));
+            Resume secondResume = resumeRepository.saveAndFlush(
+                    Resume.create(secondFreelancer, "두 번째 소개", (byte) 3,
+                            new CareerPayload(), WorkType.REMOTE, ResumeWritingStatus.DONE, null));
+
+            saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+            saveMatching(backendPosition, secondResume, MatchingStatus.ACCEPTED);
+            em.clear();
+
+            List<Matching> result = matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                    backendPosition.getId(),
+                    List.of(freelancerResume.getId(), secondResume.getId())
+            );
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(Matching::getStatus)
+                    .containsExactlyInAnyOrder(MatchingStatus.PROPOSED, MatchingStatus.ACCEPTED);
+        }
+    }
+
     @Test
     @DisplayName("getDashboardItems는 프리랜서가 받은 매칭 목록을 최신순으로 반환한다")
     void getDashboardItems_returnsFreelancerDashboardItems() {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
@@ -19,14 +21,24 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +59,7 @@ class RecommendationRunQueryServiceTest {
 
     private static final Long PROPOSAL_ID = 10L;
     private static final Long RUN_ID = 301L;
+    private static final Long RESULT_ID = 100L;
     private static final Long OWNER_ID = 1L;
     private static final String OWNER_EMAIL = "owner@example.com";
 
@@ -55,6 +68,9 @@ class RecommendationRunQueryServiceTest {
 
     @Mock
     private RecommendationResultRepository recommendationResultRepository;
+
+    @Mock
+    private MatchingRepository matchingRepository;
 
     @InjectMocks
     private RecommendationRunQueryService service;
@@ -366,6 +382,8 @@ class RecommendationRunQueryServiceTest {
         result.markLlmReady("추천 사유입니다.");
 
         given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
+        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection()))
+                .willReturn(List.of());
 
         // when
         RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
@@ -392,9 +410,206 @@ class RecommendationRunQueryServiceTest {
         assertThat(item.llmReason()).isEqualTo("추천 사유입니다.");
         assertThat(item.llmStatusLabel()).isEqualTo(LlmStatus.READY.getDescription());
         assertThat(item.llmReady()).isTrue();
+        assertThat(item.matchingStatus()).isNull();  // 매칭 없음 → null
 
         verify(recommendationRunRepository).findDetailById(RUN_ID);
         verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
+        verify(matchingRepository).findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("매칭이 PROPOSED 상태면 후보의 matchingStatus는 'PROPOSED'이다")
+    void getRecommendationResults_setsMatchingStatusProposedWhenMatchingExists() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        long resumeId = 500L;
+
+        Member candidateMember = org.mockito.Mockito.mock(Member.class);
+        given(candidateMember.getNickname()).willReturn("테스터");
+
+        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
+        given(candidateResume.getId()).willReturn(resumeId);
+        given(candidateResume.getMember()).willReturn(candidateMember);
+        given(candidateResume.getIntroduction()).willReturn(null);
+        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.REMOTE);
+
+        RecommendationResult result = RecommendationResult.create(
+                run, candidateResume, 1,
+                new BigDecimal("0.9000"), new BigDecimal("0.8000"),
+                new ReasonFacts(List.of(), List.of(), 3, List.of())
+        );
+
+        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
+
+        Resume matchingResume = org.mockito.Mockito.mock(Resume.class);
+        given(matchingResume.getId()).willReturn(resumeId);
+        Matching mockMatching = org.mockito.Mockito.mock(Matching.class);
+        given(mockMatching.getResume()).willReturn(matchingResume);
+        given(mockMatching.getStatus()).willReturn(MatchingStatus.PROPOSED);
+        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyCollection()
+        )).willReturn(List.of(mockMatching));
+
+        // when
+        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(view.candidates()).hasSize(1);
+        assertThat(view.candidates().get(0).matchingStatus()).isEqualTo("PROPOSED");
+    }
+
+    @Test
+    @DisplayName("매칭이 ACCEPTED 상태면 후보의 matchingStatus는 'ACCEPTED'이다")
+    void getRecommendationResults_setsMatchingStatusAcceptedWhenMatchingIsAccepted() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        long resumeId = 501L;
+
+        Member candidateMember = org.mockito.Mockito.mock(Member.class);
+        given(candidateMember.getNickname()).willReturn("수락자");
+
+        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
+        given(candidateResume.getId()).willReturn(resumeId);
+        given(candidateResume.getMember()).willReturn(candidateMember);
+        given(candidateResume.getIntroduction()).willReturn(null);
+        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.SITE);
+
+        RecommendationResult result = RecommendationResult.create(
+                run, candidateResume, 1,
+                new BigDecimal("0.8500"), new BigDecimal("0.7500"),
+                new ReasonFacts(List.of(), List.of(), 2, List.of())
+        );
+
+        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
+
+        Resume matchingResume = org.mockito.Mockito.mock(Resume.class);
+        given(matchingResume.getId()).willReturn(resumeId);
+        Matching mockMatching = org.mockito.Mockito.mock(Matching.class);
+        given(mockMatching.getResume()).willReturn(matchingResume);
+        given(mockMatching.getStatus()).willReturn(MatchingStatus.ACCEPTED);
+        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyCollection()
+        )).willReturn(List.of(mockMatching));
+
+        // when
+        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(view.candidates()).hasSize(1);
+        assertThat(view.candidates().get(0).matchingStatus()).isEqualTo("ACCEPTED");
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태면 추천 후보 이력서 상세 ViewModel을 조립하여 반환한다")
+    void getRecommendationCandidateResume_returnsDetailViewModel() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
+
+        Member candidateMember = org.mockito.Mockito.mock(Member.class);
+        given(candidateMember.getNickname()).willReturn(null);
+        given(candidateMember.getName()).willReturn("홍길동");
+
+        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
+        given(candidateResume.getMember()).willReturn(candidateMember);
+        given(candidateResume.getIntroduction()).willReturn("소개");
+        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.HYBRID);
+        given(candidateResume.getPortfolioUrl()).willReturn("https://example.com");
+
+        SortedSet<ResumeSkill> skills = new TreeSet<>(Comparator.comparing(rs -> rs.getSkill().getName()));
+        skills.add(ResumeSkill.create(candidateResume, Skill.create("Java", null), Proficiency.ADVANCED));
+        skills.add(ResumeSkill.create(candidateResume, Skill.create("Spring", null), Proficiency.INTERMEDIATE));
+        given(candidateResume.getSkills()).willReturn(skills);
+
+        CareerItemPayload item = new CareerItemPayload();
+        item.setCompanyName("ACME");
+        item.setPosition("Backend");
+        item.setEmploymentType(com.generic4.itda.domain.resume.CareerEmploymentType.FULL_TIME);
+        item.setStartYearMonth("2024-01");
+        item.setEndYearMonth("2025-12");
+        item.setCurrentlyWorking(false);
+        item.setSummary("요약");
+        item.setTechStack(List.of("Java", "Spring"));
+
+        CareerPayload career = new CareerPayload();
+        career.setItems(List.of(item));
+        given(candidateResume.getCareer()).willReturn(career);
+
+        ReasonFacts facts = new ReasonFacts(
+                List.of("Java", "Spring"),
+                List.of(),
+                7,
+                List.of("강점")
+        );
+
+        RecommendationResult result = RecommendationResult.create(
+                run,
+                candidateResume,
+                1,
+                new BigDecimal("0.9000"),
+                new BigDecimal("0.8000"),
+                facts
+        );
+        ReflectionTestUtils.setField(result, "id", RESULT_ID);
+        result.markLlmReady("사유");
+
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(result));
+        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection()))
+                .willReturn(List.of());
+
+        // when
+        RecommendationResumeDetailViewModel view = service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(view.runId()).isEqualTo(RUN_ID);
+        assertThat(view.resultId()).isEqualTo(RESULT_ID);
+        assertThat(view.backUrl()).isEqualTo("/proposals/10/recommendations/results?runId=301");
+        assertThat(view.candidate().maskedName()).isEqualTo("홍*동");
+        assertThat(view.candidate().matchingStatus()).isNull();  // 매칭 없음 → null
+        assertThat(view.resumeSkills()).extracting("name").contains("Java", "Spring");
+        assertThat(view.careerItems()).hasSize(1);
+        assertThat(view.careerItems().get(0).companyName()).isEqualTo("ACME");
+
+        verify(recommendationResultRepository).findDetailById(RESULT_ID);
+        verify(matchingRepository).findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        verifyNoMoreInteractions(recommendationRunRepository);
+        verifyNoMoreInteractions(recommendationResultRepository);
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태가 아니면 추천 후보 이력서 상세 조회 시 IllegalStateException이 발생한다")
+    void getRecommendationCandidateResume_throwsWhenNotComputed() {
+        // given
+        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
+
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
+
+        RecommendationResult result = RecommendationResult.create(
+                run,
+                resume,
+                1,
+                new BigDecimal("0.5000"),
+                new BigDecimal("0.5000"),
+                new ReasonFacts(List.of(), List.of(), 1, List.of())
+        );
+        ReflectionTestUtils.setField(result, "id", RESULT_ID);
+
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(result));
+
+        // when / then
+        assertThatThrownBy(() -> service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
+
+        verify(recommendationResultRepository).findDetailById(RESULT_ID);
         verifyNoMoreInteractions(recommendationRunRepository);
         verifyNoMoreInteractions(recommendationResultRepository);
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
@@ -36,6 +35,7 @@ import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -382,8 +382,10 @@ class RecommendationRunQueryServiceTest {
         result.markLlmReady("추천 사유입니다.");
 
         given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
-        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection()))
-                .willReturn(List.of());
+        given(matchingRepository.getLatestMatchingStatusMap(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyCollection()
+        )).willReturn(Map.of());
 
         // when
         RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
@@ -414,7 +416,10 @@ class RecommendationRunQueryServiceTest {
 
         verify(recommendationRunRepository).findDetailById(RUN_ID);
         verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
-        verify(matchingRepository).findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        verify(matchingRepository).getLatestMatchingStatusMap(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyCollection()
+        );
         verifyNoMoreInteractions(recommendationRunRepository);
         verifyNoMoreInteractions(recommendationResultRepository);
     }
@@ -445,15 +450,10 @@ class RecommendationRunQueryServiceTest {
 
         given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
 
-        Resume matchingResume = org.mockito.Mockito.mock(Resume.class);
-        given(matchingResume.getId()).willReturn(resumeId);
-        Matching mockMatching = org.mockito.Mockito.mock(Matching.class);
-        given(mockMatching.getResume()).willReturn(matchingResume);
-        given(mockMatching.getStatus()).willReturn(MatchingStatus.PROPOSED);
-        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(
+        given(matchingRepository.getLatestMatchingStatusMap(
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.anyCollection()
-        )).willReturn(List.of(mockMatching));
+        )).willReturn(Map.of(resumeId, MatchingStatus.PROPOSED));
 
         // when
         RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
@@ -489,15 +489,10 @@ class RecommendationRunQueryServiceTest {
 
         given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
 
-        Resume matchingResume = org.mockito.Mockito.mock(Resume.class);
-        given(matchingResume.getId()).willReturn(resumeId);
-        Matching mockMatching = org.mockito.Mockito.mock(Matching.class);
-        given(mockMatching.getResume()).willReturn(matchingResume);
-        given(mockMatching.getStatus()).willReturn(MatchingStatus.ACCEPTED);
-        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(
+        given(matchingRepository.getLatestMatchingStatusMap(
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.anyCollection()
-        )).willReturn(List.of(mockMatching));
+        )).willReturn(Map.of(resumeId, MatchingStatus.ACCEPTED));
 
         // when
         RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
@@ -561,8 +556,10 @@ class RecommendationRunQueryServiceTest {
         result.markLlmReady("사유");
 
         given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(result));
-        given(matchingRepository.findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection()))
-                .willReturn(List.of());
+        given(matchingRepository.getLatestMatchingStatus(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        )).willReturn(Optional.empty());
 
         // when
         RecommendationResumeDetailViewModel view = service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL);
@@ -579,7 +576,10 @@ class RecommendationRunQueryServiceTest {
         assertThat(view.careerItems().get(0).companyName()).isEqualTo("ACME");
 
         verify(recommendationResultRepository).findDetailById(RESULT_ID);
-        verify(matchingRepository).findByProposalPositionIdAndResumeIdIn(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        verify(matchingRepository).getLatestMatchingStatus(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
         verifyNoMoreInteractions(recommendationRunRepository);
         verifyNoMoreInteractions(recommendationResultRepository);
     }


### PR DESCRIPTION
## 🔎 What

- 추천 결과가 나오도록 시드 데이터 점검/보강
- 추천에 포함되는 조건(활성/공개/AI 허용/스킬 매칭 등) 충족하도록 이력서/스킬 데이터 정리
- 추천 실행(run) 및 결과(result) 테스트용 데이터 준비(최소 N명 후보)
- 추천 결과 상세 보기 페이지 라우트 정의
- 상세 페이지 뷰 템플릿 구현
- 프리랜서 기본 정보(닉네임/경력/선호 근무형태 등)
- 매칭 점수/추천 사유(LLM reason) 및 매칭된 스킬/하이라이트 표시
- 접근 권한 검증 추가/정리
- 해당 제안서의 추천 결과에 대해서만 클라이언트가 조회 가능하도록 제한
- 추천 결과 목록(recommendation/results.html)에서 “상세 보기” 링크 연결

## 🔗 Issue

- Closes: #106

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?