### PR TITLE
[Feat] 추가 추천 시 기존 후보 제외 후 신규 추천 run 생성

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -101,6 +101,7 @@ public class RecommendationController {
             log.warn("추가 추천 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, proposalPositionId, principal.getEmail(), e);
 
+            redirectAttributes.addAttribute("proposalId", proposalId);
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
             return "redirect:/proposals/{proposalId}/recommendations";
         }

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -2,8 +2,8 @@ package com.generic4.itda.controller;
 
 import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
-import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
+import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.recommend.RecommendationEntryService;
@@ -74,6 +74,32 @@ public class RecommendationController {
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, form.proposalPositionId(), principal.getEmail(), e);
+
+            redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
+            return "redirect:/proposals/{proposalId}/recommendations";
+        }
+    }
+
+    @PostMapping("/proposal-positions/{proposalPositionId}/recommendations/more")
+    public String more(
+            @PathVariable Long proposalPositionId,
+            @RequestParam Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Long runId = recommendationRunService.createAdditional(
+                    proposalId,
+                    proposalPositionId,
+                    principal.getEmail()
+            );
+
+            redirectAttributes.addAttribute("runId", runId);
+            redirectAttributes.addAttribute("proposalId", proposalId);
+            return "redirect:/proposals/{proposalId}/runs/{runId}";
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("추가 추천 요청 실패. proposalId={}, proposalPositionId={}, email={}",
+                    proposalId, proposalPositionId, principal.getEmail(), e);
 
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
             return "redirect:/proposals/{proposalId}/recommendations";

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResultsViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResultsViewModel.java
@@ -4,10 +4,13 @@ import java.util.List;
 
 public record RecommendationResultsViewModel(
         Long proposalId,
+        Long proposalPositionId,
         Long runId,
         String proposalTitle,
         String positionTitle,
         int topK,
         Integer candidateCount,
         List<RecommendationCandidateItem> candidates
-) {}
+) {
+
+}

--- a/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationResultRepository.java
@@ -9,6 +9,26 @@ import org.springframework.data.repository.query.Param;
 
 public interface RecommendationResultRepository extends JpaRepository<RecommendationResult, Long> {
 
+    @Query("""
+            select distinct r.resume.id
+            from RecommendationResult r
+            where r.recommendationRun.proposalPosition.id = :proposalPositionId
+            order by r.resume.id asc
+            """)
+    List<Long> findRecommendedResumeIdsByProposalPositionId(Long proposalPositionId);
+
+    @Query("""
+            select distinct r.resume.id
+            from RecommendationResult r
+            where r.recommendationRun.proposalPosition.id = :proposalPositionId
+                and r.recommendationRun.id != :runId
+            order by r.resume.id asc
+            """)
+    List<Long> findRecommendedResumeIdsByProposalPositionIdExceptRunId(
+            Long proposalPositionId,
+            Long runId
+    );
+
     void deleteAllByRecommendationRun_ProposalPosition_Proposal_Id(Long proposalId);
 
     void deleteAllByRecommendationRun_Id(Long runId);

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepository.java
@@ -16,4 +16,17 @@ public interface ResumeQueryRepository {
             ProposalPosition proposalPosition,
             int candidatePoolSize
     );
+
+    List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            List<Long> excludedResumeIds,
+            int candidatePoolSize
+    );
+
+    List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            List<Long> excludedResumeIds,
+            int candidatePoolSize
+    );
 }

--- a/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/ResumeQueryRepositoryImpl.java
@@ -33,6 +33,24 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
             List<Long> requiredSkillIds,
             int candidatePoolSize
     ) {
+        return findCandidatePool(proposalPosition, requiredSkillIds, List.of(), candidatePoolSize);
+    }
+
+    @Override
+    public List<Long> findRecommendableResumeIds(
+            ProposalPosition proposalPosition,
+            int candidatePoolSize
+    ) {
+        return findRecommendableResumeIds(proposalPosition, List.of(), candidatePoolSize);
+    }
+
+    @Override
+    public List<CandidatePoolRow> findCandidatePool(
+            ProposalPosition proposalPosition,
+            List<Long> requiredSkillIds,
+            List<Long> excludedResumeIds,
+            int candidatePoolSize
+    ) {
         NumberExpression<Integer> proficiencySquaredSum = new CaseBuilder()
                 .when(resumeSkill.proficiency.eq(Proficiency.BEGINNER)).then(1)
                 .when(resumeSkill.proficiency.eq(Proficiency.INTERMEDIATE)).then(4)
@@ -56,6 +74,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                         recommendable(),
                         workTypeMatches(proposalPosition),
                         excludeProposalOwner(proposalPosition),
+                        excludeResumeIds(excludedResumeIds),
                         resumeSkill.skill.id.in(requiredSkillIds)
                 )
                 .groupBy(resume.id, resume.careerYears)
