### PR TITLE
[Feat] 매칭 결과 페이지 1차 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/MatchingController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingController.java
@@ -2,6 +2,7 @@ package com.generic4.itda.controller;
 
 import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.MatchingQueryService;
 import com.generic4.itda.service.MatchingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +23,30 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class MatchingController {
 
     private final MatchingService matchingService;
+    private final MatchingQueryService matchingQueryService;
+
+    @GetMapping("/matchings/{matchingId}")
+    public String detail(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            model.addAttribute("view", matchingQueryService.getDetail(matchingId, principal.getEmail()));
+            return "matching/detail";
+        } catch (IllegalArgumentException e) {
+            log.warn("매칭 상세 조회 실패. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 매칭입니다.");
+            return "redirect:/";
+        } catch (AccessDeniedException e) {
+            log.warn("매칭 상세 접근 거부. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다.");
+            return "redirect:/";
+        }
+    }
 
     @PostMapping("/recommendation-results/{recommendationResultId}/matchings")
     public String request(

--- a/src/main/java/com/generic4/itda/controller/MatchingController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingController.java
@@ -52,19 +52,20 @@ public class MatchingController {
     public String request(
             @PathVariable Long recommendationResultId,
             @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @RequestParam(name = "errorRedirectTo", required = false) String errorRedirectTo,
             @AuthenticationPrincipal ItDaPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
         try {
             Matching matching = matchingService.request(recommendationResultId, principal.getEmail());
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 보냈습니다.");
-            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            String fallback = "/matchings/" + matching.getId();
             return redirectTo(redirectTo, fallback);
         } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
             log.warn("매칭 요청 생성 실패. recommendationResultId={}, email={}",
                     recommendationResultId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", toRequestUserMessage(e));
-            return redirectTo(redirectTo, "/client/dashboard");
+            return redirectTo(errorRedirectTo, "/client/dashboard");
         }
     }
 
@@ -72,19 +73,20 @@ public class MatchingController {
     public String accept(
             @PathVariable Long matchingId,
             @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @RequestParam(name = "errorRedirectTo", required = false) String errorRedirectTo,
             @AuthenticationPrincipal ItDaPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
         try {
             Matching matching = matchingService.accept(matchingId, principal.getEmail());
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 수락했습니다.");
-            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            String fallback = "/matchings/" + matching.getId();
             return redirectTo(redirectTo, fallback);
         } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
             log.warn("매칭 요청 수락 실패. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", toResponseUserMessage(e));
-            return redirectTo(redirectTo, "/freelancers/dashboard");
+            return redirectTo(errorRedirectTo, "/freelancers/dashboard");
         }
     }
 
@@ -92,19 +94,20 @@ public class MatchingController {
     public String reject(
             @PathVariable Long matchingId,
             @RequestParam(name = "redirectTo", required = false) String redirectTo,
+            @RequestParam(name = "errorRedirectTo", required = false) String errorRedirectTo,
             @AuthenticationPrincipal ItDaPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
         try {
             Matching matching = matchingService.reject(matchingId, principal.getEmail());
             redirectAttributes.addFlashAttribute("noticeMessage", "매칭 요청을 거절했습니다.");
-            String fallback = "/proposals/" + matching.getProposalPosition().getProposal().getId();
+            String fallback = "/matchings/" + matching.getId();
             return redirectTo(redirectTo, fallback);
         } catch (IllegalArgumentException | AccessDeniedException | IllegalStateException e) {
             log.warn("매칭 요청 거절 실패. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", toResponseUserMessage(e));
-            return redirectTo(redirectTo, "/freelancers/dashboard");
+            return redirectTo(errorRedirectTo, "/freelancers/dashboard");
         }
     }
 

--- a/src/main/java/com/generic4/itda/domain/matching/Matching.java
+++ b/src/main/java/com/generic4/itda/domain/matching/Matching.java
@@ -5,18 +5,28 @@ import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.shared.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor
 public class Matching extends BaseTimeEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,26 +49,53 @@ public class Matching extends BaseTimeEntity {
     @Column(nullable = false)
     private MatchingStatus status;
 
+    private LocalDateTime requestedAt;
+    private LocalDateTime acceptedAt;
+    private LocalDateTime rejectedAt;
+    private LocalDateTime canceledAt;
     private LocalDateTime contractDate;
     private LocalDateTime completeDate;
 
     @Builder
-    private Matching(Resume resume, ProposalPosition proposalPosition, Member clientMember,
-                     Member freelancerMember, MatchingStatus status) {
+    private Matching(
+            Resume resume,
+            ProposalPosition proposalPosition,
+            Member clientMember,
+            Member freelancerMember,
+            MatchingStatus status,
+            LocalDateTime requestedAt,
+            LocalDateTime acceptedAt,
+            LocalDateTime rejectedAt,
+            LocalDateTime canceledAt,
+            LocalDateTime contractDate,
+            LocalDateTime completeDate
+    ) {
         this.resume = resume;
         this.proposalPosition = proposalPosition;
         this.clientMember = clientMember;
         this.freelancerMember = freelancerMember;
         this.status = status != null ? status : MatchingStatus.PROPOSED;
+        this.requestedAt = requestedAt;
+        this.acceptedAt = acceptedAt;
+        this.rejectedAt = rejectedAt;
+        this.canceledAt = canceledAt;
+        this.contractDate = contractDate;
+        this.completeDate = completeDate;
     }
 
-    public static Matching create(Resume resume, ProposalPosition proposalPosition, Member clientMember, Member freelancerMember) {
+    public static Matching create(
+            Resume resume,
+            ProposalPosition proposalPosition,
+            Member clientMember,
+            Member freelancerMember
+    ) {
         return Matching.builder()
                 .resume(resume)
                 .proposalPosition(proposalPosition)
                 .clientMember(clientMember)
                 .freelancerMember(freelancerMember)
                 .status(MatchingStatus.PROPOSED)
+                .requestedAt(LocalDateTime.now())
                 .build();
     }
 
@@ -67,6 +104,7 @@ public class Matching extends BaseTimeEntity {
             throw new IllegalStateException("제안 상태의 매칭만 수락할 수 있습니다.");
         }
         this.status = MatchingStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
     }
 
     public void reject() {
@@ -74,5 +112,6 @@ public class Matching extends BaseTimeEntity {
             throw new IllegalStateException("제안 상태의 매칭만 거절할 수 있습니다.");
         }
         this.status = MatchingStatus.REJECTED;
+        this.rejectedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingDetailContactViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingDetailContactViewModel.java
@@ -1,0 +1,8 @@
+package com.generic4.itda.dto.matching;
+
+public record MatchingDetailContactViewModel(
+        boolean contactVisible,
+        MatchingParticipantContactViewModel client,
+        MatchingParticipantContactViewModel freelancer
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingDetailHeaderViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingDetailHeaderViewModel.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.dto.matching;
+
+public record MatchingDetailHeaderViewModel(
+        String proposalTitle,
+        String positionTitle,
+        String counterpartDisplayName,
+        String statusLabel
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingDetailProjectSummaryViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingDetailProjectSummaryViewModel.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.dto.matching;
+
+import java.util.List;
+
+public record MatchingDetailProjectSummaryViewModel(
+        Long proposalId,
+        String proposalTitle,
+        String description,
+        String positionTitle,
+        String positionCategory,
+        String budgetText,
+        String expectedPeriodText,
+        String workTypeLabel,
+        List<String> essentialSkills,
+        List<String> preferredSkills
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingDetailSummaryViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingDetailSummaryViewModel.java
@@ -1,0 +1,12 @@
+package com.generic4.itda.dto.matching;
+
+import java.time.LocalDateTime;
+
+public record MatchingDetailSummaryViewModel(
+        String headline,
+        String helperMessage,
+        LocalDateTime requestedAt,
+        LocalDateTime respondedAt,
+        String contactGuideMessage
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingDetailViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingDetailViewModel.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.dto.matching;
+
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import java.util.List;
+
+public record MatchingDetailViewModel(
+        Long matchingId,
+        String viewerRole,
+        MatchingStatus status,
+        boolean contactVisible,
+        MatchingDetailHeaderViewModel header,
+        MatchingDetailSummaryViewModel summary,
+        MatchingDetailContactViewModel contacts,
+        MatchingDetailProjectSummaryViewModel project,
+        List<MatchingTimelineItemViewModel> timeline
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingParticipantContactViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingParticipantContactViewModel.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.dto.matching;
+
+public record MatchingParticipantContactViewModel(
+        String roleLabel,
+        String displayName,
+        String email,
+        String phone
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/matching/MatchingTimelineItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/MatchingTimelineItemViewModel.java
@@ -1,0 +1,11 @@
+package com.generic4.itda.dto.matching;
+
+import java.time.LocalDateTime;
+
+public record MatchingTimelineItemViewModel(
+        LocalDateTime occurredAt,
+        String actorLabel,
+        String actionLabel,
+        String description
+) {
+}

--- a/src/main/java/com/generic4/itda/repository/MatchingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepository.java
@@ -38,9 +38,12 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     );
 
     @Query("""
-            select m
+            select distinct m
             from Matching m
             join fetch m.proposalPosition pp
+            join fetch pp.position position
+            left join fetch pp.skills pps
+            left join fetch pps.skill skill
             join fetch pp.proposal p
             join fetch p.member proposalOwner
             join fetch m.resume resume

--- a/src/main/java/com/generic4/itda/service/MatchingQueryService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingQueryService.java
@@ -1,0 +1,250 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkill;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.dto.matching.MatchingDetailContactViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailHeaderViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailProjectSummaryViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailSummaryViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailViewModel;
+import com.generic4.itda.dto.matching.MatchingParticipantContactViewModel;
+import com.generic4.itda.dto.matching.MatchingTimelineItemViewModel;
+import com.generic4.itda.repository.MatchingRepository;
+import java.text.NumberFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MatchingQueryService {
+
+    private static final String VIEWER_ROLE_CLIENT = "CLIENT";
+    private static final String VIEWER_ROLE_FREELANCER = "FREELANCER";
+
+    private final MatchingRepository matchingRepository;
+
+    public MatchingDetailViewModel getDetail(Long matchingId, String email) {
+        Matching matching = matchingRepository.findDetailById(matchingId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=" + matchingId));
+
+        String viewerRole = resolveViewerRole(matching, email);
+
+        return new MatchingDetailViewModel(
+                matching.getId(),
+                viewerRole,
+                matching.getStatus(),
+                isContactVisible(matching.getStatus()),
+                toHeader(matching, viewerRole),
+                toSummary(matching, viewerRole),
+                toContacts(matching),
+                toProjectSummary(matching.getProposalPosition()),
+                toTimeline(matching)
+        );
+    }
+
+    private String resolveViewerRole(Matching matching, String email) {
+        if (matching.getClientMember().getEmail().getValue().equals(email)) {
+            return VIEWER_ROLE_CLIENT;
+        }
+        if (matching.getFreelancerMember().getEmail().getValue().equals(email)) {
+            return VIEWER_ROLE_FREELANCER;
+        }
+        throw new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다.");
+    }
+
+    private boolean isContactVisible(MatchingStatus status) {
+        return switch (status) {
+            case ACCEPTED, IN_PROGRESS, COMPLETED, CANCELED -> true;
+            case PROPOSED, REJECTED -> false;
+        };
+    }
+
+    private MatchingDetailHeaderViewModel toHeader(Matching matching, String viewerRole) {
+        ProposalPosition proposalPosition = matching.getProposalPosition();
+        Member counterpart = VIEWER_ROLE_CLIENT.equals(viewerRole)
+                ? matching.getFreelancerMember()
+                : matching.getClientMember();
+
+        return new MatchingDetailHeaderViewModel(
+                proposalPosition.getProposal().getTitle(),
+                proposalPosition.getTitle(),
+                resolveDisplayName(counterpart),
+                matching.getStatus().getDescription()
+        );
+    }
+
+    private MatchingDetailSummaryViewModel toSummary(Matching matching, String viewerRole) {
+        MatchingStatus status = matching.getStatus();
+        String headline = switch (status) {
+            case PROPOSED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "프리랜서 응답을 기다리는 중입니다."
+                    : "매칭 요청이 도착했습니다.";
+            case ACCEPTED -> "매칭이 수락되었습니다.";
+            case REJECTED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "매칭 요청이 거절되었습니다."
+                    : "매칭 요청을 거절했습니다.";
+            case IN_PROGRESS -> "프로젝트가 진행 중입니다.";
+            case COMPLETED -> "프로젝트가 완료되었습니다.";
+            case CANCELED -> "매칭이 취소되었습니다.";
+        };
+
+        String helperMessage = switch (status) {
+            case PROPOSED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다."
+                    : "요청 내용을 확인한 뒤 수락 또는 거절할 수 있습니다.";
+            case ACCEPTED -> "연락처가 공개되었습니다. 제안서를 다시 확인하고 협의를 이어가세요.";
+            case REJECTED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "다른 추천 후보를 검토하거나 제안서 상태를 다시 확인해보세요."
+                    : "이 매칭은 종료 상태이며 추가 응답은 필요하지 않습니다.";
+            case IN_PROGRESS -> "계약 및 진행 현황을 이 화면에서 이어서 관리할 예정입니다.";
+            case COMPLETED -> "완료된 매칭입니다.";
+            case CANCELED -> "취소된 매칭입니다.";
+        };
+
+        String contactGuideMessage = isContactVisible(status)
+                ? "매칭이 성사되어 연락처 정보가 공개된 상태입니다."
+                : "매칭이 수락되기 전까지는 연락처가 공개되지 않습니다.";
+
+        LocalDateTime respondedAt = switch (status) {
+            case ACCEPTED, REJECTED, IN_PROGRESS, COMPLETED, CANCELED -> matching.getModifiedAt();
+            case PROPOSED -> null;
+        };
+
+        return new MatchingDetailSummaryViewModel(
+                headline,
+                helperMessage,
+                matching.getCreatedAt(),
+                respondedAt,
+                contactGuideMessage
+        );
+    }
+
+    private MatchingDetailContactViewModel toContacts(Matching matching) {
+        return new MatchingDetailContactViewModel(
+                isContactVisible(matching.getStatus()),
+                toParticipant("클라이언트", matching.getClientMember()),
+                toParticipant("프리랜서", matching.getFreelancerMember())
+        );
+    }
+
+    private MatchingParticipantContactViewModel toParticipant(String roleLabel, Member member) {
+        return new MatchingParticipantContactViewModel(
+                roleLabel,
+                resolveDisplayName(member),
+                member.getEmail().getValue(),
+                formatPhone(member.getPhone().getValue())
+        );
+    }
+
+    private MatchingDetailProjectSummaryViewModel toProjectSummary(ProposalPosition proposalPosition) {
+        return new MatchingDetailProjectSummaryViewModel(
+                proposalPosition.getProposal().getId(),
+                proposalPosition.getProposal().getTitle(),
+                proposalPosition.getProposal().getDescription(),
+                proposalPosition.getTitle(),
+                proposalPosition.getPosition().getName(),
+                formatBudgetText(proposalPosition.getUnitBudgetMin(), proposalPosition.getUnitBudgetMax()),
+                formatExpectedPeriod(proposalPosition.getExpectedPeriod()),
+                proposalPosition.getWorkType() != null ? proposalPosition.getWorkType().getDescription() : "미정",
+                proposalPosition.getSkills().stream()
+                        .filter(skill -> skill.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                        .map(skill -> skill.getSkill().getName())
+                        .toList(),
+                proposalPosition.getSkills().stream()
+                        .filter(skill -> skill.getImportance() == ProposalPositionSkillImportance.PREFERENCE)
+                        .map(skill -> skill.getSkill().getName())
+                        .toList()
+        );
+    }
+
+    private List<MatchingTimelineItemViewModel> toTimeline(Matching matching) {
+        List<MatchingTimelineItemViewModel> timeline = new java.util.ArrayList<>();
+        timeline.add(new MatchingTimelineItemViewModel(
+                matching.getCreatedAt(),
+                "클라이언트",
+                "매칭 요청 전송",
+                "프리랜서에게 매칭 요청을 보냈습니다."
+        ));
+
+        if (matching.getStatus() == MatchingStatus.ACCEPTED) {
+            timeline.add(new MatchingTimelineItemViewModel(
+                    matching.getModifiedAt(),
+                    "프리랜서",
+                    "매칭 요청 수락",
+                    "매칭 요청이 수락되어 연락처가 공개되었습니다."
+            ));
+        }
+
+        if (matching.getStatus() == MatchingStatus.REJECTED) {
+            timeline.add(new MatchingTimelineItemViewModel(
+                    matching.getModifiedAt(),
+                    "프리랜서",
+                    "매칭 요청 거절",
+                    "매칭 요청이 거절되어 이 매칭은 종료되었습니다."
+            ));
+        }
+
+        return List.copyOf(timeline);
+    }
+
+    private String resolveDisplayName(Member member) {
+        if (StringUtils.hasText(member.getNickname())) {
+            return member.getNickname().trim();
+        }
+        return member.getName();
+    }
+
+    private String formatBudgetText(Long budgetMin, Long budgetMax) {
+        if (budgetMin == null && budgetMax == null) {
+            return "미정";
+        }
+        NumberFormat formatter = NumberFormat.getNumberInstance(Locale.KOREA);
+        if (budgetMin == null) {
+            return "~ " + formatter.format(budgetMax) + "원";
+        }
+        if (budgetMax == null) {
+            return formatter.format(budgetMin) + "원 ~";
+        }
+        if (budgetMin.equals(budgetMax)) {
+            return formatter.format(budgetMin) + "원";
+        }
+        return formatter.format(budgetMin) + "원 ~ " + formatter.format(budgetMax) + "원";
+    }
+
+    private String formatExpectedPeriod(Long expectedPeriod) {
+        return expectedPeriod != null ? expectedPeriod + "주" : "미정";
+    }
+
+    private String formatPhone(String phone) {
+        if (!StringUtils.hasText(phone)) {
+            return "-";
+        }
+        String digits = phone.replaceAll("[^0-9]", "");
+        if (digits.startsWith("02")) {
+            if (digits.length() == 9) {
+                return digits.substring(0, 2) + "-" + digits.substring(2, 5) + "-" + digits.substring(5);
+            }
+            if (digits.length() == 10) {
+                return digits.substring(0, 2) + "-" + digits.substring(2, 6) + "-" + digits.substring(6);
+            }
+        }
+        if (digits.length() == 10) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 6) + "-" + digits.substring(6);
+        }
+        if (digits.length() == 11) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
+        }
+        return digits;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/MatchingQueryService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingQueryService.java
@@ -4,7 +4,6 @@ import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.ProposalPosition;
-import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.dto.matching.MatchingDetailContactViewModel;
 import com.generic4.itda.dto.matching.MatchingDetailHeaderViewModel;
@@ -16,6 +15,7 @@ import com.generic4.itda.dto.matching.MatchingTimelineItemViewModel;
 import com.generic4.itda.repository.MatchingRepository;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
@@ -107,25 +107,20 @@ public class MatchingQueryService {
             case REJECTED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
                     ? "다른 추천 후보를 검토하거나 제안서 상태를 다시 확인해보세요."
                     : "이 매칭은 종료 상태이며 추가 응답은 필요하지 않습니다.";
-            case IN_PROGRESS -> "계약 및 진행 현황을 이 화면에서 이어서 관리할 예정입니다.";
-            case COMPLETED -> "완료된 매칭입니다.";
-            case CANCELED -> "취소된 매칭입니다.";
+            case IN_PROGRESS -> "프로젝트가 진행 중입니다. 연락처와 제안서 정보를 확인하며 협업을 이어가세요.";
+            case COMPLETED -> "완료된 매칭입니다. 프로젝트 진행 이력을 확인할 수 있습니다.";
+            case CANCELED -> "취소된 매칭입니다. 필요한 경우 다른 추천 후보를 검토해보세요.";
         };
 
         String contactGuideMessage = isContactVisible(status)
                 ? "매칭이 성사되어 연락처 정보가 공개된 상태입니다."
                 : "매칭이 수락되기 전까지는 연락처가 공개되지 않습니다.";
 
-        LocalDateTime respondedAt = switch (status) {
-            case ACCEPTED, REJECTED, IN_PROGRESS, COMPLETED, CANCELED -> matching.getModifiedAt();
-            case PROPOSED -> null;
-        };
-
         return new MatchingDetailSummaryViewModel(
                 headline,
                 helperMessage,
-                matching.getCreatedAt(),
-                respondedAt,
+                resolveRequestedAt(matching),
+                resolveRespondedAt(matching),
                 contactGuideMessage
         );
     }
@@ -169,33 +164,72 @@ public class MatchingQueryService {
     }
 
     private List<MatchingTimelineItemViewModel> toTimeline(Matching matching) {
-        List<MatchingTimelineItemViewModel> timeline = new java.util.ArrayList<>();
+        List<MatchingTimelineItemViewModel> timeline = new ArrayList<>();
         timeline.add(new MatchingTimelineItemViewModel(
-                matching.getCreatedAt(),
+                resolveRequestedAt(matching),
                 "클라이언트",
                 "매칭 요청 전송",
                 "프리랜서에게 매칭 요청을 보냈습니다."
         ));
 
-        if (matching.getStatus() == MatchingStatus.ACCEPTED) {
+        if (matching.getAcceptedAt() != null) {
             timeline.add(new MatchingTimelineItemViewModel(
-                    matching.getModifiedAt(),
+                    matching.getAcceptedAt(),
                     "프리랜서",
                     "매칭 요청 수락",
                     "매칭 요청이 수락되어 연락처가 공개되었습니다."
             ));
         }
 
-        if (matching.getStatus() == MatchingStatus.REJECTED) {
+        if (matching.getRejectedAt() != null) {
             timeline.add(new MatchingTimelineItemViewModel(
-                    matching.getModifiedAt(),
+                    matching.getRejectedAt(),
                     "프리랜서",
                     "매칭 요청 거절",
                     "매칭 요청이 거절되어 이 매칭은 종료되었습니다."
             ));
         }
 
+        if (matching.getContractDate() != null) {
+            timeline.add(new MatchingTimelineItemViewModel(
+                    matching.getContractDate(),
+                    "클라이언트·프리랜서",
+                    "프로젝트 진행 시작",
+                    "계약이 확정되어 프로젝트가 진행 중 상태로 전환되었습니다."
+            ));
+        }
+
+        if (matching.getCompleteDate() != null) {
+            timeline.add(new MatchingTimelineItemViewModel(
+                    matching.getCompleteDate(),
+                    "클라이언트·프리랜서",
+                    "프로젝트 완료",
+                    "프로젝트가 완료되었습니다."
+            ));
+        }
+
+        if (matching.getCanceledAt() != null) {
+            timeline.add(new MatchingTimelineItemViewModel(
+                    matching.getCanceledAt(),
+                    "클라이언트·프리랜서",
+                    "매칭 취소",
+                    "매칭이 취소되었습니다."
+            ));
+        }
+
         return List.copyOf(timeline);
+    }
+
+    private LocalDateTime resolveRequestedAt(Matching matching) {
+        return matching.getRequestedAt() != null ? matching.getRequestedAt() : matching.getCreatedAt();
+    }
+
+    private LocalDateTime resolveRespondedAt(Matching matching) {
+        return switch (matching.getStatus()) {
+            case ACCEPTED, IN_PROGRESS, COMPLETED, CANCELED -> matching.getAcceptedAt();
+            case REJECTED -> matching.getRejectedAt();
+            case PROPOSED -> null;
+        };
     }
 
     private String resolveDisplayName(Member member) {

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -78,7 +78,8 @@
                                      <th:block th:if="${myMatching != null and myMatching.status.name() == 'PROPOSED'}">
                                          <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
+                                             <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                             <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                              <button type="submit"
                                                      class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
                                                  <i data-lucide="check" class="h-4 w-4"></i>
@@ -87,7 +88,8 @@
                                          </form>
                                          <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
+                                             <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                             <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                              <button type="submit"
                                                      class="inline-flex items-center gap-2 rounded-2xl border border-red-200 bg-white px-5 py-3 text-sm font-bold text-red-500 transition hover:bg-red-50">
                                                  <i data-lucide="x" class="h-4 w-4"></i>
@@ -110,7 +112,8 @@
                                                      <div class="flex items-center gap-2">
                                                          <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
                                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
+                                                             <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                                             <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                              <button type="submit"
                                                                      class="inline-flex items-center gap-1.5 rounded-xl bg-blue-600 px-3 py-2 text-xs font-bold text-white transition hover:bg-blue-700">
                                                                  수락
@@ -118,7 +121,8 @@
                                                          </form>
                                                          <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
                                                              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                                             <input type="hidden" name="redirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
+                                                             <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                                             <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                              <button type="submit"
                                                                      class="inline-flex items-center gap-1.5 rounded-xl border border-red-200 bg-white px-3 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
                                                                  거절
@@ -318,6 +322,8 @@
                                         <th:block th:if="${myMatching.status.name() == 'PROPOSED'}">
                                             <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
                                                 <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                                <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                 <button type="submit"
                                                         class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-xs font-bold text-white shadow-sm transition hover:bg-blue-700">
                                                     <i data-lucide="check" class="h-3.5 w-3.5"></i>
@@ -326,6 +332,8 @@
                                             </form>
                                             <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
                                                 <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
+                                                <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
                                                 <button type="submit"
                                                         class="inline-flex items-center gap-1.5 rounded-2xl border border-red-200 bg-white px-4 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
                                                     <i data-lucide="x" class="h-3.5 w-3.5"></i>
@@ -454,7 +462,6 @@
 </div>
 </body>
 </html>
-
 
 
 

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${view.header.proposalTitle} + ' | 매칭 결과'">매칭 결과 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-5xl space-y-6">
+            <section class="rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-sm shadow-slate-200/60">
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING DETAIL</p>
+                <h1 class="mt-2 text-2xl font-black tracking-tight text-slate-950"
+                    th:text="${view.header.proposalTitle}">제안서 제목</h1>
+                <p class="mt-1 text-sm text-slate-500"
+                   th:text="${view.header.positionTitle} + ' · ' + ${view.header.statusLabel}">포지션 제목 · 상태</p>
+            </section>
+
+            <section class="rounded-[28px] border border-dashed border-slate-200 bg-white px-6 py-6 shadow-sm shadow-slate-200/40">
+                <h2 class="text-base font-bold text-slate-900">매칭 결과 페이지 준비 중</h2>
+                <p class="mt-2 text-sm leading-relaxed text-slate-500">
+                    1차 작업 단위에서는 조회 백엔드와 모델 바인딩을 먼저 연결했습니다.
+                    다음 작업 단위에서 실제 카드/스텝퍼/타임라인 UI를 이 구조 위에 얹을 예정입니다.
+                </p>
+
+                <dl class="mt-6 grid gap-4 md:grid-cols-2">
+                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
+                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">매칭 ID</dt>
+                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.matchingId}">1</dd>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
+                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">뷰어 역할</dt>
+                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.viewerRole}">CLIENT</dd>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
+                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">현재 상태</dt>
+                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.status.description}">수락됨</dd>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
+                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">연락처 공개 여부</dt>
+                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.contactVisible ? '공개됨' : '비공개'}">공개됨</dd>
+                    </div>
+                </dl>
+            </section>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -51,6 +51,15 @@
         </div>
 
         <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+            <section th:if="${errorMessage != null}"
+                     class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+                <p th:text="${errorMessage}">오류 메시지</p>
+            </section>
+            <section th:if="${noticeMessage != null}"
+                     class="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+                <p th:text="${noticeMessage}">안내 메시지</p>
+            </section>
+
             <div class="grid gap-6 xl:grid-cols-[minmax(0,1.8fr)_minmax(320px,0.95fr)]">
 
                 <section class="space-y-6">
@@ -224,6 +233,71 @@
                 </section>
 
                 <aside class="space-y-6">
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60">
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">ACTIONS</p>
+                            <h3 class="mt-2 text-lg font-bold tracking-tight text-slate-900">현재 가능한 작업</h3>
+                        </div>
+
+                        <div th:if="${proposed and view.viewerRole == 'FREELANCER'}" class="mt-6 space-y-3">
+                            <p class="text-sm leading-relaxed text-slate-600">
+                                요청 내용을 확인한 뒤 이 화면에서 바로 수락하거나 거절할 수 있습니다.
+                            </p>
+
+                            <form th:action="@{/matchings/{id}/accept(id=${view.matchingId})}" method="post">
+                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${view.matchingId})}">
+                                <input type="hidden" name="errorRedirectTo" th:value="@{/matchings/{id}(id=${view.matchingId})}">
+                                <button type="submit"
+                                        class="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-blue-700">
+                                    <i data-lucide="check" class="h-4 w-4"></i>
+                                    매칭 요청 수락
+                                </button>
+                            </form>
+
+                            <form th:action="@{/matchings/{id}/reject(id=${view.matchingId})}" method="post">
+                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${view.matchingId})}">
+                                <input type="hidden" name="errorRedirectTo" th:value="@{/matchings/{id}(id=${view.matchingId})}">
+                                <button type="submit"
+                                        class="flex w-full items-center justify-center gap-2 rounded-2xl border border-rose-200 bg-white px-4 py-3 text-sm font-bold text-rose-600 transition hover:bg-rose-50">
+                                    <i data-lucide="x" class="h-4 w-4"></i>
+                                    매칭 요청 거절
+                                </button>
+                            </form>
+                        </div>
+
+                        <div th:if="${proposed and view.viewerRole == 'CLIENT'}"
+                             class="mt-6 rounded-2xl border border-blue-100 bg-blue-50 px-5 py-4">
+                            <p class="text-sm font-bold text-blue-700">프리랜서 응답 대기 중</p>
+                            <p class="mt-2 text-sm leading-relaxed text-blue-600">
+                                상대방이 요청을 확인하는 중입니다. 응답이 오면 이 화면에서 상태를 바로 확인할 수 있습니다.
+                            </p>
+                        </div>
+
+                        <div th:if="${accepted}"
+                             class="mt-6 rounded-2xl border border-emerald-100 bg-emerald-50 px-5 py-4">
+                            <p class="text-sm font-bold text-emerald-700">매칭이 수락되었습니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-emerald-600">
+                                연락처가 공개된 상태입니다. 제안서 내용을 다시 확인하고 협의를 이어가세요.
+                            </p>
+                        </div>
+
+                        <div th:if="${rejected}"
+                             class="mt-6 rounded-2xl border border-rose-100 bg-rose-50 px-5 py-4">
+                            <p class="text-sm font-bold text-rose-700">매칭 요청이 종료되었습니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-rose-600">
+                                거절된 요청입니다. 다른 추천 후보를 검토하거나 제안서 상태를 다시 확인해보세요.
+                            </p>
+                        </div>
+
+                        <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                           class="mt-4 inline-flex items-center gap-2 text-sm font-bold text-slate-500 transition hover:text-slate-700">
+                            <i data-lucide="arrow-right" class="h-4 w-4"></i>
+                            제안서 상세로 이동
+                        </a>
+                    </section>
+
                     <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60">
                         <div class="flex items-start justify-between gap-3">
                             <div>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -7,42 +7,345 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
-        <div class="mx-auto max-w-5xl space-y-6">
-            <section class="rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-sm shadow-slate-200/60">
-                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING DETAIL</p>
-                <h1 class="mt-2 text-2xl font-black tracking-tight text-slate-950"
-                    th:text="${view.header.proposalTitle}">제안서 제목</h1>
-                <p class="mt-1 text-sm text-slate-500"
-                   th:text="${view.header.positionTitle} + ' · ' + ${view.header.statusLabel}">포지션 제목 · 상태</p>
-            </section>
+    <main class="min-h-screen bg-slate-50"
+          th:with="statusName=${view.status.name()},
+                   proposed=${statusName == 'PROPOSED'},
+                   accepted=${statusName == 'ACCEPTED'},
+                   rejected=${statusName == 'REJECTED'}">
 
-            <section class="rounded-[28px] border border-dashed border-slate-200 bg-white px-6 py-6 shadow-sm shadow-slate-200/40">
-                <h2 class="text-base font-bold text-slate-900">매칭 결과 페이지 준비 중</h2>
-                <p class="mt-2 text-sm leading-relaxed text-slate-500">
-                    1차 작업 단위에서는 조회 백엔드와 모델 바인딩을 먼저 연결했습니다.
-                    다음 작업 단위에서 실제 카드/스텝퍼/타임라인 UI를 이 구조 위에 얹을 예정입니다.
-                </p>
+        <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
+            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4">
 
-                <dl class="mt-6 grid gap-4 md:grid-cols-2">
-                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
-                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">매칭 ID</dt>
-                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.matchingId}">1</dd>
+                <div class="flex items-center gap-4">
+                    <a th:href="${view.viewerRole == 'CLIENT'} ? @{/client/dashboard} : @{/freelancers/dashboard}"
+                       onclick="if (window.history.length > 1) { history.back(); return false; }"
+                       class="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
+                        <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                    </a>
+
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING DETAIL</p>
+                        <div class="mt-1 flex flex-wrap items-center gap-2">
+                            <h1 class="text-xl font-black tracking-tight text-slate-950 sm:text-2xl"
+                                th:text="${view.header.proposalTitle}">핀테크 앱 고도화 프로젝트</h1>
+                            <span th:classappend="${proposed} ? 'border-blue-200 bg-blue-50 text-blue-700' :
+                                                  (${accepted} ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
+                                                                 'border-rose-200 bg-rose-50 text-rose-700')"
+                                  class="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-bold">
+                                <span th:text="${view.header.statusLabel}">매칭 요청</span>
+                            </span>
+                        </div>
+                        <p class="mt-1 text-sm text-slate-500"
+                           th:text="|${view.header.positionTitle} · ${view.header.counterpartDisplayName}|">
+                            프론트엔드 개발자 · 김*수 프리랜서
+                        </p>
                     </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
-                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">뷰어 역할</dt>
-                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.viewerRole}">CLIENT</dd>
-                    </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
-                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">현재 상태</dt>
-                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.status.description}">수락됨</dd>
-                    </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-3">
-                        <dt class="text-xs font-semibold uppercase tracking-widest text-slate-400">연락처 공개 여부</dt>
-                        <dd class="mt-1 text-sm font-bold text-slate-900" th:text="${view.contactVisible ? '공개됨' : '비공개'}">공개됨</dd>
-                    </div>
-                </dl>
-            </section>
+                </div>
+
+                <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                   class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                    <i data-lucide="file-text" class="h-4 w-4"></i>
+                    제안서 보기
+                </a>
+            </div>
+        </div>
+
+        <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+            <div class="grid gap-6 xl:grid-cols-[minmax(0,1.8fr)_minmax(320px,0.95fr)]">
+
+                <section class="space-y-6">
+
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60 lg:p-8">
+                        <div class="flex items-center justify-between gap-4">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING FLOW</p>
+                                <h2 class="mt-2 text-lg font-bold tracking-tight text-slate-900">매칭 프로세스 현황</h2>
+                            </div>
+                            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500"
+                                  th:text="|Matching #${view.matchingId}|">Matching #1</span>
+                        </div>
+
+                        <div class="mt-8 grid gap-4 md:grid-cols-4">
+                            <div class="relative">
+                                <div th:classappend="${proposed or accepted or rejected} ? 'bg-blue-600 text-white ring-4 ring-blue-100' : 'bg-white text-slate-300 border border-slate-200'"
+                                     class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+                                    <i data-lucide="send" class="h-5 w-5"></i>
+                                </div>
+                                <div th:classappend="${accepted} ? 'bg-emerald-400' : (${rejected} ? 'bg-rose-300' : 'bg-blue-400')"
+                                     class="absolute left-1/2 top-6 hidden h-0.5 w-full md:block"></div>
+                                <div class="mt-4 text-center">
+                                    <p class="text-sm font-bold text-slate-800">매칭 요청</p>
+                                    <p class="mt-1 text-xs text-slate-400"
+                                       th:text="${#temporals.format(view.summary.requestedAt, 'MM.dd HH:mm')}">04.22 14:30</p>
+                                </div>
+                            </div>
+
+                            <div class="relative">
+                                <div th:classappend="${accepted} ? 'bg-emerald-500 text-white ring-4 ring-emerald-100' :
+                                                      (${rejected} ? 'bg-rose-500 text-white ring-4 ring-rose-100' : 'bg-white text-slate-300 border border-slate-200')"
+                                     class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+                                    <i th:if="${accepted}" data-lucide="check" class="h-5 w-5"></i>
+                                    <i th:if="${rejected}" data-lucide="x" class="h-5 w-5"></i>
+                                    <i th:if="${proposed}" data-lucide="clock-3" class="h-5 w-5"></i>
+                                </div>
+                                <div class="absolute left-1/2 top-6 hidden h-0.5 w-full bg-slate-200 md:block"></div>
+                                <div class="mt-4 text-center">
+                                    <p class="text-sm font-bold text-slate-800"
+                                       th:text="${rejected ? '요청 거절' : '매칭 수락'}">매칭 수락</p>
+                                    <p class="mt-1 text-xs text-slate-400"
+                                       th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'MM.dd HH:mm') : '응답 대기 중'}">
+                                        응답 대기 중
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="relative">
+                                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-300">
+                                    <i data-lucide="handshake" class="h-5 w-5"></i>
+                                </div>
+                                <div class="absolute left-1/2 top-6 hidden h-0.5 w-full bg-slate-200 md:block"></div>
+                                <div class="mt-4 text-center">
+                                    <p class="text-sm font-bold text-slate-400">계약 진행</p>
+                                    <p class="mt-1 text-xs text-slate-400">다음 이슈 예정</p>
+                                </div>
+                            </div>
+
+                            <div>
+                                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-300">
+                                    <i data-lucide="flag" class="h-5 w-5"></i>
+                                </div>
+                                <div class="mt-4 text-center">
+                                    <p class="text-sm font-bold text-slate-400">프로젝트 완료</p>
+                                    <p class="mt-1 text-xs text-slate-400">다음 이슈 예정</p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section th:classappend="${proposed} ? 'border-blue-200 bg-blue-50/60' :
+                                              (${accepted} ? 'border-emerald-200 bg-emerald-50/60' :
+                                                             'border-rose-200 bg-rose-50/60')"
+                             class="rounded-[32px] border p-6 shadow-sm shadow-slate-200/60 lg:p-8">
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <div class="flex items-center gap-2">
+                                    <i th:if="${proposed}" data-lucide="send" class="h-5 w-5 text-blue-500"></i>
+                                    <i th:if="${accepted}" data-lucide="circle-check-big" class="h-5 w-5 text-emerald-500"></i>
+                                    <i th:if="${rejected}" data-lucide="circle-x" class="h-5 w-5 text-rose-500"></i>
+                                    <h3 class="text-xl font-bold tracking-tight text-slate-900"
+                                        th:text="${view.summary.headline}">프리랜서 응답을 기다리는 중입니다.</h3>
+                                </div>
+                                <p class="mt-3 text-sm leading-relaxed text-slate-600"
+                                   th:text="${view.summary.helperMessage}">
+                                    프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.
+                                </p>
+                            </div>
+
+                            <span th:classappend="${view.contactVisible} ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-white text-slate-500'"
+                                  class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-bold">
+                                <i data-lucide="phone" class="h-3.5 w-3.5"></i>
+                                <span th:text="${view.contactVisible ? '연락처 공개됨' : '연락처 비공개'}">연락처 공개됨</span>
+                            </span>
+                        </div>
+
+                        <div class="mt-6 grid gap-4 md:grid-cols-3">
+                            <div class="rounded-2xl border border-white/80 bg-white/90 px-5 py-4">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">요청 일시</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${#temporals.format(view.summary.requestedAt, 'yyyy.MM.dd HH:mm')}">
+                                    2026.04.22 14:30
+                                </p>
+                            </div>
+
+                            <div class="rounded-2xl border border-white/80 bg-white/90 px-5 py-4">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">응답 일시</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'yyyy.MM.dd HH:mm') : '응답 대기 중'}">
+                                    응답 대기 중
+                                </p>
+                            </div>
+
+                            <div class="rounded-2xl border border-white/80 bg-white/90 px-5 py-4">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">현재 상태</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${view.header.statusLabel}">매칭 요청</p>
+                            </div>
+                        </div>
+
+                        <div class="mt-6 rounded-2xl border border-white/80 bg-white/90 px-5 py-4">
+                            <div class="flex items-start gap-3">
+                                <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-slate-400"></i>
+                                <p class="text-sm leading-relaxed text-slate-600"
+                                   th:text="${view.summary.contactGuideMessage}">
+                                    매칭이 수락되기 전까지는 연락처가 공개되지 않습니다.
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60 lg:p-8">
+                        <div class="flex items-center justify-between gap-4">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">TIMELINE</p>
+                                <h3 class="mt-2 text-xl font-bold tracking-tight text-slate-900">진행 이력</h3>
+                            </div>
+                            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500"
+                                  th:text="|${#lists.size(view.timeline)} events|">2 events</span>
+                        </div>
+
+                        <div class="mt-8 space-y-5">
+                            <article th:each="item, itemStat : ${view.timeline}" class="relative pl-8">
+                                <div class="absolute left-2 top-2 h-full w-px bg-slate-200"
+                                     th:if="${!itemStat.last}"></div>
+                                <div th:classappend="${itemStat.index == 0} ? 'bg-blue-500 ring-blue-100' :
+                                                      (${accepted} ? 'bg-emerald-500 ring-emerald-100' :
+                                                                     (${rejected} ? 'bg-rose-500 ring-rose-100' : 'bg-slate-300 ring-slate-100'))"
+                                     class="absolute left-0 top-1.5 h-4 w-4 rounded-full ring-4"></div>
+
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <p class="text-sm font-bold text-slate-900"
+                                           th:text="|${item.actorLabel} · ${item.actionLabel}|">
+                                            클라이언트 · 매칭 요청 전송
+                                        </p>
+                                        <span class="text-xs text-slate-400"
+                                              th:text="${#temporals.format(item.occurredAt, 'yyyy.MM.dd HH:mm')}">
+                                            2026.04.22 14:30
+                                        </span>
+                                    </div>
+                                    <p class="mt-2 text-sm leading-relaxed text-slate-600"
+                                       th:text="${item.description}">
+                                        프리랜서에게 매칭 요청을 보냈습니다.
+                                    </p>
+                                </div>
+                            </article>
+                        </div>
+                    </section>
+                </section>
+
+                <aside class="space-y-6">
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">CONTACT</p>
+                                <h3 class="mt-2 text-lg font-bold tracking-tight text-slate-900">연락처 정보</h3>
+                            </div>
+                            <span th:classappend="${view.contactVisible} ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'"
+                                  class="rounded-full px-3 py-1 text-[11px] font-bold">
+                                <span th:text="${view.contactVisible ? '공개됨' : '비공개'}">공개됨</span>
+                            </span>
+                        </div>
+
+                        <div th:if="${view.contactVisible}" class="mt-6 space-y-4">
+                            <div class="rounded-2xl border border-blue-100 bg-blue-50/70 px-5 py-4">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400"
+                                   th:text="${view.contacts.client.roleLabel}">클라이언트</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${view.contacts.client.displayName}">김클라이언트</p>
+                                <div class="mt-4 space-y-2 text-sm text-slate-600">
+                                    <p th:text="${view.contacts.client.email}">client@example.com</p>
+                                    <p th:text="${view.contacts.client.phone}">010-1234-5678</p>
+                                </div>
+                            </div>
+
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400"
+                                   th:text="${view.contacts.freelancer.roleLabel}">프리랜서</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${view.contacts.freelancer.displayName}">김프리랜서</p>
+                                <div class="mt-4 space-y-2 text-sm text-slate-600">
+                                    <p th:text="${view.contacts.freelancer.email}">freelancer@example.com</p>
+                                    <p th:text="${view.contacts.freelancer.phone}">010-9876-5432</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div th:unless="${view.contactVisible}"
+                             class="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-5 py-8 text-center">
+                            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-slate-300 shadow-sm shadow-slate-200/50">
+                                <i data-lucide="phone-off" class="h-5 w-5"></i>
+                            </div>
+                            <p class="mt-4 text-sm font-bold text-slate-700">연락처가 아직 공개되지 않았습니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-slate-500">
+                                프리랜서가 요청을 수락하면 양측 연락처를 이 영역에서 바로 확인할 수 있습니다.
+                            </p>
+                        </div>
+                    </section>
+
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60">
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">PROJECT</p>
+                                <h3 class="mt-2 text-lg font-bold tracking-tight text-slate-900">프로젝트 요약</h3>
+                            </div>
+                            <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                               class="inline-flex items-center gap-1.5 text-sm font-bold text-slate-500 transition hover:text-slate-700">
+                                <i data-lucide="eye" class="h-4 w-4"></i>
+                                제안서 보기
+                            </a>
+                        </div>
+
+                        <div class="mt-6 space-y-5">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">제목</p>
+                                <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
+                                   th:text="${view.project.proposalTitle}">온라인 쇼핑몰 모바일 앱 개발</p>
+                            </div>
+
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">설명</p>
+                                <p class="mt-2 text-sm leading-relaxed text-slate-600"
+                                   th:text="${#strings.isEmpty(view.project.description) ? '제안서 설명이 없습니다.' : view.project.description}">
+                                    프로젝트 설명입니다.
+                                </p>
+                            </div>
+
+                            <div class="grid gap-4 sm:grid-cols-2">
+                                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">포지션</p>
+                                    <p class="mt-2 text-sm font-bold text-slate-900"
+                                       th:text="${view.project.positionTitle}">프론트엔드 개발자</p>
+                                    <p class="mt-1 text-xs text-slate-500"
+                                       th:text="${view.project.positionCategory}">Frontend Developer</p>
+                                </div>
+                                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
+                                    <p class="mt-2 text-sm font-bold text-slate-900"
+                                       th:text="${view.project.workTypeLabel}">원격</p>
+                                </div>
+                                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
+                                    <p class="mt-2 text-sm font-bold text-slate-900"
+                                       th:text="${view.project.budgetText}">3,000,000원 ~ 4,000,000원</p>
+                                </div>
+                                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예상 기간</p>
+                                    <p class="mt-2 text-sm font-bold text-slate-900"
+                                       th:text="${view.project.expectedPeriodText}">8주</p>
+                                </div>
+                            </div>
+
+                            <div th:if="${!#lists.isEmpty(view.project.essentialSkills)}">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
+                                <div class="mt-3 flex flex-wrap gap-2">
+                                    <span th:each="skill : ${view.project.essentialSkills}"
+                                          class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600"
+                                          th:text="${skill}">React</span>
+                                </div>
+                            </div>
+
+                            <div th:if="${!#lists.isEmpty(view.project.preferredSkills)}">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
+                                <div class="mt-3 flex flex-wrap gap-2">
+                                    <span th:each="skill : ${view.project.preferredSkills}"
+                                          class="rounded-xl border border-blue-100 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700"
+                                          th:text="${skill}">Tailwind</span>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </aside>
+            </div>
         </div>
     </main>
 </div>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -3,7 +3,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-    <title th:text="${view.header.proposalTitle} + ' | 매칭 결과'">매칭 결과 | IT-da</title>
+    <title th:text="${view.header.proposalTitle + ' | 매칭 결과'}">매칭 결과 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
@@ -11,13 +11,16 @@
           th:with="statusName=${view.status.name()},
                    proposed=${statusName == 'PROPOSED'},
                    accepted=${statusName == 'ACCEPTED'},
-                   rejected=${statusName == 'REJECTED'}">
+                   rejected=${statusName == 'REJECTED'},
+                   inProgress=${statusName == 'IN_PROGRESS'},
+                   completed=${statusName == 'COMPLETED'},
+                   canceled=${statusName == 'CANCELED'}">
 
         <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
             <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4">
 
                 <div class="flex items-center gap-4">
-                    <a th:href="${view.viewerRole == 'CLIENT'} ? @{/client/dashboard} : @{/freelancers/dashboard}"
+                    <a th:href="${view.viewerRole == 'CLIENT' ? '/client/dashboard' : '/freelancers/dashboard'}"
                        onclick="if (window.history.length > 1) { history.back(); return false; }"
                        class="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
                         <i data-lucide="arrow-left" class="h-4 w-4"></i>
@@ -30,13 +33,16 @@
                                 th:text="${view.header.proposalTitle}">핀테크 앱 고도화 프로젝트</h1>
                             <span th:classappend="${proposed} ? 'border-blue-200 bg-blue-50 text-blue-700' :
                                                   (${accepted} ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
-                                                                 'border-rose-200 bg-rose-50 text-rose-700')"
+                                                  (${rejected} ? 'border-rose-200 bg-rose-50 text-rose-700' :
+                                                  (${inProgress} ? 'border-indigo-200 bg-indigo-50 text-indigo-700' :
+                                                  (${completed} ? 'border-slate-300 bg-slate-100 text-slate-700' :
+                                                                  'border-amber-200 bg-amber-50 text-amber-700'))))"
                                   class="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-bold">
                                 <span th:text="${view.header.statusLabel}">매칭 요청</span>
                             </span>
                         </div>
                         <p class="mt-1 text-sm text-slate-500"
-                           th:text="|${view.header.positionTitle} · ${view.header.counterpartDisplayName}|">
+                           th:text="${view.header.positionTitle + ' · ' + view.header.counterpartDisplayName}">
                             프론트엔드 개발자 · 김*수 프리랜서
                         </p>
                     </div>
@@ -71,16 +77,17 @@
                                 <h2 class="mt-2 text-lg font-bold tracking-tight text-slate-900">매칭 프로세스 현황</h2>
                             </div>
                             <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500"
-                                  th:text="|Matching #${view.matchingId}|">Matching #1</span>
+                                  th:text="${'Matching #' + view.matchingId}">Matching #1</span>
                         </div>
 
                         <div class="mt-8 grid gap-4 md:grid-cols-4">
                             <div class="relative">
-                                <div th:classappend="${proposed or accepted or rejected} ? 'bg-blue-600 text-white ring-4 ring-blue-100' : 'bg-white text-slate-300 border border-slate-200'"
-                                     class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+                                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white ring-4 ring-blue-100">
                                     <i data-lucide="send" class="h-5 w-5"></i>
                                 </div>
-                                <div th:classappend="${accepted} ? 'bg-emerald-400' : (${rejected} ? 'bg-rose-300' : 'bg-blue-400')"
+                                <div th:classappend="${rejected} ? 'bg-rose-300' :
+                                                     (${canceled} ? 'bg-amber-300' :
+                                                     (${proposed} ? 'bg-blue-400' : 'bg-emerald-400'))"
                                      class="absolute left-1/2 top-6 hidden h-0.5 w-full md:block"></div>
                                 <div class="mt-4 text-center">
                                     <p class="text-sm font-bold text-slate-800">매칭 요청</p>
@@ -90,42 +97,53 @@
                             </div>
 
                             <div class="relative">
-                                <div th:classappend="${accepted} ? 'bg-emerald-500 text-white ring-4 ring-emerald-100' :
-                                                      (${rejected} ? 'bg-rose-500 text-white ring-4 ring-rose-100' : 'bg-white text-slate-300 border border-slate-200')"
+                                <div th:classappend="${accepted or inProgress or completed} ? 'bg-emerald-500 text-white ring-4 ring-emerald-100' :
+                                                      (${rejected} ? 'bg-rose-500 text-white ring-4 ring-rose-100' :
+                                                      (${canceled} ? 'bg-amber-500 text-white ring-4 ring-amber-100' : 'bg-white text-slate-300 border border-slate-200'))"
                                      class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
-                                    <i th:if="${accepted}" data-lucide="check" class="h-5 w-5"></i>
+                                    <i th:if="${accepted or inProgress or completed}" data-lucide="check" class="h-5 w-5"></i>
                                     <i th:if="${rejected}" data-lucide="x" class="h-5 w-5"></i>
+                                    <i th:if="${canceled}" data-lucide="ban" class="h-5 w-5"></i>
                                     <i th:if="${proposed}" data-lucide="clock-3" class="h-5 w-5"></i>
                                 </div>
-                                <div class="absolute left-1/2 top-6 hidden h-0.5 w-full bg-slate-200 md:block"></div>
+                                <div th:classappend="${inProgress or completed} ? 'bg-indigo-300' : 'bg-slate-200'"
+                                     class="absolute left-1/2 top-6 hidden h-0.5 w-full md:block"></div>
                                 <div class="mt-4 text-center">
-                                    <p class="text-sm font-bold text-slate-800"
-                                       th:text="${rejected ? '요청 거절' : '매칭 수락'}">매칭 수락</p>
+                                    <p class="text-sm font-bold"
+                                       th:classappend="${proposed} ? 'text-slate-400' : 'text-slate-800'"
+                                       th:text="${rejected ? '요청 거절' : (canceled ? '매칭 취소' : '매칭 수락')}">매칭 수락</p>
                                     <p class="mt-1 text-xs text-slate-400"
-                                       th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'MM.dd HH:mm') : '응답 대기 중'}">
+                                       th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'MM.dd HH:mm') : (proposed ? '응답 대기 중' : '일시 미기록')}">
                                         응답 대기 중
                                     </p>
                                 </div>
                             </div>
 
                             <div class="relative">
-                                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-300">
+                                <div th:classappend="${inProgress or completed} ? 'bg-indigo-500 text-white ring-4 ring-indigo-100' : 'bg-white text-slate-300 border border-slate-200'"
+                                     class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
                                     <i data-lucide="handshake" class="h-5 w-5"></i>
                                 </div>
-                                <div class="absolute left-1/2 top-6 hidden h-0.5 w-full bg-slate-200 md:block"></div>
+                                <div th:classappend="${completed} ? 'bg-slate-400' : 'bg-slate-200'"
+                                     class="absolute left-1/2 top-6 hidden h-0.5 w-full md:block"></div>
                                 <div class="mt-4 text-center">
-                                    <p class="text-sm font-bold text-slate-400">계약 진행</p>
-                                    <p class="mt-1 text-xs text-slate-400">다음 이슈 예정</p>
+                                    <p class="text-sm font-bold"
+                                       th:classappend="${inProgress or completed} ? 'text-slate-800' : 'text-slate-400'">계약 진행</p>
+                                    <p class="mt-1 text-xs text-slate-400"
+                                       th:text="${inProgress ? '진행 중' : (completed ? '진행 완료' : '다음 이슈 예정')}">다음 이슈 예정</p>
                                 </div>
                             </div>
 
                             <div>
-                                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-300">
+                                <div th:classappend="${completed} ? 'bg-slate-700 text-white ring-4 ring-slate-200' : 'bg-white text-slate-300 border border-slate-200'"
+                                     class="mx-auto flex h-12 w-12 items-center justify-center rounded-full">
                                     <i data-lucide="flag" class="h-5 w-5"></i>
                                 </div>
                                 <div class="mt-4 text-center">
-                                    <p class="text-sm font-bold text-slate-400">프로젝트 완료</p>
-                                    <p class="mt-1 text-xs text-slate-400">다음 이슈 예정</p>
+                                    <p class="text-sm font-bold"
+                                       th:classappend="${completed} ? 'text-slate-800' : 'text-slate-400'">프로젝트 완료</p>
+                                    <p class="mt-1 text-xs text-slate-400"
+                                       th:text="${completed ? '완료됨' : '다음 이슈 예정'}">다음 이슈 예정</p>
                                 </div>
                             </div>
                         </div>
@@ -133,7 +151,10 @@
 
                     <section th:classappend="${proposed} ? 'border-blue-200 bg-blue-50/60' :
                                               (${accepted} ? 'border-emerald-200 bg-emerald-50/60' :
-                                                             'border-rose-200 bg-rose-50/60')"
+                                              (${rejected} ? 'border-rose-200 bg-rose-50/60' :
+                                              (${inProgress} ? 'border-indigo-200 bg-indigo-50/60' :
+                                              (${completed} ? 'border-slate-300 bg-slate-100/70' :
+                                                              'border-amber-200 bg-amber-50/60'))))"
                              class="rounded-[32px] border p-6 shadow-sm shadow-slate-200/60 lg:p-8">
                         <div class="flex flex-wrap items-start justify-between gap-4">
                             <div>
@@ -141,6 +162,9 @@
                                     <i th:if="${proposed}" data-lucide="send" class="h-5 w-5 text-blue-500"></i>
                                     <i th:if="${accepted}" data-lucide="circle-check-big" class="h-5 w-5 text-emerald-500"></i>
                                     <i th:if="${rejected}" data-lucide="circle-x" class="h-5 w-5 text-rose-500"></i>
+                                    <i th:if="${inProgress}" data-lucide="handshake" class="h-5 w-5 text-indigo-500"></i>
+                                    <i th:if="${completed}" data-lucide="flag" class="h-5 w-5 text-slate-600"></i>
+                                    <i th:if="${canceled}" data-lucide="ban" class="h-5 w-5 text-amber-500"></i>
                                     <h3 class="text-xl font-bold tracking-tight text-slate-900"
                                         th:text="${view.summary.headline}">프리랜서 응답을 기다리는 중입니다.</h3>
                                 </div>
@@ -169,7 +193,7 @@
                             <div class="rounded-2xl border border-white/80 bg-white/90 px-5 py-4">
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">응답 일시</p>
                                 <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
-                                   th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'yyyy.MM.dd HH:mm') : '응답 대기 중'}">
+                                   th:text="${view.summary.respondedAt != null ? #temporals.format(view.summary.respondedAt, 'yyyy.MM.dd HH:mm') : (proposed ? '응답 대기 중' : '일시 미기록')}">
                                     응답 대기 중
                                 </p>
                             </div>
@@ -199,7 +223,7 @@
                                 <h3 class="mt-2 text-xl font-bold tracking-tight text-slate-900">진행 이력</h3>
                             </div>
                             <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500"
-                                  th:text="|${#lists.size(view.timeline)} events|">2 events</span>
+                                  th:text="${#lists.size(view.timeline) + ' events'}">2 events</span>
                         </div>
 
                         <div class="mt-8 space-y-5">
@@ -207,18 +231,21 @@
                                 <div class="absolute left-2 top-2 h-full w-px bg-slate-200"
                                      th:if="${!itemStat.last}"></div>
                                 <div th:classappend="${itemStat.index == 0} ? 'bg-blue-500 ring-blue-100' :
-                                                      (${accepted} ? 'bg-emerald-500 ring-emerald-100' :
-                                                                     (${rejected} ? 'bg-rose-500 ring-rose-100' : 'bg-slate-300 ring-slate-100'))"
+                                                      (${rejected} ? 'bg-rose-500 ring-rose-100' :
+                                                      (${canceled} ? 'bg-amber-500 ring-amber-100' :
+                                                      (${inProgress} ? 'bg-indigo-500 ring-indigo-100' :
+                                                      (${completed} ? 'bg-slate-600 ring-slate-200' :
+                                                                      'bg-emerald-500 ring-emerald-100'))))"
                                      class="absolute left-0 top-1.5 h-4 w-4 rounded-full ring-4"></div>
 
                                 <div class="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
                                     <div class="flex flex-wrap items-center gap-2">
                                         <p class="text-sm font-bold text-slate-900"
-                                           th:text="|${item.actorLabel} · ${item.actionLabel}|">
+                                           th:text="${item.actorLabel + ' · ' + item.actionLabel}">
                                             클라이언트 · 매칭 요청 전송
                                         </p>
                                         <span class="text-xs text-slate-400"
-                                              th:text="${#temporals.format(item.occurredAt, 'yyyy.MM.dd HH:mm')}">
+                                              th:text="${item.occurredAt != null ? #temporals.format(item.occurredAt, 'yyyy.MM.dd HH:mm') : '일시 미기록'}">
                                             2026.04.22 14:30
                                         </span>
                                     </div>
@@ -280,6 +307,30 @@
                             <p class="text-sm font-bold text-emerald-700">매칭이 수락되었습니다</p>
                             <p class="mt-2 text-sm leading-relaxed text-emerald-600">
                                 연락처가 공개된 상태입니다. 제안서 내용을 다시 확인하고 협의를 이어가세요.
+                            </p>
+                        </div>
+
+                        <div th:if="${inProgress}"
+                             class="mt-6 rounded-2xl border border-indigo-100 bg-indigo-50 px-5 py-4">
+                            <p class="text-sm font-bold text-indigo-700">프로젝트가 진행 중입니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-indigo-600">
+                                연락처와 제안서 정보를 확인하며 협업을 이어가세요. 진행 상태 변경 액션은 후속 이슈에서 제공됩니다.
+                            </p>
+                        </div>
+
+                        <div th:if="${completed}"
+                             class="mt-6 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4">
+                            <p class="text-sm font-bold text-slate-700">프로젝트가 완료되었습니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-slate-600">
+                                완료된 매칭입니다. 프로젝트 정보와 진행 이력을 확인할 수 있습니다.
+                            </p>
+                        </div>
+
+                        <div th:if="${canceled}"
+                             class="mt-6 rounded-2xl border border-amber-100 bg-amber-50 px-5 py-4">
+                            <p class="text-sm font-bold text-amber-700">매칭이 취소되었습니다</p>
+                            <p class="mt-2 text-sm leading-relaxed text-amber-600">
+                                취소된 매칭입니다. 필요한 경우 다른 추천 후보를 검토하거나 제안서 상태를 확인해보세요.
                             </p>
                         </div>
 

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -164,10 +164,12 @@
 
                                 <!-- 매칭 없음: 요청 버튼 -->
                                 <th:block th:if="${candidate.matchingStatus == null}">
-                                    <form th:action="@{/recommendation-results/{id}/matchings(id=${candidate.resultId})}"
+                                    <form th:action="@{/recommendation-results/{recommendationResultId}/matchings(recommendationResultId=${candidate.resultId})}"
                                           method="post">
                                         <input type="hidden" name="_csrf" th:value="${_csrf.token}">
                                         <input type="hidden" name="redirectTo"
+                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                        <input type="hidden" name="errorRedirectTo"
                                                th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
                                         <button type="submit"
                                                 class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
@@ -189,7 +191,6 @@
                                      class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
                                     <i data-lucide="check-circle" class="h-4 w-4"></i>
                                     매칭 진행 중
-                                    <!-- TODO : 매칭 결과 페이지로 연결 하면 좋을듯 합니다-->
                                 </div>
 
                                 <!-- 거절됨 (REJECTED) -->

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -20,6 +20,7 @@ import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.MatchingQueryService;
 import com.generic4.itda.service.MatchingService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,9 @@ class MatchingControllerTest {
 
     @MockitoBean
     private MatchingService matchingService;
+
+    @MockitoBean
+    private MatchingQueryService matchingQueryService;
 
     @MockitoBean
     private MemberRepository memberRepository;

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -5,23 +5,35 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.generic4.itda.annotation.ControllerTest;
 import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.matching.MatchingDetailContactViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailHeaderViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailProjectSummaryViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailSummaryViewModel;
+import com.generic4.itda.dto.matching.MatchingDetailViewModel;
+import com.generic4.itda.dto.matching.MatchingParticipantContactViewModel;
+import com.generic4.itda.dto.matching.MatchingTimelineItemViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.MatchingQueryService;
 import com.generic4.itda.service.MatchingService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,6 +61,21 @@ class MatchingControllerTest {
     private MemberRepository memberRepository;
 
     @Test
+    @DisplayName("매칭 상세 페이지를 렌더링한다")
+    void renderMatchingDetailPage() throws Exception {
+        given(matchingQueryService.getDetail(401L, "client@example.com"))
+                .willReturn(createMatchingDetailView());
+
+        mockMvc.perform(get("/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/detail"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("매칭 프로세스 현황")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("연락처 정보")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("프로젝트 요약")));
+    }
+
+    @Test
     @DisplayName("클라이언트가 추천 결과로 매칭 요청을 보내면 지정한 화면으로 돌아간다")
     void requestMatchingAndRedirectToProvidedPath() throws Exception {
         Matching matching = createMatching();
@@ -70,6 +97,20 @@ class MatchingControllerTest {
     }
 
     @Test
+    @DisplayName("클라이언트가 추천 결과로 매칭 요청을 보내면 기본적으로 매칭 상세로 이동한다")
+    void requestMatchingAndRedirectToMatchingDetailByDefault() throws Exception {
+        Matching matching = createMatching();
+        given(matchingService.request(101L, "client@example.com")).willReturn(matching);
+
+        mockMvc.perform(post("/recommendation-results/101/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트")))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/matchings/401"))
+                .andExpect(flash().attribute("noticeMessage", "매칭 요청을 보냈습니다."));
+    }
+
+    @Test
     @DisplayName("매칭 요청 생성에 실패하면 안전한 경로로 리다이렉트하며 오류 메시지를 남긴다")
     void redirectWithErrorWhenRequestMatchingFails() throws Exception {
         given(matchingService.request(101L, "client@example.com"))
@@ -78,15 +119,15 @@ class MatchingControllerTest {
         mockMvc.perform(post("/recommendation-results/101/matchings")
                         .with(authentication(authToken("client@example.com", "클라이언트")))
                         .with(csrf())
-                        .param("redirectTo", "/proposals/200/recommendations/results?runId=501"))
+                        .param("errorRedirectTo", "/proposals/200/recommendations/results?runId=501"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/proposals/200/recommendations/results?runId=501"))
                 .andExpect(flash().attribute("errorMessage", "이미 요청했거나 진행 중인 후보입니다."));
     }
 
     @Test
-    @DisplayName("프리랜서가 수락하면 기본적으로 제안서 상세로 돌아간다")
-    void acceptMatchingAndRedirectToProposalDetail() throws Exception {
+    @DisplayName("프리랜서가 수락하면 기본적으로 매칭 상세로 이동한다")
+    void acceptMatchingAndRedirectToMatchingDetail() throws Exception {
         Matching matching = createMatching();
         given(matchingService.accept(401L, "freelancer@example.com")).willReturn(matching);
 
@@ -94,7 +135,7 @@ class MatchingControllerTest {
                         .with(authentication(authToken("freelancer@example.com", "프리랜서")))
                         .with(csrf()))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/proposals/200"))
+                .andExpect(redirectedUrl("/matchings/401"))
                 .andExpect(flash().attribute("noticeMessage", "매칭 요청을 수락했습니다."));
 
         then(matchingService).should().accept(401L, "freelancer@example.com");
@@ -126,7 +167,7 @@ class MatchingControllerTest {
         mockMvc.perform(post("/matchings/999/accept")
                         .with(authentication(authToken("freelancer@example.com", "프리랜서")))
                         .with(csrf())
-                        .param("redirectTo", "https://example.com/outside"))
+                        .param("errorRedirectTo", "https://example.com/outside"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/freelancers/dashboard"))
                 .andExpect(flash().attribute("errorMessage", "응답할 매칭 요청을 찾을 수 없습니다."));
@@ -205,5 +246,47 @@ class MatchingControllerTest {
         Matching matching = Matching.create(null, proposalPosition, client, freelancer);
         ReflectionTestUtils.setField(matching, "id", 401L);
         return matching;
+    }
+
+    private MatchingDetailViewModel createMatchingDetailView() {
+        return new MatchingDetailViewModel(
+                401L,
+                "CLIENT",
+                MatchingStatus.PROPOSED,
+                false,
+                new MatchingDetailHeaderViewModel("AI 매칭 플랫폼", "플랫폼 백엔드 개발자", "김프리랜서", "매칭 요청"),
+                new MatchingDetailSummaryViewModel(
+                        "프리랜서 응답을 기다리는 중입니다.",
+                        "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.",
+                        LocalDateTime.of(2026, 4, 22, 13, 0),
+                        null,
+                        "매칭이 수락되기 전까지는 연락처가 공개되지 않습니다."
+                ),
+                new MatchingDetailContactViewModel(
+                        false,
+                        new MatchingParticipantContactViewModel("클라이언트", "클라이언트", "client@example.com", "010-1111-2222"),
+                        new MatchingParticipantContactViewModel("프리랜서", "김프리랜서", "freelancer@example.com", "010-3333-4444")
+                ),
+                new MatchingDetailProjectSummaryViewModel(
+                        200L,
+                        "AI 매칭 플랫폼",
+                        "설명",
+                        "플랫폼 백엔드 개발자",
+                        "백엔드 개발자",
+                        "3,000,000원 ~ 5,000,000원",
+                        "4주",
+                        "원격",
+                        List.of("Java", "Spring"),
+                        List.of("Docker")
+                ),
+                List.of(
+                        new MatchingTimelineItemViewModel(
+                                LocalDateTime.of(2026, 4, 22, 13, 0),
+                                "클라이언트",
+                                "매칭 요청 전송",
+                                "프리랜서에게 매칭 요청을 보냈습니다."
+                        )
+                )
+        );
     }
 }

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -76,6 +76,32 @@ class MatchingControllerTest {
     }
 
     @Test
+    @DisplayName("없는 매칭 상세를 조회하면 홈으로 이동하며 오류 메시지를 남긴다")
+    void redirectHomeWhenMatchingDetailNotFound() throws Exception {
+        given(matchingQueryService.getDetail(999L, "client@example.com"))
+                .willThrow(new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=999"));
+
+        mockMvc.perform(get("/matchings/999")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 매칭입니다."));
+    }
+
+    @Test
+    @DisplayName("권한 없는 매칭 상세를 조회하면 홈으로 이동하며 오류 메시지를 남긴다")
+    void redirectHomeWhenMatchingDetailAccessDenied() throws Exception {
+        given(matchingQueryService.getDetail(401L, "client@example.com"))
+                .willThrow(new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다."));
+
+        mockMvc.perform(get("/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(flash().attribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다."));
+    }
+
+    @Test
     @DisplayName("클라이언트가 추천 결과로 매칭 요청을 보내면 지정한 화면으로 돌아간다")
     void requestMatchingAndRedirectToProvidedPath() throws Exception {
         Matching matching = createMatching();
@@ -205,6 +231,14 @@ class MatchingControllerTest {
     @DisplayName("인증되지 않은 사용자는 매칭 응답 시 로그인 페이지로 이동한다")
     void redirectToLoginWhenUnauthenticated() throws Exception {
         mockMvc.perform(post("/matchings/401/accept").with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 매칭 상세 조회 시 로그인 페이지로 이동한다")
+    void redirectToLoginWhenUnauthenticatedOnDetail() throws Exception {
+        mockMvc.perform(get("/matchings/401"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }

--- a/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/MatchingServiceTest.java
@@ -82,6 +82,9 @@ class MatchingServiceTest {
 
         assertThat(saved.getId()).isEqualTo(401L);
         assertThat(saved.getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+        assertThat(saved.getRequestedAt()).isNotNull();
+        assertThat(saved.getAcceptedAt()).isNull();
+        assertThat(saved.getRejectedAt()).isNull();
         assertThat(saved.getProposalPosition().getId()).isEqualTo(201L);
         assertThat(saved.getResume().getId()).isEqualTo(301L);
         assertThat(saved.getClientMember().getEmail().getValue()).isEqualTo(CLIENT_EMAIL);
@@ -90,6 +93,7 @@ class MatchingServiceTest {
         ArgumentCaptor<Matching> captor = ArgumentCaptor.forClass(Matching.class);
         verify(matchingRepository).save(captor.capture());
         assertThat(captor.getValue().getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+        assertThat(captor.getValue().getRequestedAt()).isNotNull();
     }
 
     @Test
@@ -195,6 +199,8 @@ class MatchingServiceTest {
         Matching accepted = matchingService.accept(401L, "freelancer@example.com");
 
         assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getAcceptedAt()).isNotNull();
+        assertThat(accepted.getRejectedAt()).isNull();
         assertThat(accepted.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.FULL);
     }
 
@@ -216,6 +222,8 @@ class MatchingServiceTest {
         Matching accepted = matchingService.accept(401L, "freelancer@example.com");
 
         assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getAcceptedAt()).isNotNull();
+        assertThat(accepted.getRejectedAt()).isNull();
         assertThat(accepted.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
     }
 
@@ -239,6 +247,8 @@ class MatchingServiceTest {
                 .hasMessage("정원이 이미 찬 모집 포지션입니다.");
 
         assertThat(matching.getStatus()).isEqualTo(MatchingStatus.PROPOSED);
+        assertThat(matching.getAcceptedAt()).isNull();
+        assertThat(matching.getRejectedAt()).isNull();
     }
 
     @Test
@@ -255,6 +265,9 @@ class MatchingServiceTest {
         assertThatThrownBy(() -> matchingService.accept(401L, "freelancer@example.com"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("정원이 이미 찬 모집 포지션입니다.");
+
+        assertThat(matching.getAcceptedAt()).isNull();
+        assertThat(matching.getRejectedAt()).isNull();
     }
 
     @Test
@@ -271,6 +284,9 @@ class MatchingServiceTest {
         assertThatThrownBy(() -> matchingService.accept(401L, "other@example.com"))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("본인에게 온 매칭 요청에만 응답할 수 있습니다.");
+
+        assertThat(matching.getAcceptedAt()).isNull();
+        assertThat(matching.getRejectedAt()).isNull();
     }
 
     @Test
@@ -287,6 +303,8 @@ class MatchingServiceTest {
         Matching rejected = matchingService.reject(401L, "freelancer@example.com");
 
         assertThat(rejected.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(rejected.getRejectedAt()).isNotNull();
+        assertThat(rejected.getAcceptedAt()).isNull();
         assertThat(rejected.getProposalPosition().getStatus()).isEqualTo(ProposalPositionStatus.OPEN);
     }
 
@@ -304,6 +322,9 @@ class MatchingServiceTest {
         assertThatThrownBy(() -> matchingService.reject(401L, "other@example.com"))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("본인에게 온 매칭 요청에만 응답할 수 있습니다.");
+
+        assertThat(matching.getAcceptedAt()).isNull();
+        assertThat(matching.getRejectedAt()).isNull();
     }
 
     private RecommendationResult createRecommendationResult(


### PR DESCRIPTION
## 🔎 What

- `GET /matchings/{matchingId}` 조회 컨트롤러 구현
- 매칭 결과 페이지용 조회 서비스 구현
- 매칭 결과 페이지 ViewModel 설계
- 클라이언트 / 프리랜서 공통 셸 + viewer context 기반 분기 처리
- `PROPOSED / ACCEPTED / REJECTED` 상태별 헤더/안내 문구/액션 분기 구현
- 매칭 진행 단계(stepper) UI 구현
- 현재 상태 요약 카드 구현
- 연락처 정보 섹션 구현
- `ACCEPTED` 상태 이상에서 연락처 즉시 노출 처리
- 프로젝트 / 포지션 요약 섹션 구현
- 진행 이력(요청 생성 / 수락 / 거절) 표시 구현
- `제안서 보기` 버튼을 기존 제안서 상세 페이지와 연결
- 뒤로가기 버튼 구현
- 매칭 당사자만 접근할 수 있도록 권한 검증
- 없는 매칭 / 권한 없음 / 잘못된 상태에 대한 사용자 친화적 오류 처리
- 매칭 상세 조회 서비스 테스트 작성
- 매칭 결과 페이지 컨트롤러 테스트 작성

## 🔗 Issue

- Closes: #108 

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?