### PR TITLE
[Bug] 프리랜서 대시보드 상세 진입 경로 및 응답 컨텍스트 수정

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -108,6 +108,7 @@ public class ProposalController {
     @GetMapping("/{proposalId}")
     public String detail(
             @PathVariable Long proposalId,
+            @RequestParam(name = "proposalPositionId", required = false) Long proposalPositionId,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model,
             RedirectAttributes redirectAttributes
@@ -145,11 +146,18 @@ public class ProposalController {
             List<ProposalPosition> proposedPositions = proposal.getPositions().stream()
                     .filter(pos -> matchingByPositionId.containsKey(pos.getId()))
                     .toList();
+            ProposalPosition selectedProposalPosition = resolveSelectedProposalPosition(
+                    proposedPositions,
+                    proposalPositionId
+            );
 
             model.addAttribute("proposal", proposal);
             model.addAttribute("viewerRole", "FREELANCER");
             model.addAttribute("matchingByPositionId", matchingByPositionId);
             model.addAttribute("proposedPositions", proposedPositions);
+            model.addAttribute("selectedProposalPosition", selectedProposalPosition);
+            model.addAttribute("selectedProposalPositionId",
+                    selectedProposalPosition != null ? selectedProposalPosition.getId() : null);
             addMemberAttributes(model, principal);
             return "client/proposalDetail";
         } catch (ProposalNotFoundException e) {
@@ -159,6 +167,17 @@ public class ProposalController {
             redirectAttributes.addFlashAttribute("errorMessage", "접근 권한이 없는 제안서입니다.");
             return "redirect:/";
         }
+    }
+
+    private ProposalPosition resolveSelectedProposalPosition(List<ProposalPosition> proposedPositions, Long proposalPositionId) {
+        if (proposalPositionId == null || proposedPositions == null || proposedPositions.isEmpty()) {
+            return null;
+        }
+
+        return proposedPositions.stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .findFirst()
+                .orElse(null);
     }
 
     @GetMapping("/{proposalId}/edit")

--- a/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
+++ b/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
@@ -1,13 +1,12 @@
 package com.generic4.itda.dto.freelancer;
 
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record FreelancerDashboardItem(
+        Long matchingId,
         Long proposalId,
+        Long proposalPositionId,
         String proposalTitle,
         String companyName,
         String positionName,

--- a/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
+++ b/src/main/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItem.java
@@ -40,6 +40,17 @@ public record FreelancerDashboardItem(
         };
     }
 
+    public String detailPath() {
+        return switch (getStatus()) {
+            case NEW -> proposalPositionId != null
+                    ? "/proposals/%d?proposalPositionId=%d".formatted(proposalId, proposalPositionId)
+                    : "/proposals/%d".formatted(proposalId);
+            case IN_PROGRESS, COMPLETED -> matchingId != null
+                    ? "/matchings/%d".formatted(matchingId)
+                    : "/proposals/%d".formatted(proposalId);
+        };
+    }
+
     public enum DashboardProposalStatus {
         NEW("신규 제안", "bg-blue-100 text-blue-700"),
         IN_PROGRESS("진행 중", "bg-emerald-100 text-emerald-700"),

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
@@ -36,12 +36,26 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
             MatchingStatus.ACCEPTED,
             MatchingStatus.IN_PROGRESS
     );
+    private static final EnumSet<MatchingStatus> NEW_ROW_STATUSES = EnumSet.of(
+            MatchingStatus.PROPOSED
+    );
+    private static final EnumSet<MatchingStatus> IN_PROGRESS_ROW_STATUSES = EnumSet.of(
+            MatchingStatus.ACCEPTED,
+            MatchingStatus.IN_PROGRESS
+    );
+    private static final EnumSet<MatchingStatus> COMPLETED_ROW_STATUSES = EnumSet.of(
+            MatchingStatus.COMPLETED,
+            MatchingStatus.REJECTED,
+            MatchingStatus.CANCELED
+    );
 
     @Override
     public List<FreelancerDashboardItem> getDashboardItems(String email, String status, String q) {
         return queryFactory
                 .select(Projections.constructor(FreelancerDashboardItem.class,
+                        matching.id,
                         proposal.id,
+                        proposalPosition.id,
                         proposal.title,
                         clientMember.nickname,
                         proposalPosition.title,
@@ -66,13 +80,25 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
 
     // 1. 상태 필터링 (MatchingStatus 기준)
     private BooleanExpression statusEq(String status) {
-        if (!StringUtils.hasText(status)) return null;
+        if (!StringUtils.hasText(status)) {
+            return null;
+        }
+
+        String normalizedStatus = status.trim().toUpperCase();
+
+        return switch (normalizedStatus) {
+            case "NEW" -> matching.status.in(NEW_ROW_STATUSES);
+            case "IN_PROGRESS" -> matching.status.in(IN_PROGRESS_ROW_STATUSES);
+            case "COMPLETED" -> matching.status.in(COMPLETED_ROW_STATUSES);
+            default -> matchingStatusEq(normalizedStatus);
+        };
+    }
+
+    private BooleanExpression matchingStatusEq(String normalizedStatus) {
         try {
-            // 전달받은 문자열을 Enum으로 변환하여 비교
-            MatchingStatus matchingStatus = MatchingStatus.valueOf(status.toUpperCase());
+            MatchingStatus matchingStatus = MatchingStatus.valueOf(normalizedStatus);
             return matching.status.eq(matchingStatus);
         } catch (IllegalArgumentException e) {
-            // 잘못된 상태값이 들어오면 조건을 무시 (전체 조회와 동일 효과)
             return null;
         }
     }

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -69,10 +69,45 @@
                         </th:block>
 
                          
-                         <th:block th:if="${viewerRole == 'FREELANCER'}">
-                             
-                             <th:block th:if="${proposedPositions != null and !#lists.isEmpty(proposedPositions)}">
-                                 
+                         <th:block th:if="${viewerRole == 'FREELANCER'}"
+                                   th:with="selectedPos=${selectedProposalPosition}">
+
+                             <th:block th:if="${selectedPos != null}"
+                                       th:with="selectedMatching=${matchingByPositionId != null ? matchingByPositionId[selectedPos.id] : null}">
+                                 <th:block th:if="${selectedMatching != null and selectedMatching.status.name() == 'PROPOSED'}">
+                                     <div class="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm">
+                                         <p class="text-xs font-black uppercase tracking-widest text-slate-400">현재 응답할 포지션</p>
+                                         <div class="flex flex-wrap items-center justify-between gap-2">
+                                             <span class="text-sm font-bold text-slate-700" th:text="${selectedPos.title}">포지션</span>
+                                             <div class="flex items-center gap-2">
+                                                 <form th:action="@{/matchings/{id}/accept(id=${selectedMatching.id})}" method="post" class="inline">
+                                                     <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                     <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${selectedMatching.id})}">
+                                                     <input type="hidden" name="errorRedirectTo"
+                                                            th:value="@{/proposals/{id}(id=${proposal.id}, proposalPositionId=${selectedPos.id})}">
+                                                     <button type="submit"
+                                                             class="inline-flex items-center gap-1.5 rounded-xl bg-blue-600 px-3 py-2 text-xs font-bold text-white transition hover:bg-blue-700">
+                                                         수락
+                                                     </button>
+                                                 </form>
+                                                 <form th:action="@{/matchings/{id}/reject(id=${selectedMatching.id})}" method="post" class="inline">
+                                                     <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                                     <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${selectedMatching.id})}">
+                                                     <input type="hidden" name="errorRedirectTo"
+                                                            th:value="@{/proposals/{id}(id=${proposal.id}, proposalPositionId=${selectedPos.id})}">
+                                                     <button type="submit"
+                                                             class="inline-flex items-center gap-1.5 rounded-xl border border-red-200 bg-white px-3 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
+                                                         거절
+                                                     </button>
+                                                 </form>
+                                             </div>
+                                         </div>
+                                     </div>
+                                 </th:block>
+                             </th:block>
+
+                             <th:block th:if="${selectedPos == null and proposedPositions != null and !#lists.isEmpty(proposedPositions)}">
+
                                  <th:block th:if="${#lists.size(proposedPositions) == 1}"
                                            th:with="pos=${proposedPositions[0]}, myMatching=${matchingByPositionId != null ? matchingByPositionId[proposedPositions[0].id] : null}">
                                      <th:block th:if="${myMatching != null and myMatching.status.name() == 'PROPOSED'}">
@@ -99,7 +134,6 @@
                                      </th:block>
                                  </th:block>
 
-                                 
                                  <th:block th:if="${#lists.size(proposedPositions) > 1}">
                                      <div class="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm">
                                          <p class="text-xs font-black uppercase tracking-widest text-slate-400">응답할 포지션</p>
@@ -462,6 +496,4 @@
 </div>
 </body>
 </html>
-
-
 

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -103,7 +103,7 @@
 
             <div th:if="${not items.isEmpty()}" class="divide-y divide-slate-100">
                 <div th:each="item : ${items}"
-                     th:attr="data-href=@{/proposals/{id}(id=${item.proposalId()})}"
+                     th:attr="data-href=${item.detailPath()}"
                      class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_80px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors cursor-pointer">
                     <div class="space-y-1">
                         <p class="text-sm font-bold text-slate-900" th:text="${item.proposalTitle()}">프로젝트명</p>
@@ -127,7 +127,7 @@
                         <span th:text="${#temporals.format(item.receivedAt(), 'yyyy.MM.dd')}">날짜</span>
                     </div>
                     <div class="flex justify-end">
-                        <a th:href="@{/proposals/{id}(id=${item.proposalId()})}"
+                        <a th:href="${item.detailPath()}"
                            class="flex items-center gap-1 text-sm font-semibold text-blue-600 hover:text-blue-700 whitespace-nowrap">
                             상세 보기<i data-lucide="chevron-right" class="w-4 h-4"></i>
                         </a>

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -21,12 +21,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
 import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
+import java.time.LocalDateTime;
 import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
@@ -712,6 +717,87 @@ class ProposalControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"))
                 .andExpect(flash().attributeExists("errorMessage"));
+    }
+
+    @Test
+    @DisplayName("프리랜서가 선택된 포지션 컨텍스트로 제안서 상세를 조회하면 해당 포지션을 모델에 담는다")
+    void renderProposalDetailForFreelancerWithSelectedPositionContext() throws Exception {
+        var freelancer = createMember("freelancer@example.com", "hashed-password", "프리랜서", "010-3333-4444");
+
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        ProposalPosition backendPosition = org.mockito.Mockito.mock(ProposalPosition.class);
+        ProposalPosition aiPosition = org.mockito.Mockito.mock(ProposalPosition.class);
+        Matching backendMatching = org.mockito.Mockito.mock(Matching.class);
+        Position backendCategory = Position.create("백엔드 개발자");
+        Position aiCategory = Position.create("AI 엔지니어");
+
+        given(proposal.getPositions()).willReturn(List.of(backendPosition, aiPosition));
+        given(proposal.getId()).willReturn(1L);
+        given(proposal.getTitle()).willReturn("핀테크 앱 고도화 프로젝트");
+        given(proposal.getDescription()).willReturn("설명");
+        given(proposal.getStatus()).willReturn(ProposalStatus.MATCHING);
+        given(proposal.getExpectedPeriod()).willReturn(8L);
+        given(proposal.getTotalBudgetMin()).willReturn(3_000_000L);
+        given(proposal.getTotalBudgetMax()).willReturn(4_000_000L);
+        given(proposal.getModifiedAt()).willReturn(LocalDateTime.of(2026, 4, 22, 12, 0));
+
+        given(backendPosition.getId()).willReturn(10L);
+        given(backendPosition.getTitle()).willReturn("API 백엔드 개발자");
+        given(backendPosition.getPosition()).willReturn(backendCategory);
+        given(backendPosition.getStatus()).willReturn(ProposalPositionStatus.OPEN);
+        given(backendPosition.getHeadCount()).willReturn(1L);
+        given(backendPosition.getUnitBudgetMin()).willReturn(3_000_000L);
+        given(backendPosition.getUnitBudgetMax()).willReturn(4_000_000L);
+        given(backendPosition.getExpectedPeriod()).willReturn(4L);
+        given(backendPosition.getSkills()).willReturn(List.of());
+        given(backendPosition.getWorkType()).willReturn(ProposalWorkType.REMOTE);
+        given(backendPosition.getWorkPlace()).willReturn(null);
+        given(backendPosition.getCareerMinYears()).willReturn(null);
+        given(backendPosition.getCareerMaxYears()).willReturn(null);
+
+        given(aiPosition.getId()).willReturn(20L);
+        given(aiPosition.getTitle()).willReturn("모델/프롬프트 AI 엔지니어");
+        given(aiPosition.getPosition()).willReturn(aiCategory);
+        given(aiPosition.getStatus()).willReturn(ProposalPositionStatus.OPEN);
+        given(aiPosition.getHeadCount()).willReturn(1L);
+        given(aiPosition.getUnitBudgetMin()).willReturn(4_000_000L);
+        given(aiPosition.getUnitBudgetMax()).willReturn(5_000_000L);
+        given(aiPosition.getExpectedPeriod()).willReturn(6L);
+        given(aiPosition.getSkills()).willReturn(List.of());
+        given(aiPosition.getWorkType()).willReturn(ProposalWorkType.REMOTE);
+        given(aiPosition.getWorkPlace()).willReturn(null);
+        given(aiPosition.getCareerMinYears()).willReturn(null);
+        given(aiPosition.getCareerMaxYears()).willReturn(null);
+
+        given(backendMatching.getProposalPosition()).willReturn(backendPosition);
+        given(backendMatching.getStatus()).willReturn(com.generic4.itda.domain.matching.constant.MatchingStatus.PROPOSED);
+        given(backendMatching.getId()).willReturn(101L);
+
+        given(proposalService.findOwnedProposal(1L, "freelancer@example.com"))
+                .willThrow(new AccessDeniedException("본인 제안서만 조회할 수 있습니다."));
+        given(proposalService.findProposalForFreelancer(1L, "freelancer@example.com"))
+                .willReturn(proposal);
+        given(matchingRepository.findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(
+                1L, "freelancer@example.com"))
+                .willReturn(List.of(backendMatching));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(freelancer);
+
+        mockMvc.perform(get("/proposals/1")
+                        .param("proposalPositionId", "10")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalDetail"))
+                .andExpect(model().attribute("viewerRole", "FREELANCER"))
+                .andExpect(model().attribute("selectedProposalPositionId", 10L))
+                .andExpect(model().attributeExists(
+                        "proposal",
+                        "selectedProposalPosition",
+                        "matchingByPositionId",
+                        "proposedPositions"
+                ));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItemTest.java
+++ b/src/test/java/com/generic4/itda/dto/freelancer/FreelancerDashboardItemTest.java
@@ -1,0 +1,68 @@
+package com.generic4.itda.dto.freelancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FreelancerDashboardItemTest {
+
+    @Test
+    @DisplayName("NEW 상태 아이템은 선택된 포지션 컨텍스트를 유지한 proposal 상세 경로를 반환한다")
+    void detailPathReturnsProposalPathWithSelectedPositionForNewItem() {
+        FreelancerDashboardItem item = new FreelancerDashboardItem(
+                99L,
+                3L,
+                7L,
+                "쇼핑몰 앱 개발",
+                "클라이언트 회사",
+                "API 백엔드 개발자",
+                MatchingStatus.PROPOSED,
+                3_000_000L,
+                4_000_000L,
+                LocalDateTime.now()
+        );
+
+        assertThat(item.detailPath()).isEqualTo("/proposals/3?proposalPositionId=7");
+    }
+
+    @Test
+    @DisplayName("진행 중 상태 아이템은 matching 상세 경로를 반환한다")
+    void detailPathReturnsMatchingPathForInProgressItem() {
+        FreelancerDashboardItem item = new FreelancerDashboardItem(
+                12L,
+                3L,
+                7L,
+                "쇼핑몰 앱 개발",
+                "클라이언트 회사",
+                "API 백엔드 개발자",
+                MatchingStatus.ACCEPTED,
+                3_000_000L,
+                4_000_000L,
+                LocalDateTime.now()
+        );
+
+        assertThat(item.detailPath()).isEqualTo("/matchings/12");
+    }
+
+    @Test
+    @DisplayName("matchingId가 없으면 proposal 상세 경로로 안전하게 fallback한다")
+    void detailPathFallsBackToProposalPathWhenMatchingIdIsMissing() {
+        FreelancerDashboardItem item = new FreelancerDashboardItem(
+                null,
+                5L,
+                9L,
+                "AI 서비스 구축",
+                "클라이언트 회사",
+                "모델/프롬프트 AI 엔지니어",
+                MatchingStatus.COMPLETED,
+                5_000_000L,
+                6_000_000L,
+                LocalDateTime.now()
+        );
+
+        assertThat(item.detailPath()).isEqualTo("/proposals/5");
+    }
+}

--- a/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/MatchingRepositoryTest.java
@@ -14,6 +14,7 @@ import com.generic4.itda.domain.resume.CareerPayload;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeWritingStatus;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
 import java.util.EnumSet;
@@ -278,6 +279,42 @@ class MatchingRepositoryTest {
 
         assertThat(items).hasSize(1);
         assertThat(matching.getId()).isNotNull();
+        assertThat(items)
+                .extracting("matchingId", "proposalId", "proposalPositionId")
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(
+                        matching.getId(),
+                        proposal.getId(),
+                        backendPosition.getId()
+                ));
+    }
+
+    @Test
+    @DisplayName("getDashboardItems는 대시보드 상태값 NEW/IN_PROGRESS/COMPLETED를 실제 매칭 상태에 맞게 필터링한다")
+    void getDashboardItems_filtersByDashboardStatusBuckets() {
+        Matching proposedMatching = saveMatching(backendPosition, freelancerResume, MatchingStatus.PROPOSED);
+
+        ProposalPosition acceptedPosition = saveAdditionalPosition("AI 추천 서비스", "AI 엔지니어");
+        Matching acceptedMatching = saveMatching(acceptedPosition, freelancerResume, MatchingStatus.ACCEPTED);
+
+        ProposalPosition completedPosition = saveAdditionalPosition("운영 자동화 툴", "운영 엔지니어");
+        Matching completedMatching = saveMatching(completedPosition, freelancerResume, MatchingStatus.COMPLETED);
+
+        em.flush();
+        em.clear();
+
+        List<FreelancerDashboardItem> newItems = matchingRepository.getDashboardItems(
+                freelancerMember.getEmail().getValue(), "NEW", null);
+        List<FreelancerDashboardItem> inProgressItems = matchingRepository.getDashboardItems(
+                freelancerMember.getEmail().getValue(), "IN_PROGRESS", null);
+        List<FreelancerDashboardItem> completedItems = matchingRepository.getDashboardItems(
+                freelancerMember.getEmail().getValue(), "COMPLETED", null);
+
+        assertThat(newItems).extracting(FreelancerDashboardItem::matchingId)
+                .containsExactly(proposedMatching.getId());
+        assertThat(inProgressItems).extracting(FreelancerDashboardItem::matchingId)
+                .containsExactly(acceptedMatching.getId());
+        assertThat(completedItems).extracting(FreelancerDashboardItem::matchingId)
+                .containsExactly(completedMatching.getId());
     }
 
     private Matching saveMatching(ProposalPosition proposalPosition, Resume resume, MatchingStatus status) {
@@ -295,5 +332,24 @@ class MatchingRepositoryTest {
         Position position = Position.create(name);
         em.persist(position);
         return position;
+    }
+
+    private ProposalPosition saveAdditionalPosition(String proposalTitle, String positionName) {
+        Position position = persistPosition(positionName);
+        Proposal extraProposal = Proposal.create(clientMember, proposalTitle, "원문", null, null, null, null);
+        ProposalPosition extraPosition = extraProposal.addPosition(
+                position,
+                positionName,
+                null,
+                1L,
+                2_000_000L,
+                4_000_000L,
+                null,
+                null,
+                null,
+                null
+        );
+        proposalRepository.saveAndFlush(extraProposal);
+        return extraPosition;
     }
 }


### PR DESCRIPTION
## 🔎 What

- 프리랜서 대시보드 상태 필터 동작 재점검 및 필요 시 보정
- 프리랜서 대시보드 row에 상태별 상세 진입을 위한 식별자 추가
- `새로운 제안` row는 proposal 상세로 이동하도록 유지
- `진행 중인 건`, `완료된 건` row는 matching 상세로 이동하도록 수정
- 프리랜서 대시보드의 `상세 보기` 링크도 상태별 진입 경로와 동일하게 정리
- proposal 상세 진입 시 현재 선택한 포지션 기준으로 응답 버튼 컨텍스트 전달
- 프리랜서용 proposal 상세에서 수락/거절 버튼은 현재 진입한 포지션에 대해서만 노출되도록 수정
- 관련 테스트 및 수동 검증 시나리오 정리


## 🔗 Issue

- Closes: #119 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?