@@ -72,6 +91,7 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     @Override
     public List<Long> findRecommendableResumeIds(
             ProposalPosition proposalPosition,
+            List<Long> excludedResumeIds,
             int candidatePoolSize
     ) {
         return queryFactory
@@ -80,7 +100,8 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
                 .where(
                         recommendable(),
                         workTypeMatches(proposalPosition),
-                        excludeProposalOwner(proposalPosition)
+                        excludeProposalOwner(proposalPosition),
+                        excludeResumeIds(excludedResumeIds)
                 )
                 .orderBy(
                         resume.careerYears.desc(),
@@ -114,5 +135,12 @@ public class ResumeQueryRepositoryImpl implements ResumeQueryRepository {
     private BooleanExpression excludeProposalOwner(ProposalPosition proposalPosition) {
         Long proposalOwnerId = proposalPosition.getProposal().getMember().getId();
         return resume.member.id.ne(proposalOwnerId);
+    }
+
+    private BooleanExpression excludeResumeIds(List<Long> excludedResumeIds) {
+        if (excludedResumeIds == null || excludedResumeIds.isEmpty()) {
+            return null;
+        }
+        return resume.id.notIn(excludedResumeIds);
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationCandidateFinder.java
@@ -5,10 +5,13 @@ import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.repository.ResumeQueryRepository;
 import com.generic4.itda.repository.ResumeRepository;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -24,17 +27,35 @@ public class RecommendationCandidateFinder {
     private final ResumeQueryRepository resumeQueryRepository;
     private final ResumeRepository resumeRepository;
 
-    public List<RecommendationCandidate> findCandidates(ProposalPosition proposalPosition, int topK) {
+    public List<RecommendationCandidate> findCandidates(
+            ProposalPosition proposalPosition,
+            int topK
+    ) {
+        return findCandidates(proposalPosition, topK, List.of());
+    }
+
+    public List<RecommendationCandidate> findCandidates(
+            ProposalPosition proposalPosition,
+            int topK,
+            List<Long> excludedResumeIds
+    ) {
         List<Long> requiredSkillIds = extractRequiredSkillIds(proposalPosition);
         int candidatePoolSize = resolveCandidatePoolSize(topK);
+        List<Long> normalizedExcludedResumeIds = excludedResumeIds == null ? List.of() : excludedResumeIds;
+        Set<Long> excludedSet = new HashSet<>(normalizedExcludedResumeIds);
 
         List<Long> candidateResumeIds;
         if (requiredSkillIds.isEmpty()) {
-            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(proposalPosition, candidatePoolSize);
+            candidateResumeIds = resumeQueryRepository.findRecommendableResumeIds(
+                    proposalPosition,
+                    normalizedExcludedResumeIds,
+                    candidatePoolSize
+            );
         } else {
             candidateResumeIds = resumeQueryRepository.findCandidatePool(
                             proposalPosition,
                             requiredSkillIds,
+                            normalizedExcludedResumeIds,
                             candidatePoolSize
                     ).stream()
                     .map(CandidatePoolRow::resumeId)
@@ -50,6 +71,7 @@ public class RecommendationCandidateFinder {
                 .collect(Collectors.toMap(Resume::getId, Function.identity()));
 
         return candidateResumeIds.stream()
+                .filter(Predicate.not(excludedSet::contains))
                 .map(resumeMap::get)
                 .filter(Objects::nonNull)
                 .filter(resume -> passesCareerRange(resume, proposalPosition))

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationFingerprintGenerator.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +39,43 @@ public class RecommendationFingerprintGenerator {
 
                 "recommendation.algorithm=" + algorithm.name(),
                 "recommendation.topK=" + topK
+        );
+
+        return sha256(raw);
+    }
+
+    public String generateAdditional(
+            ProposalPosition proposalPosition,
+            RecommendationAlgorithm algorithm,
+            int topK,
+            List<Long> excludedResumeIds
+    ) {
+        String skillPart = proposalPosition.getSkills().stream()
+                .sorted(Comparator.comparing((ProposalPositionSkill skill) -> skill.getSkill().getName())
+                        .thenComparing(skill -> skill.getImportance().name()))
+                .map(this::toSkillToken)
+                .collect(Collectors.joining("|"));
+
+        String excludePart = excludedResumeIds == null ? "" : excludedResumeIds.stream()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+
+        String raw = String.join("::",
+                "proposalPosition.id=" + number(proposalPosition.getId()),
+                "proposalPosition.positionId=" + number(proposalPosition.getPosition().getId()),
+                "proposalPosition.workType=" + enumName(proposalPosition.getWorkType()),
+                "proposalPosition.careerMinYears=" + number(proposalPosition.getCareerMinYears()),
+                "proposalPosition.careerMaxYears=" + number(proposalPosition.getCareerMaxYears()),
+
+                "proposalPosition.unitBudgetMin=" + number(proposalPosition.getUnitBudgetMin()),
+                "proposalPosition.unitBudgetMax=" + number(proposalPosition.getUnitBudgetMax()),
+
+                "proposalPosition.skills=" + skillPart,
+
+                "recommendation.algorithm=" + algorithm.name(),
+                "recommendation.topK=" + topK,
+                "recommendation.excludedResumeIds=" + excludePart
         );
 
         return sha256(raw);

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunProcessor.java
@@ -53,9 +53,16 @@ public class RecommendationRunProcessor {
     private void processRunningRun(RecommendationRun run) {
         ProposalPosition proposalPosition = run.getProposalPosition();
 
+        List<Long> excludedResumeIds = recommendationResultRepository
+                .findRecommendedResumeIdsByProposalPositionIdExceptRunId(
+                        proposalPosition.getId(),
+                        run.getId()
+                );
+
         List<RecommendationCandidate> candidates = recommendationCandidateFinder.findCandidates(
                 proposalPosition,
-                run.getTopK()
+                run.getTopK(),
+                excludedResumeIds
         );
 
         Set<String> requiredSkillNames = extractRequiredSkillNames(proposalPosition);

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -11,10 +11,10 @@ import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.ResumeSkill;
 import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
+import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
-import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
@@ -79,6 +79,7 @@ public class RecommendationRunQueryService {
 
         return new RecommendationResultsViewModel(
                 proposal.getId(),
+                proposalPosition.getId(),
                 run.getId(),
                 proposal.getTitle(),
                 resolvePositionTitle(proposalPosition),

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunService.java
@@ -9,7 +9,9 @@ import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,7 @@ public class RecommendationRunService {
     private final ProposalRepository proposalRepository;
     private final MemberRepository memberRepository;
     private final RecommendationRunRepository recommendationRunRepository;
+    private final RecommendationResultRepository recommendationResultRepository;
     private final RecommendationFingerprintGenerator fingerprintGenerator;
 
     public Long createOrReuse(Long proposalId, Long proposalPositionId, String email) {
@@ -48,6 +51,42 @@ public class RecommendationRunService {
                 proposalPosition,
                 DEFAULT_ALGORITHM,
                 DEFAULT_TOP_K
+        );
+
+        return recommendationRunRepository
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        proposalPositionId,
+                        fingerprint,
+                        DEFAULT_ALGORITHM
+                )
+                .map(RecommendationRun::getId)
+                .orElseGet(() -> createNewRun(proposalPosition, fingerprint).getId());
+    }
+
+    public Long createAdditional(Long proposalId, Long proposalPositionId, String email) {
+        Proposal proposal = loadProposalDetail(proposalId);
+
+        Member member = Optional.ofNullable(memberRepository.findByEmail_Value(email))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        validateOwnership(proposal, member);
+        validateProposalStatus(proposal);
+
+        ProposalPosition proposalPosition = proposal.getPositions().stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 제안서에 속한 모집 포지션 아닙니다."));
+
+        validatePositionStatus(proposalPosition);
+
+        List<Long> excludedResumeIds = recommendationResultRepository
+                .findRecommendedResumeIdsByProposalPositionId(proposalPositionId);
+
+        String fingerprint = fingerprintGenerator.generateAdditional(
+                proposalPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K,
+                excludedResumeIds
         );
 
         return recommendationRunRepository

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ ai:
     model: text-embedding-3-small
     timeout-millis: 5000
   recommend-reason:
-    api-key: ${OPEN_API_KEY}
+    api-key: ${OPENAI_API_KEY}
     enabled: ${AI_RECOMMEND_REASON_ENABLED:false}
     model: ${AI_RECOMMEND_REASON_MODEL:gpt-5-mini}
     max-output-tokens: ${AI_RECOMMEND_REASON_MAX_OUTPUT_TOKENS:400}

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -3,345 +3,352 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-    <title th:text="${view.proposalTitle} + ' | 추천 결과'">추천 결과 | IT-da</title>
+  <title th:text="${view.proposalTitle} + ' | 추천 결과'">추천 결과 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
-    <main class="min-h-screen bg-slate-50">
+  <main class="min-h-screen bg-slate-50">
 
-        <!-- ══════════════════════════════════════════
-             상단 바
-        ══════════════════════════════════════════ -->
-        <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
-            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
+    <!-- ══════════════════════════════════════════
+         상단 바
+    ══════════════════════════════════════════ -->
+    <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
+      <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
 
-                <div class="flex items-center gap-4">
-                    <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
-                       class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
-                        <i data-lucide="arrow-left" class="h-4 w-4"></i>
-                    </a>
-                    <div>
-                        <div class="flex items-center gap-2">
-                            <h1 class="text-lg font-bold text-slate-900"
-                                th:text="${view.proposalTitle}">제안서 제목</h1>
-                            <span class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-[11px] font-bold text-blue-700">
+        <div class="flex items-center gap-4">
+          <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+             class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
+            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+          </a>
+          <div>
+            <div class="flex items-center gap-2">
+              <h1 class="text-lg font-bold text-slate-900"
+                  th:text="${view.proposalTitle}">제안서 제목</h1>
+              <span
+                  class="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-[11px] font-bold text-blue-700">
                                 MATCHING
                             </span>
-                        </div>
-                        <p class="mt-0.5 text-xs text-slate-400"
-                           th:text="${view.positionTitle} + ' · AI 추천 결과'">포지션 · AI 추천 결과</p>
-                    </div>
-                </div>
-
-                <div class="flex items-center gap-2">
-                    <a th:href="@{/proposals/{id}/recommendations(id=${view.proposalId})}"
-                       class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
-                        <i data-lucide="refresh-cw" class="h-3.5 w-3.5"></i>
-                        추천 다시 실행
-                    </a>
-                    <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
-                       class="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
-                        <i data-lucide="file-text" class="h-3.5 w-3.5"></i>
-                        제안서 보기
-                    </a>
-                </div>
             </div>
+            <p class="mt-0.5 text-xs text-slate-400"
+               th:text="${view.positionTitle} + ' · AI 추천 결과'">포지션 · AI 추천 결과</p>
+          </div>
         </div>
 
-        <!-- ══════════════════════════════════════════
-             본문 2-column 레이아웃
-        ══════════════════════════════════════════ -->
-        <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
-            <section th:if="${errorMessage != null}"
-                     class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
-                <p th:text="${errorMessage}">오류 메시지</p>
-            </section>
-            <section th:if="${noticeMessage != null}"
-                     class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
-                <p th:text="${noticeMessage}">안내 메시지</p>
-            </section>
+        <div class="flex items-center gap-2">
+          <form th:action="@{/proposal-positions/{id}/recommendations/more(id=${view.proposalPositionId()})}"
+                th:method="post">
+            <input type="hidden" name="proposalId" th:value="${view.proposalId()}"/>
+            <button
+                class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
+              <i data-lucide="refresh-cw" class="h-3.5 w-3.5"></i>
+              추천 다시 실행
+            </button>
+          </form>
+          <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+             class="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+            <i data-lucide="file-text" class="h-3.5 w-3.5"></i>
+            제안서 보기
+          </a>
         </div>
+      </div>
+    </div>
 
-        <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
-            <div class="grid gap-6 lg:grid-cols-5">
+    <!-- ══════════════════════════════════════════
+         본문 2-column 레이아웃
+    ══════════════════════════════════════════ -->
+    <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
+      <section th:if="${errorMessage != null}"
+               class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+        <p th:text="${errorMessage}">오류 메시지</p>
+      </section>
+      <section th:if="${noticeMessage != null}"
+               class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+        <p th:text="${noticeMessage}">안내 메시지</p>
+      </section>
+    </div>
 
-                <!-- ────────────────────────────────────────
-                     좌측: AI 추천 카드 목록 (3/5)
-                ──────────────────────────────────────── -->
-                <section class="lg:col-span-3">
+    <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+      <div class="grid gap-6 lg:grid-cols-5">
 
-                    <!-- 섹션 헤더 -->
-                    <div class="mb-4 flex items-center justify-between">
-                        <div class="flex items-center gap-2">
-                            <div class="flex h-7 w-7 items-center justify-center rounded-xl bg-blue-600">
-                                <i data-lucide="check" class="h-3.5 w-3.5 text-white"></i>
-                            </div>
-                            <h2 class="text-base font-bold text-slate-900">
-                                AI 추천 Top <span th:text="${#lists.size(view.candidates)}">3</span>
-                            </h2>
-                        </div>
-                        <p class="text-xs text-slate-400">프로젝트 요구사항 기반 자동 분석</p>
-                    </div>
+        <!-- ────────────────────────────────────────
+             좌측: AI 추천 카드 목록 (3/5)
+        ──────────────────────────────────────── -->
+        <section class="lg:col-span-3">
 
-                    <!-- 후보 없음 -->
-                    <div th:if="${#lists.isEmpty(view.candidates)}"
-                         class="rounded-2xl border border-dashed border-slate-200 bg-white py-16 text-center">
-                        <i data-lucide="users" class="mx-auto mb-3 h-10 w-10 text-slate-200"></i>
-                        <p class="text-sm font-semibold text-slate-500">조건에 맞는 추천 결과가 없습니다</p>
-                        <p class="mt-1 text-xs text-slate-400">포지션 조건을 조정하거나 다시 시도해보세요.</p>
-                    </div>
+          <!-- 섹션 헤더 -->
+          <div class="mb-4 flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <div class="flex h-7 w-7 items-center justify-center rounded-xl bg-blue-600">
+                <i data-lucide="check" class="h-3.5 w-3.5 text-white"></i>
+              </div>
+              <h2 class="text-base font-bold text-slate-900">
+                AI 추천 Top <span th:text="${#lists.size(view.candidates)}">3</span>
+              </h2>
+            </div>
+            <p class="text-xs text-slate-400">프로젝트 요구사항 기반 자동 분석</p>
+          </div>
 
-                    <!-- 후보 카드 목록 -->
-                    <div class="space-y-4" th:unless="${#lists.isEmpty(view.candidates)}">
+          <!-- 후보 없음 -->
+          <div th:if="${#lists.isEmpty(view.candidates)}"
+               class="rounded-2xl border border-dashed border-slate-200 bg-white py-16 text-center">
+            <i data-lucide="users" class="mx-auto mb-3 h-10 w-10 text-slate-200"></i>
+            <p class="text-sm font-semibold text-slate-500">조건에 맞는 추천 결과가 없습니다</p>
+            <p class="mt-1 text-xs text-slate-400">포지션 조건을 조정하거나 다시 시도해보세요.</p>
+          </div>
 
-                        <article th:each="candidate : ${view.candidates}"
-                                 th:classappend="${candidate.matchingStatus == 'REJECTED' or candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'} ? 'opacity-60' : ''"
-                                 class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50 transition-all hover:border-slate-300 hover:shadow-md">
-                            <a th:href="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${candidate.resultId})}"
-                               class="block focus:outline-none">
+          <!-- 후보 카드 목록 -->
+          <div class="space-y-4" th:unless="${#lists.isEmpty(view.candidates)}">
 
-                                <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
-                                <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-4">
+            <article th:each="candidate : ${view.candidates}"
+                     th:classappend="${candidate.matchingStatus == 'REJECTED' or candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'} ? 'opacity-60' : ''"
+                     class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50 transition-all hover:border-slate-300 hover:shadow-md">
+              <a th:href="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${candidate.resultId})}"
+                 class="block focus:outline-none">
 
-                                    <div class="flex items-start gap-3">
-                                        <!-- 아바타 -->
-                                        <div th:classappend="${candidate.rank == 1} ? 'bg-amber-50 text-amber-500 border-amber-100' :
+                <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
+                <div class="flex items-start justify-between gap-4 px-5 pt-5 pb-4">
+
+                  <div class="flex items-start gap-3">
+                    <!-- 아바타 -->
+                    <div th:classappend="${candidate.rank == 1} ? 'bg-amber-50 text-amber-500 border-amber-100' :
                                                               (${candidate.rank == 2} ? 'bg-slate-100 text-slate-400 border-slate-200' :
                                                                                         'bg-orange-50 text-orange-400 border-orange-100')"
-                                             class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border">
-                                            <i data-lucide="user-plus" class="h-5 w-5"></i>
-                                        </div>
+                         class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border">
+                      <i data-lucide="user-plus" class="h-5 w-5"></i>
+                    </div>
 
-                                        <div>
-                                            <div class="flex items-center gap-2">
+                    <div>
+                      <div class="flex items-center gap-2">
                                                 <span class="text-base font-bold text-slate-900"
                                                       th:text="${candidate.maskedName}">김*수</span>
-                                                <span class="text-sm font-medium text-slate-400"
-                                                      th:text="${view.positionTitle}">프론트엔드 개발자</span>
-                                            </div>
-                                            <!-- 스킬 칩 -->
-                                            <div class="mt-2 flex flex-wrap gap-1.5"
-                                                 th:if="${!#lists.isEmpty(candidate.matchedSkills)}">
+                        <span class="text-sm font-medium text-slate-400"
+                              th:text="${view.positionTitle}">프론트엔드 개발자</span>
+                      </div>
+                      <!-- 스킬 칩 -->
+                      <div class="mt-2 flex flex-wrap gap-1.5"
+                           th:if="${!#lists.isEmpty(candidate.matchedSkills)}">
                                                 <span th:each="skill : ${candidate.matchedSkills}"
                                                       class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
                                                       th:text="${skill}">Java</span>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- 점수 -->
-                                    <div class="shrink-0 text-right">
-                                        <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
-                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
-                                           class="text-2xl font-black tracking-tight"
-                                           th:text="${candidate.finalScorePercent + '%'}">98%</p>
-                                        <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
-                                    </div>
-                                </div>
-
-                                <!-- ── AI 추천 사유 ── -->
-                                <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
-                                    <div class="mb-1.5 flex items-center gap-1.5">
-                                        <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
-                                        <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
-                                    </div>
-                                    <p th:if="${candidate.llmReady and candidate.llmReason != null}"
-                                       class="text-sm leading-relaxed text-slate-700"
-                                       th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
-                                    <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
-                                       class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
-                                </div>
-
-                                <div class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
-                                    <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
-                                    이력서 및 상세 정보 보기
-                                    <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
-                                </div>
-                            </a>
-
-                            <!-- ── 매칭 액션 영역 ── -->
-                            <div class="border-t border-slate-100 px-5 py-4">
-
-                                <!-- 매칭 없음: 요청 버튼 -->
-                                <th:block th:if="${candidate.matchingStatus == null}">
-                                    <form th:action="@{/recommendation-results/{recommendationResultId}/matchings(recommendationResultId=${candidate.resultId})}"
-                                          method="post">
-                                        <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                        <input type="hidden" name="redirectTo"
-                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
-                                        <input type="hidden" name="errorRedirectTo"
-                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
-                                        <button type="submit"
-                                                class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
-                                            <i data-lucide="send" class="h-4 w-4"></i>
-                                            매칭 요청하기
-                                        </button>
-                                    </form>
-                                </th:block>
-
-                                <!-- 수락 대기 중 (PROPOSED) -->
-                                <div th:if="${candidate.matchingStatus == 'PROPOSED'}"
-                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
-                                    <i data-lucide="clock" class="h-4 w-4"></i>
-                                    수락 대기 중
-                                </div>
-
-                                <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
-                                <div th:if="${candidate.matchingStatus == 'ACCEPTED' or candidate.matchingStatus == 'IN_PROGRESS'}"
-                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
-                                    <i data-lucide="check-circle" class="h-4 w-4"></i>
-                                    매칭 진행 중
-                                </div>
-
-                                <!-- 거절됨 (REJECTED) -->
-                                <div th:if="${candidate.matchingStatus == 'REJECTED'}"
-                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                                    <i data-lucide="x-circle" class="h-4 w-4"></i>
-                                    거절됨
-                                </div>
-
-                                <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
-                                <div th:if="${candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'}"
-                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                                    <i data-lucide="archive" class="h-4 w-4"></i>
-                                    <span th:text="${candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
-                                </div>
-
-                            </div>
-
-                        </article>
+                      </div>
                     </div>
-                </section>
+                  </div>
 
-                <!-- ────────────────────────────────────────
-                     우측: 실행 요약 사이드바 (2/5)
-                ──────────────────────────────────────── -->
-                <aside class="lg:col-span-2 space-y-4">
+                  <!-- 점수 -->
+                  <div class="shrink-0 text-right">
+                    <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
+                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
+                       class="text-2xl font-black tracking-tight"
+                       th:text="${candidate.finalScorePercent + '%'}">98%</p>
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
+                  </div>
+                </div>
 
-                    <!-- 실행 요약 카드 -->
-                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
-                        <div class="mb-4 flex items-center justify-between">
-                            <h3 class="text-sm font-bold text-slate-900">추천 실행 요약</h3>
-                        </div>
+                <!-- ── AI 추천 사유 ── -->
+                <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+                  <div class="mb-1.5 flex items-center gap-1.5">
+                    <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
+                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
+                  </div>
+                  <p th:if="${candidate.llmReady and candidate.llmReason != null}"
+                     class="text-sm leading-relaxed text-slate-700"
+                     th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
+                  <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
+                     class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
+                </div>
 
-                        <div class="space-y-3">
-                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
-                                <div class="flex items-center gap-2 text-sm text-slate-500">
-                                    <i data-lucide="layers" class="h-4 w-4 text-slate-400"></i>
-                                    포지션
-                                </div>
-                                <span class="text-sm font-semibold text-slate-800"
-                                      th:text="${view.positionTitle}">백엔드 개발자</span>
-                            </div>
+                <div
+                    class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
+                  <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
+                  이력서 및 상세 정보 보기
+                  <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+                </div>
+              </a>
 
-                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
-                                <div class="flex items-center gap-2 text-sm text-slate-500">
-                                    <i data-lucide="users" class="h-4 w-4 text-slate-400"></i>
-                                    후보 풀
-                                </div>
-                                <span class="text-sm font-semibold text-slate-800">
+              <!-- ── 매칭 액션 영역 ── -->
+              <div class="border-t border-slate-100 px-5 py-4">
+
+                <!-- 매칭 없음: 요청 버튼 -->
+                <th:block th:if="${candidate.matchingStatus == null}">
+                  <form
+                      th:action="@{/recommendation-results/{recommendationResultId}/matchings(recommendationResultId=${candidate.resultId})}"
+                      method="post">
+                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                    <input type="hidden" name="redirectTo"
+                           th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                    <input type="hidden" name="errorRedirectTo"
+                           th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                    <button type="submit"
+                            class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
+                      <i data-lucide="send" class="h-4 w-4"></i>
+                      매칭 요청하기
+                    </button>
+                  </form>
+                </th:block>
+
+                <!-- 수락 대기 중 (PROPOSED) -->
+                <div th:if="${candidate.matchingStatus == 'PROPOSED'}"
+                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
+                  <i data-lucide="clock" class="h-4 w-4"></i>
+                  수락 대기 중
+                </div>
+
+                <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
+                <div th:if="${candidate.matchingStatus == 'ACCEPTED' or candidate.matchingStatus == 'IN_PROGRESS'}"
+                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
+                  <i data-lucide="check-circle" class="h-4 w-4"></i>
+                  매칭 진행 중
+                </div>
+
+                <!-- 거절됨 (REJECTED) -->
+                <div th:if="${candidate.matchingStatus == 'REJECTED'}"
+                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                  <i data-lucide="x-circle" class="h-4 w-4"></i>
+                  거절됨
+                </div>
+
+                <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
+                <div th:if="${candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'}"
+                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                  <i data-lucide="archive" class="h-4 w-4"></i>
+                  <span th:text="${candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
+                </div>
+
+              </div>
+
+            </article>
+          </div>
+        </section>
+
+        <!-- ────────────────────────────────────────
+             우측: 실행 요약 사이드바 (2/5)
+        ──────────────────────────────────────── -->
+        <aside class="lg:col-span-2 space-y-4">
+
+          <!-- 실행 요약 카드 -->
+          <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+            <div class="mb-4 flex items-center justify-between">
+              <h3 class="text-sm font-bold text-slate-900">추천 실행 요약</h3>
+            </div>
+
+            <div class="space-y-3">
+              <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                <div class="flex items-center gap-2 text-sm text-slate-500">
+                  <i data-lucide="layers" class="h-4 w-4 text-slate-400"></i>
+                  포지션
+                </div>
+                <span class="text-sm font-semibold text-slate-800"
+                      th:text="${view.positionTitle}">백엔드 개발자</span>
+              </div>
+
+              <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                <div class="flex items-center gap-2 text-sm text-slate-500">
+                  <i data-lucide="users" class="h-4 w-4 text-slate-400"></i>
+                  후보 풀
+                </div>
+                <span class="text-sm font-semibold text-slate-800">
                                     <span th:text="${view.candidateCount != null ? view.candidateCount : '-'}">17</span>명
                                 </span>
-                            </div>
+              </div>
 
-                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
-                                <div class="flex items-center gap-2 text-sm text-slate-500">
-                                    <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>
-                                    추천 결과
-                                </div>
-                                <span class="text-sm font-semibold text-slate-800">
+              <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3">
+                <div class="flex items-center gap-2 text-sm text-slate-500">
+                  <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>
+                  추천 결과
+                </div>
+                <span class="text-sm font-semibold text-slate-800">
                                     Top <span th:text="${view.topK}">3</span>
                                 </span>
-                            </div>
-                        </div>
-                    </div>
+              </div>
+            </div>
+          </div>
 
-                    <!-- 매칭 현황 카드 -->
-                    <div th:if="${not #lists.isEmpty(view.candidates)}"
-                         th:with="proposedCount=${#lists.size(view.candidates.?[matchingStatus == 'PROPOSED'])},
+          <!-- 매칭 현황 카드 -->
+          <div th:if="${not #lists.isEmpty(view.candidates)}"
+               th:with="proposedCount=${#lists.size(view.candidates.?[matchingStatus == 'PROPOSED'])},
                                   activeCount=${#lists.size(view.candidates.?[matchingStatus == 'ACCEPTED' or matchingStatus == 'IN_PROGRESS'])},
                                   rejectedCount=${#lists.size(view.candidates.?[matchingStatus == 'REJECTED' or matchingStatus == 'COMPLETED' or matchingStatus == 'CANCELED'])},
                                   noneCount=${#lists.size(view.candidates.?[matchingStatus == null])}"
-                         class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
-                        <h3 class="mb-3 text-sm font-bold text-slate-900">매칭 현황</h3>
-                        <div class="space-y-2">
-                            <div class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
-                                <div class="flex items-center gap-2 text-xs text-slate-500">
-                                    <span class="h-2 w-2 rounded-full bg-slate-200"></span>
-                                    미요청
-                                </div>
-                                <span class="text-sm font-bold text-slate-700" th:text="${noneCount} + '명'">0명</span>
-                            </div>
-                            <div class="flex items-center justify-between rounded-xl bg-amber-50 px-3 py-2.5">
-                                <div class="flex items-center gap-2 text-xs text-amber-600">
-                                    <span class="h-2 w-2 rounded-full bg-amber-400"></span>
-                                    수락 대기 중
-                                </div>
-                                <span class="text-sm font-bold text-amber-700" th:text="${proposedCount} + '명'">0명</span>
-                            </div>
-                            <div class="flex items-center justify-between rounded-xl bg-emerald-50 px-3 py-2.5">
-                                <div class="flex items-center gap-2 text-xs text-emerald-600">
-                                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
-                                    매칭 진행 중
-                                </div>
-                                <span class="text-sm font-bold text-emerald-700" th:text="${activeCount} + '명'">0명</span>
-                            </div>
-                            <div th:if="${rejectedCount > 0}"
-                                 class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
-                                <div class="flex items-center gap-2 text-xs text-slate-400">
-                                    <span class="h-2 w-2 rounded-full bg-slate-300"></span>
-                                    거절 / 완료
-                                </div>
-                                <span class="text-sm font-bold text-slate-400" th:text="${rejectedCount} + '명'">0명</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- 점수 범례 카드 -->
-                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
-                        <h3 class="mb-3 text-sm font-bold text-slate-900">점수 기준</h3>
-                        <div class="space-y-2.5">
-                            <div class="flex items-center justify-between text-xs">
-                                <div class="flex items-center gap-2">
-                                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
-                                    <span class="font-semibold text-slate-600">80% 이상</span>
-                                </div>
-                                <span class="text-slate-400">매우 높은 적합도</span>
-                            </div>
-                            <div class="flex items-center justify-between text-xs">
-                                <div class="flex items-center gap-2">
-                                    <span class="h-2 w-2 rounded-full bg-blue-400"></span>
-                                    <span class="font-semibold text-slate-600">60 ~ 79%</span>
-                                </div>
-                                <span class="text-slate-400">높은 적합도</span>
-                            </div>
-                            <div class="flex items-center justify-between text-xs">
-                                <div class="flex items-center gap-2">
-                                    <span class="h-2 w-2 rounded-full bg-slate-300"></span>
-                                    <span class="font-semibold text-slate-600">60% 미만</span>
-                                </div>
-                                <span class="text-slate-400">보통 적합도</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- 안내 카드 -->
-                    <div class="rounded-2xl border border-blue-100 bg-blue-50 p-5">
-                        <div class="flex items-start gap-3">
-                            <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-blue-400"></i>
-                            <div>
-                                <p class="text-xs font-bold text-blue-700">매칭 요청 안내</p>
-                                <p class="mt-1 text-xs leading-relaxed text-blue-600">
-                                    매칭 요청 후 프리랜서가 수락하면 상세 프로필과 연락처를 확인할 수 있습니다.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-
-                </aside>
+               class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+            <h3 class="mb-3 text-sm font-bold text-slate-900">매칭 현황</h3>
+            <div class="space-y-2">
+              <div class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
+                <div class="flex items-center gap-2 text-xs text-slate-500">
+                  <span class="h-2 w-2 rounded-full bg-slate-200"></span>
+                  미요청
+                </div>
+                <span class="text-sm font-bold text-slate-700" th:text="${noneCount} + '명'">0명</span>
+              </div>
+              <div class="flex items-center justify-between rounded-xl bg-amber-50 px-3 py-2.5">
+                <div class="flex items-center gap-2 text-xs text-amber-600">
+                  <span class="h-2 w-2 rounded-full bg-amber-400"></span>
+                  수락 대기 중
+                </div>
+                <span class="text-sm font-bold text-amber-700" th:text="${proposedCount} + '명'">0명</span>
+              </div>
+              <div class="flex items-center justify-between rounded-xl bg-emerald-50 px-3 py-2.5">
+                <div class="flex items-center gap-2 text-xs text-emerald-600">
+                  <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                  매칭 진행 중
+                </div>
+                <span class="text-sm font-bold text-emerald-700" th:text="${activeCount} + '명'">0명</span>
+              </div>
+              <div th:if="${rejectedCount > 0}"
+                   class="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2.5">
+                <div class="flex items-center gap-2 text-xs text-slate-400">
+                  <span class="h-2 w-2 rounded-full bg-slate-300"></span>
+                  거절 / 완료
+                </div>
+                <span class="text-sm font-bold text-slate-400" th:text="${rejectedCount} + '명'">0명</span>
+              </div>
             </div>
-        </div>
-    </main>
+          </div>
+
+          <!-- 점수 범례 카드 -->
+          <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+            <h3 class="mb-3 text-sm font-bold text-slate-900">점수 기준</h3>
+            <div class="space-y-2.5">
+              <div class="flex items-center justify-between text-xs">
+                <div class="flex items-center gap-2">
+                  <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                  <span class="font-semibold text-slate-600">80% 이상</span>
+                </div>
+                <span class="text-slate-400">매우 높은 적합도</span>
+              </div>
+              <div class="flex items-center justify-between text-xs">
+                <div class="flex items-center gap-2">
+                  <span class="h-2 w-2 rounded-full bg-blue-400"></span>
+                  <span class="font-semibold text-slate-600">60 ~ 79%</span>
+                </div>
+                <span class="text-slate-400">높은 적합도</span>
+              </div>
+              <div class="flex items-center justify-between text-xs">
+                <div class="flex items-center gap-2">
+                  <span class="h-2 w-2 rounded-full bg-slate-300"></span>
+                  <span class="font-semibold text-slate-600">60% 미만</span>
+                </div>
+                <span class="text-slate-400">보통 적합도</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 안내 카드 -->
+          <div class="rounded-2xl border border-blue-100 bg-blue-50 p-5">
+            <div class="flex items-start gap-3">
+              <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-blue-400"></i>
+              <div>
+                <p class="text-xs font-bold text-blue-700">매칭 요청 안내</p>
+                <p class="mt-1 text-xs leading-relaxed text-blue-600">
+                  매칭 요청 후 프리랜서가 수락하면 상세 프로필과 연락처를 확인할 수 있습니다.
+                </p>
+              </div>
+            </div>
+          </div>
+
+        </aside>
+      </div>
+    </div>
+  </main>
 </div>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class RecommendationControllerTest {
 
     private static final Long PROPOSAL_ID = 10L;
+    private static final Long PROPOSAL_POSITION_ID = 20L;
     private static final Long RUN_ID = 301L;
     private static final Long RESULT_ID = 100L;
 
@@ -62,6 +63,7 @@ class RecommendationControllerTest {
 
         RecommendationResultsViewModel viewModel = new RecommendationResultsViewModel(
                 PROPOSAL_ID,
+                PROPOSAL_POSITION_ID,
                 RUN_ID,
                 "추천 테스트 제안서",
                 "백엔드 개발자",
@@ -194,4 +196,3 @@ class RecommendationControllerTest {
                 .getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com"));
     }
 }
-

--- a/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationResultRepositoryTest.java
@@ -216,13 +216,155 @@ class RecommendationResultRepositoryTest {
             assertThat(util.isLoaded(found, "resume")).isTrue();
             assertThat(util.isLoaded(found.getRecommendationRun(), "proposalPosition")).isTrue();
             assertThat(util.isLoaded(found.getRecommendationRun().getProposalPosition(), "proposal")).isTrue();
-            assertThat(util.isLoaded(found.getRecommendationRun().getProposalPosition().getProposal(), "member")).isTrue();
+            assertThat(
+                    util.isLoaded(found.getRecommendationRun().getProposalPosition().getProposal(), "member")).isTrue();
             assertThat(util.isLoaded(found.getResume(), "member")).isTrue();
 
             assertThat(found.getRecommendationRun().getId()).isEqualTo(run.getId());
-            assertThat(found.getRecommendationRun().getProposalPosition().getProposal().getMember().getEmail().getValue())
+            assertThat(
+                    found.getRecommendationRun().getProposalPosition().getProposal().getMember().getEmail().getValue())
                     .isEqualTo("proposer@test.com");
             assertThat(found.getResume().getMember().getEmail().getValue()).isEqualTo("applicant@test.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("포지션별 추천 이력서 ID 조회")
+    class FindRecommendedResumeIds {
+
+        @Test
+        @DisplayName("proposalPosition 기준으로 추천된 resumeId를 중복 없이 정렬하여 조회한다")
+        void findRecommendedResumeIdsByProposalPositionId_returnsDistinctSortedResumeIds() {
+            // given
+            Member proposalMember = memberRepository.save(createMember("p2@test.com", "pw", "제안자2", "010-1000-0001"));
+            Position p = persistPosition("프론트엔드 개발자");
+            Proposal proposal = Proposal.create(proposalMember, "프로젝트", "원문", null, null, null, null);
+            ProposalPosition pp = proposal.addPosition(p, "프론트", null, 1L, null, null, null, null, null, null);
+            proposalRepository.saveAndFlush(proposal);
+
+            RecommendationRun run1 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp, "fp-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp, "fp-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            Resume res1 = createAndSaveResume("u1@test.com");
+            Resume res2 = createAndSaveResume("u2@test.com");
+            Resume res3 = createAndSaveResume("u3@test.com");
+
+            ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 0, List.of());
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run1, res1, 1, new BigDecimal("0.9"), new BigDecimal("0.9"), facts));
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run1, res2, 2, new BigDecimal("0.8"), new BigDecimal("0.8"), facts));
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run2, res2, 1, new BigDecimal("0.9"), new BigDecimal("0.9"),
+                            facts)); // 중복
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run2, res3, 2, new BigDecimal("0.8"), new BigDecimal("0.8"), facts));
+            recommendationResultRepository.flush();
+            em.clear();
+
+            // when
+            List<Long> resumeIds = recommendationResultRepository.findRecommendedResumeIdsByProposalPositionId(
+                    pp.getId());
+
+            // then
+            assertThat(resumeIds).hasSize(3);
+            assertThat(resumeIds).isSorted();
+            assertThat(resumeIds).containsExactlyInAnyOrder(res1.getId(), res2.getId(), res3.getId());
+        }
+
+        @Test
+        @DisplayName("특정 runId를 제외하고 proposalPositionId 기준 추천된 resumeId를 조회한다")
+        void findRecommendedResumeIdsByProposalPositionIdExceptRunId_excludesTargetRunResults() {
+            // given
+            Member proposalMember = memberRepository.save(createMember("p3@test.com", "pw", "제안자3", "010-2000-0001"));
+            Position p = persistPosition("데이터 엔지니어");
+            Proposal proposal = Proposal.create(proposalMember, "프로젝트2", "원문", null, null, null, null);
+            ProposalPosition pp = proposal.addPosition(p, "데이터", null, 1L, null, null, null, null, null, null);
+            proposalRepository.saveAndFlush(proposal);
+
+            RecommendationRun run1 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp, "fp-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp, "fp-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            Resume res1 = createAndSaveResume("u4@test.com");
+            Resume res2 = createAndSaveResume("u5@test.com");
+            Resume res3 = createAndSaveResume("u6@test.com");
+
+            ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 0, List.of());
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run1, res1, 1, new BigDecimal("0.9"), new BigDecimal("0.9"), facts));
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run1, res2, 2, new BigDecimal("0.8"), new BigDecimal("0.8"), facts));
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run2, res3, 1, new BigDecimal("0.9"), new BigDecimal("0.9"), facts));
+            recommendationResultRepository.flush();
+            em.clear();
+
+            // when: run2 제외
+            List<Long> resumeIds = recommendationResultRepository.findRecommendedResumeIdsByProposalPositionIdExceptRunId(
+                    pp.getId(), run2.getId());
+
+            // then: run1의 결과인 res1, res2만 조회되어야 함
+            assertThat(resumeIds).hasSize(2);
+            assertThat(resumeIds).containsExactlyInAnyOrder(res1.getId(), res2.getId());
+            assertThat(resumeIds).doesNotContain(res3.getId());
+            assertThat(resumeIds).isSorted();
+        }
+
+        @Test
+        @DisplayName("다른 proposalPosition의 결과는 포함되지 않는다")
+        void findRecommendedResumeIdsByProposalPositionId_onlyReturnsTargetPositionResults() {
+            // given
+            Member proposalMember = memberRepository.save(createMember("p4@test.com", "pw", "제안자4", "010-3000-0001"));
+            Position p = persistPosition("QA");
+            Proposal proposal = Proposal.create(proposalMember, "프로젝트3", "원문", null, null, null, null);
+            ProposalPosition pp1 = proposal.addPosition(p, "QA1", null, 1L, null, null, null, null, null, null);
+            ProposalPosition pp2 = proposal.addPosition(p, "QA2", null, 1L, null, null, null, null, null, null);
+            proposalRepository.saveAndFlush(proposal);
+
+            RecommendationRun run1 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp1, "fp-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.save(
+                    RecommendationRun.create(pp2, "fp-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            Resume res1 = createAndSaveResume("u7@test.com");
+            Resume res2 = createAndSaveResume("u8@test.com");
+
+            ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 0, List.of());
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run1, res1, 1, new BigDecimal("0.9"), new BigDecimal("0.9"), facts));
+            recommendationResultRepository.save(
+                    RecommendationResult.create(run2, res2, 1, new BigDecimal("0.9"), new BigDecimal("0.9"), facts));
+            recommendationResultRepository.flush();
+            em.clear();
+
+            // when
+            List<Long> resumeIds = recommendationResultRepository.findRecommendedResumeIdsByProposalPositionId(
+                    pp1.getId());
+
+            // then
+            assertThat(resumeIds).isSorted();
+            assertThat(resumeIds).containsExactly(res1.getId());
+            assertThat(resumeIds).doesNotContain(res2.getId());
+        }
+
+        @Test
+        @DisplayName("결과가 없으면 빈 리스트를 반환한다")
+        void findRecommendedResumeIdsByProposalPositionId_returnsEmptyListWhenNoResults() {
+            // when
+            List<Long> resumeIds = recommendationResultRepository.findRecommendedResumeIdsByProposalPositionId(999L);
+
+            // then
+            assertThat(resumeIds).isEmpty();
+        }
+
+        private Resume createAndSaveResume(String email) {
+            Member member = memberRepository.save(createMember(email, "pw", "지원자", "010-9999-9999"));
+            return resumeRepository.save(Resume.create(member, "소개", (byte) 3, new CareerPayload(), WorkType.REMOTE,
+                    ResumeWritingStatus.WRITING, null));
         }
     }
 

--- a/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/ResumeQueryRepositoryTest.java
@@ -240,6 +240,57 @@ class ResumeQueryRepositoryTest {
                 .containsExactly(otherResume.getId());
     }
 
+    @DisplayName("findCandidatePool은 명시된 이력서를 후보 풀에서 제외한다")
+    @Test
+    void findCandidatePool_excludesExplicitResumeIds() {
+        // given
+        Skill java = skillRepository.saveAndFlush(Skill.create("Java-query-pool-exclude", null));
+        Skill spring = skillRepository.saveAndFlush(Skill.create("Spring-query-pool-exclude", null));
+
+        Resume excludedStrongest = saveResume(
+                "pool-exclude-strongest",
+                (byte) 20,
+                true,
+                true,
+                true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.ADVANCED)
+        );
+        Resume includedHigherScore = saveResume(
+                "pool-exclude-included-high",
+                (byte) 10,
+                true,
+                true,
+                true,
+                skill(java, Proficiency.ADVANCED),
+                skill(spring, Proficiency.INTERMEDIATE)
+        );
+        Resume includedLowerScore = saveResume(
+                "pool-exclude-included-low",
+                (byte) 7,
+                true,
+                true,
+                true,
+                skill(java, Proficiency.INTERMEDIATE),
+                skill(spring, Proficiency.INTERMEDIATE)
+        );
+
+        // when
+        List<CandidatePoolRow> result = resumeQueryRepository.findCandidatePool(
+                createProposalPosition(null),
+                List.of(java.getId(), spring.getId()),
+                List.of(excludedStrongest.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).extracting(CandidatePoolRow::resumeId)
+                .containsExactly(
+                        includedHigherScore.getId(),
+                        includedLowerScore.getId()
+                );
+    }
+
     @DisplayName("findCandidatePool은 근무 형태 정책 조합에 따라 후보를 필터링한다")
     @ParameterizedTest(name = "proposalWorkType={0}")
     @MethodSource("workTypePolicyCases")
@@ -353,6 +404,28 @@ class ResumeQueryRepositoryTest {
 
         // then
         assertThat(result).containsExactly(otherResume.getId());
+    }
+
+    @DisplayName("findRecommendableResumeIds는 명시된 이력서를 fallback 후보에서 제외한다")
+    @Test
+    void findRecommendableResumeIds_excludesExplicitResumeIds() {
+        // given
+        Resume excludedHighestCareer = saveResume("recommend-exclude-highest", (byte) 10, true, true, true);
+        Resume includedMediumCareerLowId = saveResume("recommend-exclude-medium-low-id", (byte) 5, true, true, true);
+        Resume includedMediumCareerHighId = saveResume("recommend-exclude-medium-high-id", (byte) 5, true, true, true);
+
+        // when
+        List<Long> result = resumeQueryRepository.findRecommendableResumeIds(
+                createProposalPosition(null),
+                List.of(excludedHighestCareer.getId()),
+                10
+        );
+
+        // then
+        assertThat(result).containsExactly(
+                includedMediumCareerLowId.getId(),
+                includedMediumCareerHighId.getId()
+        );
     }
 
     @DisplayName("findRecommendableResumeIds는 fallback 조회 경로에서도 근무 형태 정책 조합을 적용한다")

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -51,7 +51,8 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L));
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, List.of(), 100))
+                .willReturn(List.of(11L, 22L));
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L))).willReturn(List.of(second, first));
 
         // when
@@ -63,7 +64,7 @@ class RecommendationCandidateFinderTest {
         assertThat(result.get(0).skills()).extracting(RecommendationCandidate.CandidateSkill::skillName)
                 .containsExactly("Java");
 
-        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, List.of(), 100);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -79,10 +80,11 @@ class RecommendationCandidateFinderTest {
         Resume first = createResume(11L, (byte) 9, skillData(101L, "Java", Proficiency.ADVANCED));
         Resume second = createResume(22L, (byte) 4, skillData(101L, "Java", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 120)).willReturn(List.of(
-                new CandidatePoolRow(22L, 1L, 4, (byte) 4),
-                new CandidatePoolRow(11L, 1L, 9, (byte) 9)
-        ));
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), List.of(), 120))
+                .willReturn(List.of(
+                        new CandidatePoolRow(22L, 1L, 4, (byte) 4),
+                        new CandidatePoolRow(11L, 1L, 9, (byte) 9)
+                ));
         given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(first, second));
 
         // when
@@ -92,7 +94,62 @@ class RecommendationCandidateFinderTest {
         assertThat(result).extracting(RecommendationCandidate::resumeId)
                 .containsExactly(22L, 11L);
 
-        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 120);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), List.of(), 120);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("제외 이력서가 있으면 전체 추천 가능 풀 조회에 전달하고 최종 후보에서도 제외한다")
+    @Test
+    void findCandidates_excludesResumeIdsWhenNoEssentialSkills() {
+        // given
+        ProposalPosition proposalPosition = createProposalPosition(
+                skillRequirement(201L, "Communication", ProposalPositionSkillImportance.PREFERENCE)
+        );
+        Resume included = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume excluded = createResume(22L, (byte) 5, skillData(102L, "Spring", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, List.of(22L), 100))
+                .willReturn(List.of(22L, 11L));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(excluded, included));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3, List.of(22L));
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L);
+
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, List.of(22L), 100);
+        verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
+        verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
+    }
+
+    @DisplayName("제외 이력서가 있으면 필수 스킬 후보 풀 조회에 전달하고 최종 후보에서도 제외한다")
+    @Test
+    void findCandidates_excludesResumeIdsWhenEssentialSkillsExist() {
+        // given
+        ProposalPosition proposalPosition = createProposalPosition(
+                skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
+        );
+        Resume included = createResume(11L, (byte) 7, skillData(101L, "Java", Proficiency.ADVANCED));
+        Resume excluded = createResume(22L, (byte) 5, skillData(101L, "Java", Proficiency.INTERMEDIATE));
+
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), List.of(22L), 100))
+                .willReturn(List.of(
+                        new CandidatePoolRow(22L, 1L, 4, (byte) 5),
+                        new CandidatePoolRow(11L, 1L, 9, (byte) 7)
+                ));
+        given(resumeRepository.findAllWithSkillsByIds(List.of(22L, 11L))).willReturn(List.of(excluded, included));
+
+        // when
+        List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 3, List.of(22L));
+
+        // then
+        assertThat(result).extracting(RecommendationCandidate::resumeId)
+                .containsExactly(11L);
+
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), List.of(22L), 100);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(22L, 11L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }
@@ -104,14 +161,15 @@ class RecommendationCandidateFinderTest {
         ProposalPosition proposalPosition = createProposalPosition(
                 skillRequirement(101L, "Java", ProposalPositionSkillImportance.ESSENTIAL)
         );
-        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), 100)).willReturn(List.of());
+        given(resumeQueryRepository.findCandidatePool(proposalPosition, List.of(101L), List.of(), 100))
+                .willReturn(List.of());
 
         // when
         List<RecommendationCandidate> result = finder.findCandidates(proposalPosition, 5);
 
         // then
         assertThat(result).isEmpty();
-        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), 100);
+        verify(resumeQueryRepository).findCandidatePool(proposalPosition, List.of(101L), List.of(), 100);
         verifyNoInteractions(resumeRepository);
         verifyNoMoreInteractions(resumeQueryRepository);
     }
@@ -131,7 +189,8 @@ class RecommendationCandidateFinderTest {
         Resume belowRange = createResume(22L, (byte) 2, skillData(101L, "Java", Proficiency.INTERMEDIATE));
         Resume aboveRange = createResume(33L, (byte) 9, skillData(101L, "Java", Proficiency.INTERMEDIATE));
 
-        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, 100)).willReturn(List.of(11L, 22L, 33L));
+        given(resumeQueryRepository.findRecommendableResumeIds(proposalPosition, List.of(), 100))
+                .willReturn(List.of(11L, 22L, 33L));
         given(resumeRepository.findAllWithSkillsByIds(List.of(11L, 22L, 33L)))
                 .willReturn(List.of(aboveRange, inRange, belowRange));
 
@@ -141,7 +200,7 @@ class RecommendationCandidateFinderTest {
         // then
         assertThat(result).extracting(RecommendationCandidate::resumeId)
                 .containsExactly(11L);
-        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, 100);
+        verify(resumeQueryRepository).findRecommendableResumeIds(proposalPosition, List.of(), 100);
         verify(resumeRepository).findAllWithSkillsByIds(List.of(11L, 22L, 33L));
         verifyNoMoreInteractions(resumeQueryRepository, resumeRepository);
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationFingerprintGeneratorTest.java
@@ -11,6 +11,7 @@ import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.fixture.MemberFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -209,6 +210,70 @@ class RecommendationFingerprintGeneratorTest {
 
         assertThat(fpNullId1).isEqualTo(fpNullId2);
         assertThat(fpNullId1).isNotEqualTo(fpWithId);
+    }
+
+    @Test
+    @DisplayName("추가 추천 fingerprint는 제외 이력서 id 순서가 달라도 동일하다")
+    void generateAdditional_isOrderInvariantForExcludedResumeIds() {
+        ProposalPosition position = createBasePosition(createBaseProposal());
+        addSkillWithId(position, 1L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
+
+        String fp1 = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                List.of(3L, 1L, 2L)
+        );
+        String fp2 = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                List.of(2L, 3L, 1L)
+        );
+
+        assertThat(fp1).isEqualTo(fp2);
+    }
+
+    @Test
+    @DisplayName("추가 추천 fingerprint는 제외 이력서 id가 바뀌면 달라진다")
+    void generateAdditional_changesWhenExcludedResumeIdsChange() {
+        ProposalPosition position = createBasePosition(createBaseProposal());
+
+        String fp1 = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                List.of(1L, 2L)
+        );
+        String fp2 = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                List.of(1L, 3L)
+        );
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    @Test
+    @DisplayName("추가 추천 fingerprint는 제외 이력서 id가 null 또는 empty여도 안정적으로 생성된다")
+    void generateAdditional_nullAndEmptyExcludedResumeIdsAreEquivalent() {
+        ProposalPosition position = createBasePosition(createBaseProposal());
+
+        String nullExcludedFingerprint = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                null
+        );
+        String emptyExcludedFingerprint = generator.generateAdditional(
+                position,
+                RecommendationAlgorithm.HEURISTIC_V1,
+                10,
+                List.of()
+        );
+
+        assertThat(nullExcludedFingerprint).isEqualTo(emptyExcludedFingerprint);
     }
 
     private Proposal createBaseProposal() {

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorIntegrationTest.java
@@ -95,7 +95,8 @@ class RecommendationRunProcessorIntegrationTest {
                 "resume-owner-happy@test.com"
         );
 
-        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(prepared.candidate()));
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt(), anyList()))
+                .willReturn(List.of(prepared.candidate()));
         given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(prepared.scoredCandidate()));
         given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(prepared.result()));
         given(recommendationReasonGenerator.generate(any())).willReturn("  Java 경험이 적합합니다.  ");
@@ -139,7 +140,7 @@ class RecommendationRunProcessorIntegrationTest {
         // given
         RunFixture fixture = createRunningRunFixture("proc-fail@test.com", "fp-fail");
 
-        given(recommendationCandidateFinder.findCandidates(any(), anyInt()))
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt(), anyList()))
                 .willThrow(new RuntimeException("후보 조회 중 오류 발생"));
 
         entityManager.flush();
@@ -171,7 +172,8 @@ class RecommendationRunProcessorIntegrationTest {
                 "resume-owner-reason-fail@test.com"
         );
 
-        given(recommendationCandidateFinder.findCandidates(any(), anyInt())).willReturn(List.of(prepared.candidate()));
+        given(recommendationCandidateFinder.findCandidates(any(), anyInt(), anyList()))
+                .willReturn(List.of(prepared.candidate()));
         given(recommendationScorer.score(any(), any(), anySet(), anySet(), anyList())).willReturn(List.of(prepared.scoredCandidate()));
         given(recommendationResultCreator.create(any(), anyList(), anyInt(), anySet())).willReturn(List.of(prepared.result()));
         given(recommendationReasonGenerator.generate(any())).willThrow(new RuntimeException("추천 이유 생성 실패"));

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunProcessorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.position.Position;
@@ -140,10 +141,13 @@ class RecommendationRunProcessorTest {
             );
             List<ScoredCandidate> scoredCandidates = List.of();
             List<RecommendationResult> results = List.of(org.mockito.Mockito.mock(RecommendationResult.class));
+            List<Long> excludedResumeIds = List.of(303L, 404L);
 
             given(recommendationRunRepository.findById(1L))
                     .willReturn(Optional.of(run));
-            given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+            given(recommendationResultRepository.findRecommendedResumeIdsByProposalPositionIdExceptRunId(any(), any()))
+                    .willReturn(excludedResumeIds);
+            given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK(), excludedResumeIds))
                     .willReturn(candidates);
             given(recommendationScorer.score(
                     any(),
@@ -165,6 +169,8 @@ class RecommendationRunProcessorTest {
             assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.COMPUTED);
             assertThat(run.getCandidateCount()).isEqualTo(1);
             assertThat(run.getHardFilterStats()).isEqualTo(new HardFilterStat(2, 1));
+            then(recommendationCandidateFinder).should()
+                    .findCandidates(proposalPosition, run.getTopK(), excludedResumeIds);
             then(recommendationScorer).should().score(
                     proposalPosition.getProposal(),
                     proposalPosition,
@@ -193,7 +199,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willThrow(new RuntimeException("하드 필터 계산 실패"));
 
         assertThatCode(() -> recommendationRunProcessor.process(1L))
@@ -203,7 +209,7 @@ class RecommendationRunProcessorTest {
         assertThat(run.getErrorMessage()).isEqualTo("하드 필터 계산 실패");
         then(recommendationScorer).shouldHaveNoInteractions();
         then(recommendationResultCreator).shouldHaveNoInteractions();
-        then(recommendationResultRepository).shouldHaveNoInteractions();
+        then(recommendationResultRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -224,7 +230,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationQueryTextGenerator.generate(
                 proposalPosition.getProposal(),
@@ -281,7 +287,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationQueryTextGenerator.generate(
                 proposalPosition.getProposal(),
@@ -299,7 +305,7 @@ class RecommendationRunProcessorTest {
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("임베딩 실패");
         then(recommendationResultCreator).shouldHaveNoInteractions();
-        then(recommendationResultRepository).shouldHaveNoInteractions();
+        then(recommendationResultRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -314,7 +320,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationScorer.score(
                 any(),
@@ -330,7 +336,7 @@ class RecommendationRunProcessorTest {
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("scorer 계산 실패");
         then(recommendationResultCreator).shouldHaveNoInteractions();
-        then(recommendationResultRepository).shouldHaveNoInteractions();
+        then(recommendationResultRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -345,7 +351,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationScorer.score(
                 any(),
@@ -361,7 +367,7 @@ class RecommendationRunProcessorTest {
         assertThat(run.getStatus()).isEqualTo(RecommendationRunStatus.FAILED);
         assertThat(run.getErrorMessage()).isEqualTo("추천 실행 중 오류가 발생했습니다.");
         then(recommendationResultCreator).shouldHaveNoInteractions();
-        then(recommendationResultRepository).shouldHaveNoInteractions();
+        then(recommendationResultRepository).should(never()).saveAll(anyList());
     }
 
     @Test
@@ -371,7 +377,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willThrow(new RuntimeException());
 
         assertThatCode(() -> recommendationRunProcessor.process(1L))
@@ -388,7 +394,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willThrow(new RuntimeException("   "));
 
         assertThatCode(() -> recommendationRunProcessor.process(1L))
@@ -409,7 +415,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationScorer.score(
                 any(),
@@ -448,7 +454,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationScorer.score(
                 any(),
@@ -547,7 +553,7 @@ class RecommendationRunProcessorTest {
 
         given(recommendationRunRepository.findById(1L))
                 .willReturn(Optional.of(run));
-        given(recommendationCandidateFinder.findCandidates(run.getProposalPosition(), run.getTopK()))
+        given(recommendationCandidateFinder.findCandidates(eq(run.getProposalPosition()), eq(run.getTopK()), anyList()))
                 .willReturn(candidates);
         given(recommendationScorer.score(
                 any(),

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
@@ -20,7 +20,9 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.ProposalRepository;
+import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,6 +65,9 @@ class RecommendationRunServiceTest {
 
     @Mock
     private RecommendationRunRepository recommendationRunRepository;
+
+    @Mock
+    private RecommendationResultRepository recommendationResultRepository;
 
     @Mock
     private RecommendationFingerprintGenerator fingerprintGenerator;
@@ -171,6 +176,186 @@ class RecommendationRunServiceTest {
         assertThat(savedRun.getStatus()).isEqualTo(RecommendationRunStatus.PENDING);
 
         verifyNoMoreInteractions(proposalRepository, memberRepository, fingerprintGenerator, recommendationRunRepository);
+    }
+
+    @Test
+    @DisplayName("추가 추천에서 동일한 제외 이력서 목록 기반 fingerprint의 기존 run이 있으면 기존 id를 재사용한다")
+    void createAdditional_returnsExistingRunIdWhenReusableAdditionalRunExists() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        List<Long> excludedResumeIds = List.of(1L, 2L, 3L);
+
+        RecommendationRun existingRun = RecommendationRun.create(
+                selectedPosition,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K
+        );
+        ReflectionTestUtils.setField(existingRun, "id", EXISTING_RUN_ID);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+        given(recommendationResultRepository.findRecommendedResumeIdsByProposalPositionId(SELECTED_POSITION_ID))
+                .willReturn(excludedResumeIds);
+        given(fingerprintGenerator.generateAdditional(
+                selectedPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K,
+                excludedResumeIds
+        )).willReturn(FINGERPRINT);
+        given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                SELECTED_POSITION_ID,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM
+        )).willReturn(Optional.of(existingRun));
+
+        // when
+        Long result = service.createAdditional(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result).isEqualTo(EXISTING_RUN_ID);
+
+        InOrder inOrder = inOrder(
+                proposalRepository,
+                memberRepository,
+                recommendationResultRepository,
+                fingerprintGenerator,
+                recommendationRunRepository
+        );
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        inOrder.verify(recommendationResultRepository)
+                .findRecommendedResumeIdsByProposalPositionId(SELECTED_POSITION_ID);
+        inOrder.verify(fingerprintGenerator).generateAdditional(
+                selectedPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K,
+                excludedResumeIds
+        );
+        inOrder.verify(recommendationRunRepository)
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        SELECTED_POSITION_ID,
+                        FINGERPRINT,
+                        DEFAULT_ALGORITHM
+                );
+
+        verifyNoMoreInteractions(
+                proposalRepository,
+                memberRepository,
+                recommendationResultRepository,
+                fingerprintGenerator,
+                recommendationRunRepository
+        );
+    }
+
+    @Test
+    @DisplayName("추가 추천에서 재사용 가능한 run이 없으면 기존 추천 이력서를 제외한 새 run을 생성해 저장한다")
+    void createAdditional_createsNewPendingRunWhenReusableAdditionalRunDoesNotExist() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        List<Long> excludedResumeIds = List.of(1L, 2L, 3L);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+        given(recommendationResultRepository.findRecommendedResumeIdsByProposalPositionId(SELECTED_POSITION_ID))
+                .willReturn(excludedResumeIds);
+        given(fingerprintGenerator.generateAdditional(
+                selectedPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K,
+                excludedResumeIds
+        )).willReturn(FINGERPRINT);
+        given(recommendationRunRepository.findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                SELECTED_POSITION_ID,
+                FINGERPRINT,
+                DEFAULT_ALGORITHM
+        )).willReturn(Optional.empty());
+        given(recommendationRunRepository.save(any(RecommendationRun.class))).willAnswer(invocation -> {
+            RecommendationRun run = invocation.getArgument(0);
+            ReflectionTestUtils.setField(run, "id", NEW_RUN_ID);
+            return run;
+        });
+
+        // when
+        Long result = service.createAdditional(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL);
+
+        // then
+        assertThat(result).isEqualTo(NEW_RUN_ID);
+
+        ArgumentCaptor<RecommendationRun> runCaptor = ArgumentCaptor.forClass(RecommendationRun.class);
+
+        InOrder inOrder = inOrder(
+                proposalRepository,
+                memberRepository,
+                recommendationResultRepository,
+                fingerprintGenerator,
+                recommendationRunRepository
+        );
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+        inOrder.verify(recommendationResultRepository)
+                .findRecommendedResumeIdsByProposalPositionId(SELECTED_POSITION_ID);
+        inOrder.verify(fingerprintGenerator).generateAdditional(
+                selectedPosition,
+                DEFAULT_ALGORITHM,
+                DEFAULT_TOP_K,
+                excludedResumeIds
+        );
+        inOrder.verify(recommendationRunRepository)
+                .findByProposalPosition_IdAndRequestFingerprintAndAlgorithm(
+                        SELECTED_POSITION_ID,
+                        FINGERPRINT,
+                        DEFAULT_ALGORITHM
+                );
+        inOrder.verify(recommendationRunRepository).save(runCaptor.capture());
+
+        RecommendationRun savedRun = runCaptor.getValue();
+        assertThat(savedRun.getProposalPosition()).isSameAs(selectedPosition);
+        assertThat(savedRun.getRequestFingerprint()).isEqualTo(FINGERPRINT);
+        assertThat(savedRun.getAlgorithm()).isEqualTo(DEFAULT_ALGORITHM);
+        assertThat(savedRun.getTopK()).isEqualTo(DEFAULT_TOP_K);
+        assertThat(savedRun.getStatus()).isEqualTo(RecommendationRunStatus.PENDING);
+
+        verifyNoMoreInteractions(
+                proposalRepository,
+                memberRepository,
+                recommendationResultRepository,
+                fingerprintGenerator,
+                recommendationRunRepository
+        );
+    }
+
+    @Test
+    @DisplayName("추가 추천에서 OPEN 상태가 아닌 모집 포지션이면 기존 추천 결과를 조회하지 않고 거부한다")
+    void createAdditional_throwsBeforeLoadingExcludedResumesWhenProposalPositionStatusIsNotOpen() {
+        // given
+        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
+        Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.FULL);
+
+        stubProposalDetailLoad(proposal);
+        given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
+
+        // when / then
+        assertThatThrownBy(() -> service.createAdditional(PROPOSAL_ID, SELECTED_POSITION_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("OPEN 상태의 모집 포지션만 추천을 실행할 수 있습니다.");
+
+        InOrder inOrder = inOrder(proposalRepository, memberRepository);
+        inOrder.verify(proposalRepository).findWithPositionsById(PROPOSAL_ID);
+        inOrder.verify(proposalRepository).findPositionsWithSkillsByProposalId(PROPOSAL_ID);
+        inOrder.verify(memberRepository).findByEmail_Value(OWNER_EMAIL);
+
+        verifyNoMoreInteractions(proposalRepository, memberRepository);
+        verifyNoInteractions(recommendationResultRepository, fingerprintGenerator, recommendationRunRepository);
     }
 
     @Test


### PR DESCRIPTION
## 🔎 What

* 추가 추천 기능을 도입하여, 기존 추천 결과를 유지한 채 새로운 추천 실행(`RecommendationRun`)을 생성할 수 있도록 구현했습니다.
* 추가 추천 실행 시 기존 추천된 후보(`resumeId`)를 제외하고, 새로운 상위 3명(`topK=3`)만 다시 추천하도록 처리했습니다.
* `RecommendationFingerprintGenerator`에 exclude context를 반영한 `generateAdditional(...)`를 추가하여, 동일 exclude 조건에서는 run을 재사용하고 조건이 다르면 새로운 run이 생성되도록 했습니다.
* `RecommendationResultRepository`에 기존 추천된 후보 목록 조회 기능을 추가하여, 추가 추천 시 제외 대상 집합을 구성할 수 있도록 했습니다.
* `ResumeQueryRepository` 및 `RecommendationCandidateFinder`에 exclude 조건(`resume.id NOT IN (...)`)을 지원하도록 확장했습니다.
* `RecommendationRunProcessor`에서 기존 run의 결과를 제외한 후보만 탐색하도록 수정하여, 추가 추천 시 중복 후보가 포함되지 않도록 했습니다.
* 추가 추천 전용 엔드포인트(`POST /proposal-positions/{proposalPositionId}/recommendations/more`)를 추가하고, 새로 생성된 `runId` 기준으로 상태/결과 페이지로 연결되도록 구성했습니다.
* LLM 추천 이유 생성은 기존과 동일하게 현재 run의 결과에 대해서만 수행되도록 유지하여, 추가 추천 시 새 후보 3명에 대해서만 이유가 생성되도록 했습니다.

<img width="1920" height="1026" alt="image" src="https://github.com/user-attachments/assets/8215e8b2-ddb0-4f42-8308-200c699b47b3" />

---

## 🔗 Issue

* Closes: #118 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
