### PR TITLE
[Feat] 매칭 결과 페이지 진입 플로우 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/MatchingEntryController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingEntryController.java
@@ -1,0 +1,249 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.dto.matching.ClientMatchingFreelancerItemViewModel;
+import com.generic4.itda.dto.matching.ClientMatchingFreelancerSelectionViewModel;
+import com.generic4.itda.dto.matching.ClientMatchingPositionItemViewModel;
+import com.generic4.itda.dto.matching.ClientMatchingPositionSelectionViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.service.ProposalService;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/proposals/{proposalId}/matchings")
+@RequiredArgsConstructor
+public class MatchingEntryController {
+
+    private static final EnumSet<MatchingStatus> ACTIVE_STATUSES = EnumSet.of(
+            MatchingStatus.PROPOSED,
+            MatchingStatus.ACCEPTED,
+            MatchingStatus.IN_PROGRESS
+    );
+
+    private final ProposalService proposalService;
+    private final MatchingRepository matchingRepository;
+
+    @GetMapping
+    public String selectPosition(
+            @PathVariable Long proposalId,
+            @RequestParam(name = "openOnly", defaultValue = "false") boolean openOnly,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Proposal proposal = proposalService.findOwnedProposal(proposalId, principal.getEmail());
+
+            List<Matching> matchings = matchingRepository
+                    .findByProposalPosition_Proposal_IdAndClientMember_Email_Value(proposalId, principal.getEmail());
+
+            Map<Long, List<Matching>> byPositionId = matchings.stream()
+                    .collect(Collectors.groupingBy(matching -> matching.getProposalPosition().getId()));
+
+            List<ClientMatchingPositionItemViewModel> positions = proposal.getPositions().stream()
+                    .filter(position -> !openOnly || position.getStatus() == ProposalPositionStatus.OPEN)
+                    .sorted(positionSortComparator())
+                    .map(position -> toPositionItem(position, byPositionId.getOrDefault(position.getId(), List.of())))
+                    .toList();
+
+            model.addAttribute("view", new ClientMatchingPositionSelectionViewModel(
+                    proposal.getId(),
+                    proposal.getTitle(),
+                    openOnly,
+                    positions
+            ));
+            return "matching/positions";
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+            return "redirect:/client/dashboard";
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 조회할 수 있습니다.");
+            return "redirect:/client/dashboard";
+        }
+    }
+
+    @GetMapping("/positions/{proposalPositionId}")
+    public String selectFreelancer(
+            @PathVariable Long proposalId,
+            @PathVariable Long proposalPositionId,
+            @RequestParam(name = "status", required = false) String status,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            Proposal proposal = proposalService.findOwnedProposal(proposalId, principal.getEmail());
+
+            ProposalPosition proposalPosition = findPosition(proposal, proposalPositionId)
+                    .orElseThrow(() -> new IllegalArgumentException("잘못된 포지션입니다."));
+
+            List<Matching> matchings = matchingRepository
+                    .findWithFreelancerMemberByProposalPositionIdAndClientEmail(proposalPositionId, principal.getEmail());
+
+            MatchingStatus filterStatus = parseStatus(status).orElse(null);
+
+            List<ClientMatchingFreelancerItemViewModel> items = matchings.stream()
+                    .filter(matching -> filterStatus == null || matching.getStatus() == filterStatus)
+                    .sorted(matchingSortComparator())
+                    .map(this::toFreelancerItem)
+                    .toList();
+
+            model.addAttribute("view", new ClientMatchingFreelancerSelectionViewModel(
+                    proposal.getId(),
+                    proposal.getTitle(),
+                    proposalPosition.getId(),
+                    resolvePositionTitle(proposalPosition),
+                    toPositionStatusLabel(proposalPosition.getStatus()),
+                    filterStatus != null ? filterStatus.name() : "",
+                    availableFilterStatuses(),
+                    items
+            ));
+            return "matching/freelancers";
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+            return "redirect:/client/dashboard";
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 조회할 수 있습니다.");
+            return "redirect:/client/dashboard";
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/proposals/" + proposalId + "/matchings";
+        }
+    }
+
+    private static List<MatchingStatus> availableFilterStatuses() {
+        return List.of(
+                MatchingStatus.PROPOSED,
+                MatchingStatus.ACCEPTED,
+                MatchingStatus.IN_PROGRESS,
+                MatchingStatus.COMPLETED
+        );
+    }
+
+    private static Optional<MatchingStatus> parseStatus(String status) {
+        if (!StringUtils.hasText(status)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(MatchingStatus.valueOf(status.trim().toUpperCase()));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<ProposalPosition> findPosition(Proposal proposal, Long proposalPositionId) {
+        if (proposal.getPositions() == null || proposal.getPositions().isEmpty()) {
+            return Optional.empty();
+        }
+        return proposal.getPositions().stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .findFirst();
+    }
+
+    private static ClientMatchingPositionItemViewModel toPositionItem(ProposalPosition position, Collection<Matching> matchings) {
+        long requestedCount = matchings.size();
+        long activeCount = matchings.stream()
+                .map(Matching::getStatus)
+                .filter(ACTIVE_STATUSES::contains)
+                .count();
+
+        return new ClientMatchingPositionItemViewModel(
+                position.getId(),
+                resolvePositionTitle(position),
+                position.getStatus(),
+                toPositionStatusLabel(position.getStatus()),
+                requestedCount,
+                activeCount
+        );
+    }
+
+    private ClientMatchingFreelancerItemViewModel toFreelancerItem(Matching matching) {
+        String freelancerName = matching.getFreelancerMember().getNickname() != null
+                && !matching.getFreelancerMember().getNickname().isBlank()
+                ? matching.getFreelancerMember().getNickname().trim()
+                : matching.getFreelancerMember().getName();
+
+        return new ClientMatchingFreelancerItemViewModel(
+                matching.getId(),
+                freelancerName,
+                matching.getStatus(),
+                matching.getStatus().getDescription(),
+                resolveRequestedAt(matching)
+        );
+    }
+
+    private static LocalDateTime resolveRequestedAt(Matching matching) {
+        if (matching.getRequestedAt() != null) {
+            return matching.getRequestedAt();
+        }
+        return matching.getCreatedAt();
+    }
+
+    private static Comparator<ProposalPosition> positionSortComparator() {
+        Map<ProposalPositionStatus, Integer> weight = Map.of(
+                ProposalPositionStatus.OPEN, 0,
+                ProposalPositionStatus.FULL, 1,
+                ProposalPositionStatus.CLOSED, 2
+        );
+        return Comparator
+                .comparing((ProposalPosition position) -> weight.getOrDefault(position.getStatus(), 99))
+                .thenComparing(ProposalPosition::getId);
+    }
+
+    private static Comparator<Matching> matchingSortComparator() {
+        Map<MatchingStatus, Integer> weight = Map.of(
+                MatchingStatus.PROPOSED, 0,
+                MatchingStatus.IN_PROGRESS, 1,
+                MatchingStatus.ACCEPTED, 2,
+                MatchingStatus.REJECTED, 3,
+                MatchingStatus.COMPLETED, 4,
+                MatchingStatus.CANCELED, 5
+        );
+        return Comparator
+                .comparing((Matching matching) -> weight.getOrDefault(matching.getStatus(), 99))
+                .thenComparing(Matching::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                .thenComparing(Matching::getId, Comparator.nullsLast(Comparator.reverseOrder()));
+    }
+
+    private static String resolvePositionTitle(ProposalPosition position) {
+        if (StringUtils.hasText(position.getTitle())) {
+            return position.getTitle().trim();
+        }
+        return position.getPosition().getName();
+    }
+
+    private static String toPositionStatusLabel(ProposalPositionStatus status) {
+        if (status == null) {
+            return "미정";
+        }
+        return switch (status) {
+            case OPEN -> "모집 중";
+            case FULL -> "모집 완료";
+            case CLOSED -> "모집 종료";
+        };
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/matching/ClientMatchingFreelancerItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/ClientMatchingFreelancerItemViewModel.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.dto.matching;
+
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import java.time.LocalDateTime;
+
+public record ClientMatchingFreelancerItemViewModel(
+        Long matchingId,
+        String freelancerName,
+        MatchingStatus status,
+        String statusLabel,
+        LocalDateTime requestedAt
+) {
+}
+

--- a/src/main/java/com/generic4/itda/dto/matching/ClientMatchingFreelancerSelectionViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/ClientMatchingFreelancerSelectionViewModel.java
@@ -1,0 +1,17 @@
+package com.generic4.itda.dto.matching;
+
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import java.util.List;
+
+public record ClientMatchingFreelancerSelectionViewModel(
+        Long proposalId,
+        String proposalTitle,
+        Long proposalPositionId,
+        String proposalPositionTitle,
+        String positionStatusLabel,
+        String filterStatusKey,
+        List<MatchingStatus> availableStatuses,
+        List<ClientMatchingFreelancerItemViewModel> items
+) {
+}
+

--- a/src/main/java/com/generic4/itda/dto/matching/ClientMatchingPositionItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/ClientMatchingPositionItemViewModel.java
@@ -1,0 +1,14 @@
+package com.generic4.itda.dto.matching;
+
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+
+public record ClientMatchingPositionItemViewModel(
+        Long proposalPositionId,
+        String title,
+        ProposalPositionStatus status,
+        String statusLabel,
+        long requestedCount,
+        long activeCount
+) {
+}
+

--- a/src/main/java/com/generic4/itda/dto/matching/ClientMatchingPositionSelectionViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/matching/ClientMatchingPositionSelectionViewModel.java
@@ -1,0 +1,12 @@
+package com.generic4.itda.dto.matching;
+
+import java.util.List;
+
+public record ClientMatchingPositionSelectionViewModel(
+        Long proposalId,
+        String proposalTitle,
+        boolean openOnly,
+        List<ClientMatchingPositionItemViewModel> positions
+) {
+}
+

--- a/src/main/java/com/generic4/itda/dto/matching/LatestMatchingSummary.java
+++ b/src/main/java/com/generic4/itda/dto/matching/LatestMatchingSummary.java
@@ -1,0 +1,10 @@
+package com.generic4.itda.dto.matching;
+
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+
+public record LatestMatchingSummary(
+        Long matchingId,
+        MatchingStatus status
+) {
+}
+

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationCandidateItem.java
@@ -16,6 +16,7 @@ public record RecommendationCandidateItem(
         String llmReason,
         String llmStatusLabel,
         boolean llmReady,
+        Long matchingId,
         /**
          * 현재 매칭 상태. null이면 매칭 요청이 없는 상태 (버튼 활성).
          * 값이 있으면 MatchingStatus.name() 문자열 (예: "PROPOSED", "ACCEPTED", ...).

--- a/src/main/java/com/generic4/itda/repository/MatchingRepository.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepository.java
@@ -5,6 +5,7 @@ import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,6 +28,12 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
 
     List<Matching> findByProposalPosition_Proposal_IdAndFreelancerMember_Email_Value(Long proposalId, String freelancerEmail);
 
+    @EntityGraph(attributePaths = {"proposalPosition"})
+    List<Matching> findByProposalPosition_Proposal_IdAndClientMember_Email_Value(Long proposalId, String clientEmail);
+
+    @EntityGraph(attributePaths = {"freelancerMember"})
+    List<Matching> findByProposalPosition_IdAndClientMember_Email_Value(Long proposalPositionId, String clientEmail);
+
     /**
      * 주어진 포지션에 대해 resume ID 목록에 해당하는 매칭 상태를 한 번에 조회한다.
      * 추천 결과 페이지에서 후보별 매칭 상태를 N+1 없이 표시하기 위해 사용한다.
@@ -35,6 +42,18 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     List<Matching> findByProposalPositionIdAndResumeIdIn(
             @Param("positionId") Long positionId,
             @Param("resumeIds") Collection<Long> resumeIds
+    );
+
+    @Query("""
+            select m
+            from Matching m
+            join fetch m.freelancerMember freelancerMember
+            where m.proposalPosition.id = :proposalPositionId
+              and m.clientMember.email.value = :clientEmail
+            """)
+    List<Matching> findWithFreelancerMemberByProposalPositionIdAndClientEmail(
+            @Param("proposalPositionId") Long proposalPositionId,
+            @Param("clientEmail") String clientEmail
     );
 
     @Query("""

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryCustom.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.generic4.itda.repository;
 
 import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.dto.matching.LatestMatchingSummary;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,4 +22,8 @@ public interface MatchingRepositoryCustom {
      * 단일 후보의 대표 매칭 상태를 조회한다(ACTIVE 우선, 없으면 최신).
      */
     Optional<MatchingStatus> getLatestMatchingStatus(Long proposalPositionId, Long resumeId);
+
+    Map<Long, LatestMatchingSummary> getLatestMatchingSummaryMap(Long proposalPositionId, Collection<Long> resumeIds);
+
+    Optional<LatestMatchingSummary> getLatestMatchingSummary(Long proposalPositionId, Long resumeId);
 }

--- a/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/generic4/itda/repository/MatchingRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.generic4.itda.domain.member.QMember;
 import com.generic4.itda.domain.proposal.QProposal;
 import com.generic4.itda.domain.proposal.QProposalPosition;
 import com.generic4.itda.dto.freelancer.FreelancerDashboardItem;
+import com.generic4.itda.dto.matching.LatestMatchingSummary;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -175,5 +176,79 @@ public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
                 .fetchFirst();
 
         return Optional.ofNullable(status);
+    }
+
+    @Override
+    public Map<Long, LatestMatchingSummary> getLatestMatchingSummaryMap(Long proposalPositionId, Collection<Long> resumeIds) {
+        if (proposalPositionId == null || resumeIds == null || resumeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        NumberExpression<Integer> activeFirst = new CaseBuilder()
+                .when(matching.status.in(ACTIVE_STATUSES)).then(0)
+                .otherwise(1);
+
+        List<com.querydsl.core.Tuple> rows = queryFactory
+                .select(matching.resume.id, matching.id, matching.status)
+                .from(matching)
+                .where(
+                        matching.proposalPosition.id.eq(proposalPositionId),
+                        matching.resume.id.in(resumeIds)
+                )
+                .orderBy(
+                        matching.resume.id.asc(),
+                        activeFirst.asc(),
+                        matching.createdAt.desc(),
+                        matching.id.desc()
+                )
+                .fetch();
+
+        Map<Long, LatestMatchingSummary> map = new LinkedHashMap<>();
+        for (com.querydsl.core.Tuple row : rows) {
+            Long resumeId = row.get(matching.resume.id);
+            Long matchingId = row.get(matching.id);
+            MatchingStatus status = row.get(matching.status);
+            if (resumeId != null && matchingId != null && status != null) {
+                map.putIfAbsent(resumeId, new LatestMatchingSummary(matchingId, status));
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public Optional<LatestMatchingSummary> getLatestMatchingSummary(Long proposalPositionId, Long resumeId) {
+        if (proposalPositionId == null || resumeId == null) {
+            return Optional.empty();
+        }
+
+        NumberExpression<Integer> activeFirst = new CaseBuilder()
+                .when(matching.status.in(ACTIVE_STATUSES)).then(0)
+                .otherwise(1);
+
+        com.querydsl.core.Tuple row = queryFactory
+                .select(matching.id, matching.status)
+                .from(matching)
+                .where(
+                        matching.proposalPosition.id.eq(proposalPositionId),
+                        matching.resume.id.eq(resumeId)
+                )
+                .orderBy(
+                        activeFirst.asc(),
+                        matching.createdAt.desc(),
+                        matching.id.desc()
+                )
+                .fetchFirst();
+
+        if (row == null) {
+            return Optional.empty();
+        }
+
+        Long matchingId = row.get(matching.id);
+        MatchingStatus status = row.get(matching.status);
+        if (matchingId == null || status == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new LatestMatchingSummary(matchingId, status));
     }
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -16,6 +16,7 @@ import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
+import com.generic4.itda.dto.matching.LatestMatchingSummary;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
@@ -70,11 +71,11 @@ public class RecommendationRunQueryService {
         List<Long> resumeIds = results.stream()
                 .map(r -> r.getResume().getId())
                 .toList();
-        Map<Long, MatchingStatus> matchingStatusMap = loadMatchingStatusMap(
+        Map<Long, LatestMatchingSummary> matchingSummaryMap = loadMatchingSummaryMap(
                 proposalPosition.getId(), resumeIds);
 
         List<RecommendationCandidateItem> candidates = results.stream()
-                .map(r -> toCandidateItem(r, matchingStatusMap.get(r.getResume().getId())))
+                .map(r -> toCandidateItem(r, matchingSummaryMap.get(r.getResume().getId())))
                 .toList();
 
         return new RecommendationResultsViewModel(
@@ -107,8 +108,8 @@ public class RecommendationRunQueryService {
         Resume resume = result.getResume();
 
         // 해당 후보의 매칭 상태 조회
-        MatchingStatus matchingStatus = matchingRepository
-                .getLatestMatchingStatus(proposalPosition.getId(), resume.getId())
+        LatestMatchingSummary matchingSummary = matchingRepository
+                .getLatestMatchingSummary(proposalPosition.getId(), resume.getId())
                 .orElse(null);
 
         return new RecommendationResumeDetailViewModel(
@@ -118,21 +119,21 @@ public class RecommendationRunQueryService {
                 proposal.getTitle(),
                 resolvePositionTitle(proposalPosition),
                 "/proposals/%d/recommendations/results?runId=%d".formatted(proposal.getId(), run.getId()),
-                toCandidateItem(result, matchingStatus),
+                toCandidateItem(result, matchingSummary),
                 resume.getPortfolioUrl(),
                 toSkillItems(resume.getSkills()),
                 toCareerItems(resume)
         );
     }
 
-    private Map<Long, MatchingStatus> loadMatchingStatusMap(Long positionId, Collection<Long> resumeIds) {
+    private Map<Long, LatestMatchingSummary> loadMatchingSummaryMap(Long positionId, Collection<Long> resumeIds) {
         if (resumeIds.isEmpty()) {
             return Map.of();
         }
-        return matchingRepository.getLatestMatchingStatusMap(positionId, resumeIds);
+        return matchingRepository.getLatestMatchingSummaryMap(positionId, resumeIds);
     }
 
-    private RecommendationCandidateItem toCandidateItem(RecommendationResult result, MatchingStatus matchingStatus) {
+    private RecommendationCandidateItem toCandidateItem(RecommendationResult result, LatestMatchingSummary matchingSummary) {
         Resume resume = result.getResume();
         Member member = resume.getMember();
         ReasonFacts facts = result.getReasonFacts();
@@ -164,6 +165,9 @@ public class RecommendationRunQueryService {
         List<String> highlights = facts != null && facts.highlights() != null
                 ? facts.highlights() : List.of();
 
+        MatchingStatus matchingStatus = matchingSummary != null ? matchingSummary.status() : null;
+        Long matchingId = matchingSummary != null ? matchingSummary.matchingId() : null;
+
         return new RecommendationCandidateItem(
                 result.getId(),
                 result.getRank(),
@@ -178,6 +182,7 @@ public class RecommendationRunQueryService {
                 result.getLlmReason(),
                 result.getLlmStatus().getDescription(),
                 result.getLlmStatus() == LlmStatus.READY,
+                matchingId,
                 matchingStatus != null ? matchingStatus.name() : null
         );
     }

--- a/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
+++ b/src/main/java/com/generic4/itda/service/recommend/reason/RecommendationReasonContext.java
@@ -22,9 +22,16 @@ public record RecommendationReasonContext(
 
         return new RecommendationReasonContext(
                 proposalPosition.getProposal().getTitle(),
-                proposalPosition.getTitle(),
+                resolvePositionTitle(proposalPosition),
                 result.getReasonFacts(),
                 result.getFinalScore()
         );
+    }
+
+    private static String resolvePositionTitle(ProposalPosition proposalPosition) {
+        if (proposalPosition.getTitle() != null && !proposalPosition.getTitle().isBlank()) {
+            return proposalPosition.getTitle();
+        }
+        return proposalPosition.getPosition().getName();
     }
 }

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -182,7 +182,7 @@
     </main>
 
     <!-- 공유 액션 메뉴 (position: fixed로 overflow-hidden 부모 탈출) -->
-    <div id="actionMenu" class="hidden fixed z-40 w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
+    <div id="actionMenu" class="hidden fixed z-[9999] w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
         <a id="menuDetail" href="#"
            class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
             <i data-lucide="file-text" class="h-4 w-4 text-slate-400"></i>제안서 상세 보기
@@ -194,6 +194,10 @@
         <a id="menuRecommend" href="#"
            class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
             <i data-lucide="sparkles" class="h-4 w-4 text-slate-400"></i>추천 결과 보기
+        </a>
+        <a id="menuMatching" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="activity" class="h-4 w-4 text-slate-400"></i>매칭 결과 보기
         </a>
         <div id="menuDeleteDivider" class="my-1 border-t border-slate-100"></div>
         <button id="menuDelete" type="button"
@@ -316,9 +320,15 @@
         var menuDetail    = document.getElementById('menuDetail');
         var menuEdit      = document.getElementById('menuEdit');
         var menuRecommend = document.getElementById('menuRecommend');
+        var menuMatching  = document.getElementById('menuMatching');
         var menuDeleteDiv = document.getElementById('menuDeleteDivider');
         var menuDelete    = document.getElementById('menuDelete');
         var menuOpen      = false;
+
+        // 레이아웃 컨테이너(overflow/transform)의 영향을 피하기 위해 body 아래로 이동
+        if (actionMenu && actionMenu.parentElement !== document.body) {
+            document.body.appendChild(actionMenu);
+        }
 
         function closeActionMenu() {
             if (!menuOpen) return;
@@ -335,12 +345,14 @@
             menuDetail.href    = '/proposals/' + proposalId;
             menuEdit.href      = '/proposals/' + proposalId + '/edit';
             menuRecommend.href = '/proposals/' + proposalId + '/recommendations';
+            menuMatching.href  = '/proposals/' + proposalId + '/matchings';
             menuDelete.dataset.proposalId    = proposalId;
             menuDelete.dataset.proposalTitle = proposalTitle;
 
             // 상태별 항목 표시/숨김
             menuEdit.classList.toggle('hidden', statusKey === 'COMPLETE');
             menuRecommend.classList.toggle('hidden', statusKey === 'WRITING');
+            menuMatching.classList.toggle('hidden', !(statusKey === 'MATCHING' || statusKey === 'COMPLETE'));
             var showDelete = statusKey === 'WRITING';
             menuDeleteDiv.classList.toggle('hidden', !showDelete);
             menuDelete.classList.toggle('hidden', !showDelete);

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -58,7 +58,13 @@
                                th:href="@{/proposals/{id}/recommendations(id=${proposal.id})}"
                                class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
                                 <i data-lucide="sparkles" class="h-4 w-4"></i>
-                                추천 결과 보기
+                                추천 받아 보기
+                            </a>
+                            <a th:if="${proposal.status.name() == 'MATCHING'}"
+                               th:href="@{/proposals/{id}/matchings(id=${proposal.id})}"
+                               class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                <i data-lucide="activity" class="h-4 w-4"></i>
+                                매칭 결과 보기
                             </a>
                             
                             <span th:if="${proposal.status.name() == 'COMPLETE'}"
@@ -66,6 +72,12 @@
                                 <i data-lucide="badge-check" class="h-4 w-4"></i>
                                 완료된 프로젝트
                             </span>
+                            <a th:if="${proposal.status.name() == 'COMPLETE'}"
+                               th:href="@{/proposals/{id}/matchings(id=${proposal.id})}"
+                               class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                <i data-lucide="activity" class="h-4 w-4"></i>
+                                매칭 결과 보기
+                            </a>
                         </th:block>
 
                          
@@ -131,7 +143,18 @@
                                                  거절하기
                                              </button>
                                          </form>
+                                         <a th:href="@{/matchings/{id}(id=${myMatching.id})}"
+                                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                             <i data-lucide="activity" class="h-4 w-4"></i>
+                                             매칭 결과 보기
+                                         </a>
                                      </th:block>
+                                     <a th:if="${myMatching != null and myMatching.status.name() != 'PROPOSED'}"
+                                        th:href="@{/matchings/{id}(id=${myMatching.id})}"
+                                        class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                                         <i data-lucide="activity" class="h-4 w-4"></i>
+                                         매칭 결과 보기
+                                     </a>
                                  </th:block>
 
                                  <th:block th:if="${#lists.size(proposedPositions) > 1}">
@@ -162,6 +185,10 @@
                                                                  거절
                                                              </button>
                                                          </form>
+                                                         <a th:href="@{/matchings/{id}(id=${myMatching.id})}"
+                                                            class="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3 py-2 text-xs font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                                                             결과 보기
+                                                         </a>
                                                      </div>
                                                  </div>
                                              </th:block>

--- a/src/main/resources/templates/freelancer/dashboard.html
+++ b/src/main/resources/templates/freelancer/dashboard.html
@@ -127,10 +127,14 @@
                         <span th:text="${#temporals.format(item.receivedAt(), 'yyyy.MM.dd')}">날짜</span>
                     </div>
                     <div class="flex justify-end">
-                        <a th:href="${item.detailPath()}"
-                           class="flex items-center gap-1 text-sm font-semibold text-blue-600 hover:text-blue-700 whitespace-nowrap">
-                            상세 보기<i data-lucide="chevron-right" class="w-4 h-4"></i>
-                        </a>
+                        <button type="button"
+                                th:attr="data-matching-id=${item.matchingId},
+                                         data-proposal-id=${item.proposalId},
+                                         data-proposal-position-id=${item.proposalPositionId},
+                                         data-dash-status=${item.status().name()}"
+                                class="menu-trigger inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-300 transition hover:bg-slate-100 hover:text-slate-500">
+                            <i data-lucide="ellipsis" class="w-4 h-4"></i>
+                        </button>
                     </div>
                 </div>
             </div>
@@ -139,6 +143,19 @@
     </div>
 </div>
 </main>
+
+    <!-- 공유 액션 메뉴 (position: fixed로 overflow-hidden 부모 탈출) -->
+    <div id="actionMenu" class="hidden fixed z-[9999] w-52 rounded-2xl border border-slate-200 bg-white py-2 shadow-lg shadow-slate-200/80">
+        <a id="menuDetail" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="file-text" class="h-4 w-4 text-slate-400"></i>제안서 보기
+        </a>
+        <a id="menuMatching" href="#"
+           class="flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+            <i data-lucide="activity" class="h-4 w-4 text-slate-400"></i>매칭 결과 보기
+        </a>
+    </div>
+
 </div>
 
 <th:block layout:fragment="scripts">
@@ -164,14 +181,87 @@
     var inp  = document.getElementById('searchInput');
     if (form) form.addEventListener('submit', function() { cur_query = inp ? inp.value.trim() : ''; loadList(cur_status, cur_query); });
 
+    // ── 공유 액션 메뉴 ──────────────────────────────────────
+    var actionMenu   = document.getElementById('actionMenu');
+    var menuDetail   = document.getElementById('menuDetail');
+    var menuMatching = document.getElementById('menuMatching');
+    var menuOpen     = false;
+
+    // body 아래로 이동해 overflow/transform 부모의 영향을 피함
+    if (actionMenu && actionMenu.parentElement !== document.body) {
+        document.body.appendChild(actionMenu);
+    }
+
+    function closeActionMenu() {
+        if (!menuOpen) return;
+        actionMenu.classList.add('hidden');
+        menuOpen = false;
+    }
+
+    function openActionMenu(trigger) {
+        var matchingId         = trigger.dataset.matchingId;
+        var proposalId         = trigger.dataset.proposalId;
+        var proposalPositionId = trigger.dataset.proposalPositionId;
+        var dashStatus         = trigger.dataset.dashStatus; // NEW | IN_PROGRESS | COMPLETED
+
+        // "제안서 보기" — NEW 상태는 positionId 쿼리 포함
+        menuDetail.href = (proposalPositionId && dashStatus === 'NEW')
+            ? '/proposals/' + proposalId + '?proposalPositionId=' + proposalPositionId
+            : '/proposals/' + proposalId;
+
+        // "매칭 결과 보기" — 수락 이후 상태(IN_PROGRESS, COMPLETED)에서만 노출
+        var showMatching = (dashStatus === 'IN_PROGRESS' || dashStatus === 'COMPLETED') && matchingId;
+        menuMatching.classList.toggle('hidden', !showMatching);
+        if (showMatching) {
+            menuMatching.href = '/matchings/' + matchingId;
+        }
+
+        // 버튼 기준 위치 계산 (fixed)
+        actionMenu.classList.remove('hidden');
+        if (window.lucide) lucide.createIcons();
+
+        var rect       = trigger.getBoundingClientRect();
+        var menuHeight = actionMenu.offsetHeight;
+        var spaceBelow = window.innerHeight - rect.bottom;
+
+        actionMenu.style.left  = 'auto';
+        actionMenu.style.right = (window.innerWidth - rect.right) + 'px';
+
+        if (spaceBelow < menuHeight + 8) {
+            actionMenu.style.top    = 'auto';
+            actionMenu.style.bottom = (window.innerHeight - rect.top + 4) + 'px';
+        } else {
+            actionMenu.style.bottom = 'auto';
+            actionMenu.style.top    = (rect.bottom + 4) + 'px';
+        }
+
+        menuOpen = true;
+    }
+
+    // 스크롤 시 메뉴 닫기
+    window.addEventListener('scroll', closeActionMenu, true);
+
     // Row click navigation (works for both initial render and AJAX-replaced list).
     document.addEventListener('click', function (e) {
+        // ... 메뉴 트리거
+        var trigger = e.target.closest('.menu-trigger');
+        if (trigger) {
+            e.stopPropagation();
+            if (menuOpen) { closeActionMenu(); return; }
+            openActionMenu(trigger);
+            return;
+        }
+
+        // 액션 메뉴 내부 클릭은 그대로 통과
+        if (actionMenu && actionMenu.contains(e.target)) return;
+
+        // 외부 클릭 시 메뉴 닫기
+        if (menuOpen) { closeActionMenu(); return; }
+
+        // 행 클릭 → detailPath 이동
         var row = e.target.closest('#listSection [data-href]');
         if (!row) return;
-
-        // Let explicit interactive elements handle their own clicks.
         if (e.target.closest('a, button, input, select, textarea, label')) return;
-
         var href = row.dataset.href;
         if (href) window.location.href = href;
     });

--- a/src/main/resources/templates/matching/freelancers.html
+++ b/src/main/resources/templates/matching/freelancers.html
@@ -1,0 +1,101 @@
+﻿<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${view.proposalTitle + ' | 매칭 결과'}">매칭 결과 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-5xl space-y-6">
+
+            <div class="sticky top-0 z-10 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div class="flex items-center gap-4">
+                        <a th:href="@{/proposals/{proposalId}/matchings(proposalId=${view.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            포지션 선택
+                        </a>
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING ENTRY</p>
+                            <h1 class="mt-1 text-2xl font-black tracking-tight text-slate-950"
+                                th:text="${view.proposalPositionTitle}">포지션명</h1>
+                            <p class="mt-1 text-sm text-slate-500">
+                                <span th:text="${view.positionStatusLabel}">모집 중</span> · 매칭 요청을 보낸 프리랜서를 선택하세요.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-2">
+                        <a th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${view.proposalPositionId})}"
+                           th:classappend="${view.filterStatusKey == ''} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            전체보기
+                        </a>
+                        <a th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${view.proposalPositionId}, status='PROPOSED')}"
+                           th:classappend="${view.filterStatusKey == 'PROPOSED'} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            제안됨
+                        </a>
+                        <a th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${view.proposalPositionId}, status='ACCEPTED')}"
+                           th:classappend="${view.filterStatusKey == 'ACCEPTED'} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            수락됨
+                        </a>
+                        <a th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${view.proposalPositionId}, status='IN_PROGRESS')}"
+                           th:classappend="${view.filterStatusKey == 'IN_PROGRESS'} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            협의 중
+                        </a>
+                        <a th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${view.proposalPositionId}, status='COMPLETED')}"
+                           th:classappend="${view.filterStatusKey == 'COMPLETED'} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            완료됨
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <section th:if="${view.items.isEmpty()}"
+                     class="rounded-[28px] border border-slate-200 bg-white px-6 py-16 text-center shadow-sm shadow-slate-200/70">
+                <i data-lucide="user-x" class="mx-auto h-12 w-12 text-slate-300"></i>
+                <p class="mt-4 text-base font-bold text-slate-600">표시할 매칭 요청이 없습니다.</p>
+                <p class="mt-1 text-sm text-slate-400">필터를 변경하거나 다른 포지션을 선택해 보세요.</p>
+            </section>
+
+            <section th:if="${!view.items.isEmpty()}"
+                     class="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70">
+                <div class="hidden md:grid grid-cols-[minmax(0,2fr)_1fr_1fr_80px] gap-4 px-6 py-3 border-b border-slate-100 text-xs font-bold text-slate-400 uppercase tracking-wide">
+                    <span>프리랜서</span><span>상태</span><span>요청일</span><span></span>
+                </div>
+                <div class="divide-y divide-slate-100">
+                    <a th:each="item : ${view.items}"
+                       th:href="@{/matchings/{id}(id=${item.matchingId})}"
+                       class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_1fr_1fr_80px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors">
+                        <div class="space-y-1">
+                            <p class="text-sm font-bold text-slate-900" th:text="${item.freelancerName}">프리랜서</p>
+                            <p class="text-xs text-slate-500" th:text="${view.proposalTitle}">제안서</p>
+                        </div>
+                        <div>
+                            <span class="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-700"
+                                  th:text="${item.statusLabel}">상태</span>
+                        </div>
+                        <div class="flex items-center gap-1.5 text-sm text-slate-500">
+                            <i data-lucide="calendar" class="h-4 w-4 text-slate-400 hidden md:block"></i>
+                            <span th:text="${item.requestedAt != null ? #temporals.format(item.requestedAt, 'yyyy.MM.dd') : '-'}">날짜</span>
+                        </div>
+                        <div class="flex justify-end">
+                            <span class="flex items-center gap-1 text-sm font-semibold text-blue-600 hover:text-blue-700 whitespace-nowrap">
+                                보기<i data-lucide="chevron-right" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                    </a>
+                </div>
+            </section>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/matching/positions.html
+++ b/src/main/resources/templates/matching/positions.html
@@ -1,0 +1,83 @@
+﻿<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title th:text="${view.proposalTitle + ' | 매칭 결과'}">매칭 결과 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+        <div class="mx-auto max-w-5xl space-y-6">
+
+            <div class="sticky top-0 z-10 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div class="flex items-center gap-4">
+                        <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                           class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                            <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                            제안서로
+                        </a>
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING ENTRY</p>
+                            <h1 class="mt-1 text-2xl font-black tracking-tight text-slate-950"
+                                th:text="${view.proposalTitle}">제안서 제목</h1>
+                            <p class="mt-1 text-sm text-slate-500">매칭 요청을 보낸 포지션을 선택하세요.</p>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-2">
+                        <a th:href="@{/proposals/{id}/matchings(id=${view.proposalId})}"
+                           th:classappend="${!view.openOnly} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            전체보기
+                        </a>
+                        <a th:href="@{/proposals/{id}/matchings(id=${view.proposalId}, openOnly=true)}"
+                           th:classappend="${view.openOnly} ? 'bg-blue-600 text-white shadow-lg shadow-blue-100' : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50'"
+                           class="inline-flex items-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-bold transition">
+                            모집중만
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <section th:if="${view.positions.isEmpty()}"
+                     class="rounded-[28px] border border-slate-200 bg-white px-6 py-16 text-center shadow-sm shadow-slate-200/70">
+                <i data-lucide="inbox" class="mx-auto h-12 w-12 text-slate-300"></i>
+                <p class="mt-4 text-base font-bold text-slate-600">표시할 포지션이 없습니다.</p>
+                <p class="mt-1 text-sm text-slate-400">모집중만 보기 상태라면 전체보기로 전환해 보세요.</p>
+            </section>
+
+            <section th:if="${!view.positions.isEmpty()}" class="grid gap-4 md:grid-cols-2">
+                <a th:each="pos : ${view.positions}"
+                   th:href="@{/proposals/{proposalId}/matchings/positions/{positionId}(proposalId=${view.proposalId}, positionId=${pos.proposalPositionId})}"
+                   class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/70 transition hover:-translate-y-0.5 hover:border-slate-300">
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <p class="text-xs font-black uppercase tracking-widest text-slate-400"
+                               th:text="${pos.status.name()}">OPEN</p>
+                            <h2 class="mt-2 text-lg font-black tracking-tight text-slate-950" th:text="${pos.title}">포지션명</h2>
+                            <p class="mt-1 text-sm font-semibold text-slate-500" th:text="${pos.statusLabel}">모집 중</p>
+                        </div>
+                        <span class="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-600">
+                            <span th:text="${pos.requestedCount}">0</span>건 요청
+                        </span>
+                    </div>
+
+                    <div class="mt-5 grid grid-cols-2 gap-3">
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                            <p class="text-xs font-semibold text-slate-400">요청 보낸 프리랜서</p>
+                            <p class="mt-1 text-xl font-black text-slate-900" th:text="${pos.requestedCount}">0</p>
+                        </div>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                            <p class="text-xs font-semibold text-slate-400">진행중</p>
+                            <p class="mt-1 text-xl font-black text-slate-900" th:text="${pos.activeCount}">0</p>
+                        </div>
+                    </div>
+                </a>
+            </section>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -135,13 +135,14 @@
                                     </div>
 
                                     <!-- 점수 -->
-                                    <div class="shrink-0 text-right">
-                                        <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
-                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
-                                           class="text-2xl font-black tracking-tight"
-                                           th:text="${candidate.finalScorePercent + '%'}">98%</p>
-                                        <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
-                                    </div>
+                                     <div class="shrink-0 text-right">
+                                         <p th:with="score=${candidate.finalScorePercent}"
+                                            th:classappend="${score != null and score >= 80} ? 'text-blue-600' :
+                                                             (${score != null and score >= 60} ? 'text-indigo-500' : 'text-slate-500')"
+                                            class="text-2xl font-black tracking-tight"
+                                            th:text="${score != null ? score + '%' : '-'}">98%</p>
+                                         <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
+                                     </div>
                                 </div>
 
                                 <!-- ── AI 추천 사유 ── -->
@@ -233,92 +234,6 @@
                             </div>
 
                         </article>
-                    </div>
-                  </div>
-
-                  <!-- 점수 -->
-                  <div class="shrink-0 text-right">
-                    <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
-                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
-                       class="text-2xl font-black tracking-tight"
-                       th:text="${candidate.finalScorePercent + '%'}">98%</p>
-                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
-                  </div>
-                </div>
-
-                <!-- ── AI 추천 사유 ── -->
-                <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
-                  <div class="mb-1.5 flex items-center gap-1.5">
-                    <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
-                    <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
-                  </div>
-                  <p th:if="${candidate.llmReady and candidate.llmReason != null}"
-                     class="text-sm leading-relaxed text-slate-700"
-                     th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
-                  <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
-                     class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
-                </div>
-
-                <div
-                    class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
-                  <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
-                  이력서 및 상세 정보 보기
-                  <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
-                </div>
-              </a>
-
-              <!-- ── 매칭 액션 영역 ── -->
-              <div class="border-t border-slate-100 px-5 py-4">
-
-                <!-- 매칭 없음: 요청 버튼 -->
-                <th:block th:if="${candidate.matchingStatus == null}">
-                  <form
-                      th:action="@{/recommendation-results/{recommendationResultId}/matchings(recommendationResultId=${candidate.resultId})}"
-                      method="post">
-                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                    <input type="hidden" name="redirectTo"
-                           th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
-                    <input type="hidden" name="errorRedirectTo"
-                           th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
-                    <button type="submit"
-                            class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
-                      <i data-lucide="send" class="h-4 w-4"></i>
-                      매칭 요청하기
-                    </button>
-                  </form>
-                </th:block>
-
-                <!-- 수락 대기 중 (PROPOSED) -->
-                <div th:if="${candidate.matchingStatus == 'PROPOSED'}"
-                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
-                  <i data-lucide="clock" class="h-4 w-4"></i>
-                  수락 대기 중
-                </div>
-
-                <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
-                <div th:if="${candidate.matchingStatus == 'ACCEPTED' or candidate.matchingStatus == 'IN_PROGRESS'}"
-                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
-                  <i data-lucide="check-circle" class="h-4 w-4"></i>
-                  매칭 진행 중
-                </div>
-
-                <!-- 거절됨 (REJECTED) -->
-                <div th:if="${candidate.matchingStatus == 'REJECTED'}"
-                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                  <i data-lucide="x-circle" class="h-4 w-4"></i>
-                  거절됨
-                </div>
-
-                <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
-                <div th:if="${candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'}"
-                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                  <i data-lucide="archive" class="h-4 w-4"></i>
-                  <span th:text="${candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
-                </div>
-
-              </div>
-
-            </article>
           </div>
         </section>
 

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -130,7 +130,109 @@
                                                 <span th:each="skill : ${candidate.matchedSkills}"
                                                       class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
                                                       th:text="${skill}">Java</span>
-                      </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 점수 -->
+                                    <div class="shrink-0 text-right">
+                                        <p th:classappend="${candidate.finalScorePercent >= 80} ? 'text-blue-600' :
+                                                            (${candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-500')"
+                                           class="text-2xl font-black tracking-tight"
+                                           th:text="${candidate.finalScorePercent + '%'}">98%</p>
+                                        <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">MATCH SCORE</p>
+                                    </div>
+                                </div>
+
+                                <!-- ── AI 추천 사유 ── -->
+                                <div class="mx-5 mb-3 rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+                                    <div class="mb-1.5 flex items-center gap-1.5">
+                                        <i data-lucide="sparkles" class="h-3.5 w-3.5 text-blue-400"></i>
+                                        <p class="text-[11px] font-bold uppercase tracking-widest text-slate-400">AI 추천 사유</p>
+                                    </div>
+                                    <p th:if="${candidate.llmReady and candidate.llmReason != null}"
+                                       class="text-sm leading-relaxed text-slate-700"
+                                       th:text="${candidate.llmReason}">AI 추천 사유 내용</p>
+                                    <p th:unless="${candidate.llmReady and candidate.llmReason != null}"
+                                       class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
+                                </div>
+
+                                <div class="mx-5 mb-4 flex items-center justify-center gap-1.5 rounded-xl bg-slate-50 py-2.5 text-xs font-semibold text-slate-500">
+                                    <i data-lucide="file-search" class="h-3.5 w-3.5"></i>
+                                    이력서 및 상세 정보 보기
+                                    <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+                                </div>
+                            </a>
+
+                            <!-- ── 매칭 액션 영역 ── -->
+                            <div class="border-t border-slate-100 px-5 py-4">
+
+                                <!-- 매칭 없음: 요청 버튼 -->
+                                <th:block th:if="${candidate.matchingStatus == null}">
+                                    <form th:action="@{/recommendation-results/{recommendationResultId}/matchings(recommendationResultId=${candidate.resultId})}"
+                                          method="post">
+                                        <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                                        <input type="hidden" name="redirectTo"
+                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                        <input type="hidden" name="errorRedirectTo"
+                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                        <button type="submit"
+                                                class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
+                                            <i data-lucide="send" class="h-4 w-4"></i>
+                                            매칭 요청하기
+                                        </button>
+                                    </form>
+                                </th:block>
+
+                                <!-- 수락 대기 중(PROPOSED) -->
+                                <th:block th:if="${candidate.matchingStatus == 'PROPOSED'}">
+                                    <a th:if="${candidate.matchingId != null}"
+                                       th:href="@{/matchings/{id}(id=${candidate.matchingId})}"
+                                       class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700 transition hover:bg-amber-100">
+                                        <i data-lucide="clock" class="h-4 w-4"></i>
+                                        수락 대기 중
+                                        <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
+                                    </a>
+                                    <div th:unless="${candidate.matchingId != null}"
+                                         class="flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
+                                        <i data-lucide="clock" class="h-4 w-4"></i>
+                                        수락 대기 중
+                                    </div>
+                                </th:block>
+
+                                <!-- 매칭 진행 중(ACCEPTED / IN_PROGRESS) -->
+                                <th:block th:if="${candidate.matchingStatus == 'ACCEPTED' or candidate.matchingStatus == 'IN_PROGRESS'}">
+                                    <a th:if="${candidate.matchingId != null}"
+                                       th:href="@{/matchings/{id}(id=${candidate.matchingId})}"
+                                       class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700 transition hover:bg-emerald-100">
+                                        <i data-lucide="check-circle" class="h-4 w-4"></i>
+                                        매칭 진행 중
+                                        <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
+                                    </a>
+                                    <div th:unless="${candidate.matchingId != null}"
+                                         class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
+                                        <i data-lucide="check-circle" class="h-4 w-4"></i>
+                                        매칭 진행 중
+                                    </div>
+                                </th:block>
+
+                                <!-- 거절됨 (REJECTED) -->
+                                <div th:if="${candidate.matchingStatus == 'REJECTED'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                                    <i data-lucide="x-circle" class="h-4 w-4"></i>
+                                    거절됨
+                                </div>
+
+                                <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
+                                <div th:if="${candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'}"
+                                     class="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
+                                    <i data-lucide="archive" class="h-4 w-4"></i>
+                                    <span th:text="${candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
+                                </div>
+
+                            </div>
+
+                        </article>
                     </div>
                   </div>
 

--- a/src/main/resources/templates/recommendation/resume.html
+++ b/src/main/resources/templates/recommendation/resume.html
@@ -90,6 +90,8 @@
                                 <input type="hidden" name="_csrf" th:value="${_csrf.token}">
                                 <input type="hidden" name="redirectTo"
                                        th:value="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${view.resultId})}">
+                                <input type="hidden" name="errorRedirectTo"
+                                       th:value="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${view.resultId})}">
                                 <button type="submit"
                                         class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
                                     <i data-lucide="send" class="h-4 w-4"></i>

--- a/src/main/resources/templates/recommendation/resume.html
+++ b/src/main/resources/templates/recommendation/resume.html
@@ -41,7 +41,7 @@
         <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
             <div class="grid gap-6 lg:grid-cols-5">
 
-                <!-- 좌측: 후보 요약 + 사유 -->
+                <!-- 좌측: 후보 요약/사유/강점 -->
                 <section class="lg:col-span-2 space-y-6">
                     <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
                         <div class="flex items-center justify-between">
@@ -98,20 +98,38 @@
                             </form>
                         </th:block>
 
-                        <!-- 수락 대기 중 (PROPOSED) -->
-                        <div th:if="${view.candidate.matchingStatus == 'PROPOSED'}"
-                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
-                            <i data-lucide="clock" class="h-4 w-4"></i>
-                            수락 대기 중
-                        </div>
+                        <!-- 수락 대기 중(PROPOSED) -->
+                        <th:block th:if="${view.candidate.matchingStatus == 'PROPOSED'}">
+                            <a th:if="${view.candidate.matchingId != null}"
+                               th:href="@{/matchings/{id}(id=${view.candidate.matchingId})}"
+                               class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700 transition hover:bg-amber-100">
+                                <i data-lucide="clock" class="h-4 w-4"></i>
+                                수락 대기 중
+                                <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
+                            </a>
+                            <div th:unless="${view.candidate.matchingId != null}"
+                                 class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
+                                <i data-lucide="clock" class="h-4 w-4"></i>
+                                수락 대기 중
+                            </div>
+                        </th:block>
 
-                        <!-- 매칭 진행 중 (ACCEPTED / IN_PROGRESS) -->
-                        <div th:if="${view.candidate.matchingStatus == 'ACCEPTED' or view.candidate.matchingStatus == 'IN_PROGRESS'}"
-                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
-                            <i data-lucide="check-circle" class="h-4 w-4"></i>
-                            매칭 진행 중
-                            <!-- TODO : 매칭 결과 페이지로 연결 하면 좋을듯 합니다-->
-                        </div>
+                        <!-- 매칭 진행 중(ACCEPTED / IN_PROGRESS) -->
+                        <th:block th:if="${view.candidate.matchingStatus == 'ACCEPTED' or view.candidate.matchingStatus == 'IN_PROGRESS'}">
+                            <a th:if="${view.candidate.matchingId != null}"
+                               th:href="@{/matchings/{id}(id=${view.candidate.matchingId})}"
+                               class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700 transition hover:bg-emerald-100">
+                                <i data-lucide="check-circle" class="h-4 w-4"></i>
+                                매칭 진행 중
+                                <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
+                            </a>
+                            <div th:unless="${view.candidate.matchingId != null}"
+                                 class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
+                                <i data-lucide="check-circle" class="h-4 w-4"></i>
+                                매칭 진행 중
+                            </div>
+                        </th:block>
+
 
                         <!-- 거절됨 (REJECTED) -->
                         <div th:if="${view.candidate.matchingStatus == 'REJECTED'}"
@@ -135,7 +153,7 @@
                         </div>
                         <p th:if="${view.candidate.llmReady and view.candidate.llmReason != null}"
                            class="text-sm leading-relaxed text-slate-700"
-                           th:text="${view.candidate.llmReason}">사유</p>
+                           th:text="${view.candidate.llmReason}">AI 추천 사유 내용</p>
                         <p th:unless="${view.candidate.llmReady and view.candidate.llmReason != null}"
                            class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
                     </article>

--- a/src/test/java/com/generic4/itda/controller/MatchingEntryControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingEntryControllerTest.java
@@ -1,0 +1,318 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.exception.ProposalNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.dto.matching.ClientMatchingFreelancerSelectionViewModel;
+import com.generic4.itda.dto.matching.ClientMatchingPositionSelectionViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.ProposalService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ControllerTest(MatchingEntryController.class)
+class MatchingEntryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProposalService proposalService;
+
+    @MockitoBean
+    private MatchingRepository matchingRepository;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    void selectPosition_rendersPositionsSortedAndCounts() throws Exception {
+        Proposal proposal = createProposalWithThreePositions();
+        given(proposalService.findOwnedProposal(10L, "client@example.com"))
+                .willReturn(proposal);
+
+        List<Matching> matchings = createMatchingsForPositions(proposal);
+        given(matchingRepository.findByProposalPosition_Proposal_IdAndClientMember_Email_Value(10L, "client@example.com"))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/10/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/positions"))
+                .andReturn();
+
+        ClientMatchingPositionSelectionViewModel viewModel = (ClientMatchingPositionSelectionViewModel)
+                result.getModelAndView().getModel().get("view");
+
+        assertThat(viewModel.proposalId()).isEqualTo(10L);
+        assertThat(viewModel.openOnly()).isFalse();
+        assertThat(viewModel.positions()).hasSize(3);
+
+        // 정렬: OPEN -> FULL -> CLOSED
+        assertThat(viewModel.positions().get(0).status()).isEqualTo(ProposalPositionStatus.OPEN);
+        assertThat(viewModel.positions().get(1).status()).isEqualTo(ProposalPositionStatus.FULL);
+        assertThat(viewModel.positions().get(2).status()).isEqualTo(ProposalPositionStatus.CLOSED);
+
+        // 카운트: pos1(OPEN) = 2요청, 1활성 / pos2(FULL)=1요청, 1활성 / pos3(CLOSED)=0
+        assertThat(viewModel.positions().get(0).requestedCount()).isEqualTo(2);
+        assertThat(viewModel.positions().get(0).activeCount()).isEqualTo(1);
+        assertThat(viewModel.positions().get(1).requestedCount()).isEqualTo(1);
+        assertThat(viewModel.positions().get(1).activeCount()).isEqualTo(1);
+        assertThat(viewModel.positions().get(2).requestedCount()).isZero();
+        assertThat(viewModel.positions().get(2).activeCount()).isZero();
+    }
+
+    @Test
+    void selectPosition_openOnly_filtersOpen() throws Exception {
+        Proposal proposal = createProposalWithThreePositions();
+        given(proposalService.findOwnedProposal(10L, "client@example.com"))
+                .willReturn(proposal);
+
+        List<Matching> matchings = createMatchingsForPositions(proposal);
+        given(matchingRepository.findByProposalPosition_Proposal_IdAndClientMember_Email_Value(10L, "client@example.com"))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/10/matchings")
+                        .param("openOnly", "true")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/positions"))
+                .andReturn();
+
+        ClientMatchingPositionSelectionViewModel viewModel = (ClientMatchingPositionSelectionViewModel)
+                result.getModelAndView().getModel().get("view");
+
+        assertThat(viewModel.openOnly()).isTrue();
+        assertThat(viewModel.positions()).hasSize(1);
+        assertThat(viewModel.positions().get(0).status()).isEqualTo(ProposalPositionStatus.OPEN);
+    }
+
+    @Test
+    void selectFreelancer_rendersFreelancersSortedAndFilterable() throws Exception {
+        Proposal proposal = createProposalWithSinglePosition();
+        given(proposalService.findOwnedProposal(10L, "client@example.com"))
+                .willReturn(proposal);
+
+        List<Matching> matchings = List.of(
+                createMatching(101L, MatchingStatus.REJECTED, "프리랜서A", LocalDateTime.of(2026, 4, 22, 10, 0)),
+                createMatching(103L, MatchingStatus.IN_PROGRESS, "프리랜서B", LocalDateTime.of(2026, 4, 22, 12, 0)),
+                createMatching(102L, MatchingStatus.PROPOSED, "프리랜서C", LocalDateTime.of(2026, 4, 22, 11, 0))
+        );
+        given(matchingRepository.findWithFreelancerMemberByProposalPositionIdAndClientEmail(1L, "client@example.com"))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/10/matchings/positions/1")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/freelancers"))
+                .andReturn();
+
+        ClientMatchingFreelancerSelectionViewModel viewModel = (ClientMatchingFreelancerSelectionViewModel)
+                result.getModelAndView().getModel().get("view");
+
+        assertThat(viewModel.proposalId()).isEqualTo(10L);
+        assertThat(viewModel.proposalPositionId()).isEqualTo(1L);
+        assertThat(viewModel.items()).hasSize(3);
+
+        // 정렬: PROPOSED -> IN_PROGRESS -> REJECTED
+        assertThat(viewModel.items().get(0).status()).isEqualTo(MatchingStatus.PROPOSED);
+        assertThat(viewModel.items().get(1).status()).isEqualTo(MatchingStatus.IN_PROGRESS);
+        assertThat(viewModel.items().get(2).status()).isEqualTo(MatchingStatus.REJECTED);
+
+        MvcResult filtered = mockMvc.perform(get("/proposals/10/matchings/positions/1")
+                        .param("status", "IN_PROGRESS")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        ClientMatchingFreelancerSelectionViewModel filteredView = (ClientMatchingFreelancerSelectionViewModel)
+                filtered.getModelAndView().getModel().get("view");
+
+        assertThat(filteredView.filterStatusKey()).isEqualTo("IN_PROGRESS");
+        assertThat(filteredView.items()).hasSize(1);
+        assertThat(filteredView.items().get(0).matchingId()).isEqualTo(103L);
+    }
+
+    // ── 포지션 선택: 권한/미존재 케이스 ────────────────────────
+
+    @Test
+    void selectPosition_proposalNotFound_redirectsToDashboard() throws Exception {
+        given(proposalService.findOwnedProposal(99L, "client@example.com"))
+                .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다."));
+
+        mockMvc.perform(get("/proposals/99/matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 제안서입니다."));
+    }
+
+    @Test
+    void selectPosition_accessDenied_redirectsToDashboard() throws Exception {
+        given(proposalService.findOwnedProposal(10L, "other@example.com"))
+                .willThrow(new AccessDeniedException("접근 불가"));
+
+        mockMvc.perform(get("/proposals/10/matchings")
+                        .with(authentication(authToken("other@example.com", "타인"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "본인 제안서만 조회할 수 있습니다."));
+    }
+
+    // ── 프리랜서 선택: 권한/미존재 케이스 ───────────────────────
+
+    @Test
+    void selectFreelancer_proposalNotFound_redirectsToDashboard() throws Exception {
+        given(proposalService.findOwnedProposal(99L, "client@example.com"))
+                .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다."));
+
+        mockMvc.perform(get("/proposals/99/matchings/positions/1")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 제안서입니다."));
+    }
+
+    @Test
+    void selectFreelancer_accessDenied_redirectsToDashboard() throws Exception {
+        given(proposalService.findOwnedProposal(10L, "other@example.com"))
+                .willThrow(new AccessDeniedException("접근 불가"));
+
+        mockMvc.perform(get("/proposals/10/matchings/positions/1")
+                        .with(authentication(authToken("other@example.com", "타인"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/client/dashboard"))
+                .andExpect(flash().attribute("errorMessage", "본인 제안서만 조회할 수 있습니다."));
+    }
+
+    @Test
+    void selectFreelancer_invalidPositionId_redirectsToPositionList() throws Exception {
+        Proposal proposal = createProposalWithSinglePosition(); // positionId=1만 있음
+        given(proposalService.findOwnedProposal(10L, "client@example.com"))
+                .willReturn(proposal);
+        // proposalPositionId=999 는 proposal 안에 없으므로 repository 호출 없이 예외 발생
+
+        mockMvc.perform(get("/proposals/10/matchings/positions/999")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/10/matchings"))
+                .andExpect(flash().attribute("errorMessage", "잘못된 포지션입니다."));
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(String email, String name) {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember(email, "hashed-password", name, "010-1234-5678")
+        );
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private Proposal createProposalWithThreePositions() {
+        Member client = createMember("client@example.com", "pw", "클라이언트", "010-0000-0001");
+        Proposal proposal = Proposal.create(client, "테스트 제안서", "", "설명", null, null, 8L);
+        proposal.startMatching();
+        ReflectionTestUtils.setField(proposal, "id", 10L);
+
+        Position backend = Position.create("백엔드");
+        Position frontend = Position.create("프론트엔드");
+        Position design = Position.create("디자인");
+
+        ProposalPosition pos1 = proposal.addPosition(backend, "백엔드", ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, null, null, null);
+        ProposalPosition pos2 = proposal.addPosition(frontend, "프론트엔드", ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, null, null, null);
+        ProposalPosition pos3 = proposal.addPosition(design, "디자인", ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, null, null, null);
+
+        ReflectionTestUtils.setField(pos1, "id", 1L);
+        ReflectionTestUtils.setField(pos2, "id", 2L);
+        ReflectionTestUtils.setField(pos3, "id", 3L);
+
+        pos2.changeStatus(ProposalPositionStatus.FULL);
+        pos3.changeStatus(ProposalPositionStatus.CLOSED);
+        return proposal;
+    }
+
+    private Proposal createProposalWithSinglePosition() {
+        Member client = createMember("client@example.com", "pw", "클라이언트", "010-0000-0001");
+        Proposal proposal = Proposal.create(client, "테스트 제안서", "", "설명", null, null, 8L);
+        proposal.startMatching();
+        ReflectionTestUtils.setField(proposal, "id", 10L);
+
+        Position backend = Position.create("백엔드");
+        ProposalPosition pos1 = proposal.addPosition(backend, "백엔드", ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, null, null, null);
+        ReflectionTestUtils.setField(pos1, "id", 1L);
+        return proposal;
+    }
+
+    private List<Matching> createMatchingsForPositions(Proposal proposal) {
+        Member client = proposal.getMember();
+        ProposalPosition pos1 = proposal.getPositions().stream().filter(p -> p.getId().equals(1L)).findFirst().orElseThrow();
+        ProposalPosition pos2 = proposal.getPositions().stream().filter(p -> p.getId().equals(2L)).findFirst().orElseThrow();
+
+        Matching openActive = Matching.create(null, pos1, client,
+                createMember("freelancer1@example.com", "pw", "프리랜서1", "010-0000-0002"));
+        ReflectionTestUtils.setField(openActive, "id", 11L);
+        ReflectionTestUtils.setField(openActive, "status", MatchingStatus.PROPOSED);
+
+        Matching openInactive = Matching.create(null, pos1, client,
+                createMember("freelancer2@example.com", "pw", "프리랜서2", "010-0000-0003"));
+        ReflectionTestUtils.setField(openInactive, "id", 12L);
+        ReflectionTestUtils.setField(openInactive, "status", MatchingStatus.REJECTED);
+
+        Matching fullActive = Matching.create(null, pos2, client,
+                createMember("freelancer3@example.com", "pw", "프리랜서3", "010-0000-0004"));
+        ReflectionTestUtils.setField(fullActive, "id", 21L);
+        ReflectionTestUtils.setField(fullActive, "status", MatchingStatus.ACCEPTED);
+
+        return List.of(openActive, openInactive, fullActive);
+    }
+
+    private Matching createMatching(Long matchingId, MatchingStatus status, String freelancerName, LocalDateTime createdAt) {
+        Member client = createMember("client@example.com", "pw", "클라이언트", "010-0000-0001");
+        Member freelancer = createMember("freelancer+" + matchingId + "@example.com", "pw", freelancerName, "010-0000-0002");
+
+        Proposal proposal = Proposal.create(client, "테스트 제안서", "", "설명", null, null, 8L);
+        proposal.startMatching();
+        ReflectionTestUtils.setField(proposal, "id", 10L);
+
+        Position backend = Position.create("백엔드");
+        ProposalPosition position = proposal.addPosition(backend, "백엔드", ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, null, null, null);
+        ReflectionTestUtils.setField(position, "id", 1L);
+
+        Matching matching = Matching.create(null, position, client, freelancer);
+        ReflectionTestUtils.setField(matching, "id", matchingId);
+        ReflectionTestUtils.setField(matching, "status", status);
+        ReflectionTestUtils.setField(matching, "createdAt", createdAt);
+        ReflectionTestUtils.setField(matching, "requestedAt", createdAt);
+        return matching;
+    }
+}

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -83,7 +83,8 @@ class RecommendationControllerTest {
                         null,
                         "대기 중",
                         false,
-                        null  // 매칭 없음
+                        null,  // matchingId — 매칭 없음
+                        null   // matchingStatus — 매칭 없음
                 ))
         );
 
@@ -164,7 +165,8 @@ class RecommendationControllerTest {
                         "사유",
                         "READY",
                         true,
-                        "PROPOSED"  // 매칭 요청 후 대기 중 시나리오
+                        9001L,       // matchingId
+                        "PROPOSED"   // matchingStatus
                 ),
                 "https://example.com",
                 List.of(new RecommendationResumeSkillItem("Java", "고급")),

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -2,9 +2,10 @@ package com.generic4.itda.service.recommend;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.BDDMockito.then;
 
 import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
@@ -12,20 +13,16 @@ import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalStatus;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
-import com.generic4.itda.domain.recommendation.constant.LlmStatus;
 import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
-import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
+import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.Resume;
-import com.generic4.itda.domain.resume.CareerItemPayload;
-import com.generic4.itda.domain.resume.CareerPayload;
-import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.WorkType;
-import com.generic4.itda.domain.resume.ResumeSkill;
-import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.matching.LatestMatchingSummary;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
@@ -33,34 +30,26 @@ import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-/**
- * RecommendationRunQueryService 단위 테스트: - repository가 준비한 RecommendationRun 상세 aggregate를 바탕으로 접근 검증과 상태별 ViewModel 조립을
- * 수행하는지 확인한다.
- * <p>
- * 한계: - 이 테스트는 Mockito 기반 단위 테스트라 findDetailById의 fetch join 범위나 lazy 초기화는 검증하지 않는다. - proposal/member/proposalPosition
- * 그래프 preload 계약은 RecommendationRunRepositoryTest가 보장해야 한다.
- */
 @ExtendWith(MockitoExtension.class)
 class RecommendationRunQueryServiceTest {
 
     private static final Long PROPOSAL_ID = 10L;
     private static final Long RUN_ID = 301L;
     private static final Long RESULT_ID = 100L;
-    private static final Long OWNER_ID = 1L;
+    private static final Long PROPOSAL_POSITION_ID = 21L;
     private static final String OWNER_EMAIL = "owner@example.com";
 
     @Mock
@@ -76,297 +65,38 @@ class RecommendationRunQueryServiceTest {
     private RecommendationRunQueryService service;
 
     @Test
-    @DisplayName("PENDING 상태면 새로고침 가능한 상태 ViewModel을 반환한다")
-    void getRecommendationRunStatus_returnsPendingViewModel() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
+    @DisplayName("COMPUTED 상태가 아니면 추천 결과 조회 시 예외를 던진다")
+    void getRecommendationResults_throwsWhenRunNotComputed() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.PENDING);
         given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
 
-        // when
-        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertViewModel(
-                result,
-                RecommendationRunStatus.PENDING,
-                "추천 요청이 접수되었습니다.",
-                "선택한 포지션의 추천 결과를 준비하고 있습니다.",
-                "새로고침",
-                "/proposals/10/runs/301",
-                true
-        );
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("RUNNING 상태면 새로고침 가능한 진행중 ViewModel을 반환한다")
-    void getRecommendationRunStatus_returnsRunningViewModel() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when
-        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertViewModel(
-                result,
-                RecommendationRunStatus.RUNNING,
-                "추천을 계산하고 있습니다.",
-                "잠시 후 추천 결과를 확인할 수 있습니다.",
-                "새로고침",
-                "/proposals/10/runs/301",
-                true
-        );
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("COMPUTED 상태면 결과 페이지로 이동하는 ViewModel을 반환한다")
-    void getRecommendationRunStatus_returnsComputedViewModel() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when
-        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertViewModel(
-                result,
-                RecommendationRunStatus.COMPUTED,
-                "추천 결과가 준비되었습니다.",
-                "추천 결과 목록으로 이동할 수 있습니다.",
-                "결과 보기",
-                "/proposals/10/recommendations/results?runId=301",
-                false
-        );
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("FAILED 상태면 재실행 안내 ViewModel을 반환한다")
-    void getRecommendationRunStatus_returnsFailedViewModel() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.FAILED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when
-        RecommendationRunStatusViewModel result = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertViewModel(
-                result,
-                RecommendationRunStatus.FAILED,
-                "추천 생성에 실패했습니다.",
-                "잠시 후 다시 시도해 주세요.",
-                "추천 다시 실행",
-                "/proposals/10/recommendations",
-                false
-        );
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 run이면 IllegalArgumentException이 발생한다")
-    void getRecommendationRunStatus_throwsWhenRunNotFound() {
-        // given
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("추천 실행 정보를 찾을 수 없습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("run이 다른 proposal에 속하면 IllegalArgumentException이 발생한다")
-    void getRecommendationRunStatus_throwsWhenProposalDoesNotMatch() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationRunStatus(999L, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("잘못된 추천 실행 접근입니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("제안서 소유자 이메일과 다르면 IllegalArgumentException이 발생한다")
-    void getRecommendationRunStatus_throwsWhenEmailDoesNotMatchOwner() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, "other@example.com"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("접근 권한이 없습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-    }
-
-    @Test
-    @DisplayName("COMPUTED 상태가 아니면 추천 결과 조회 시 IllegalStateException이 발생한다")
-    void getRecommendationResults_throwsWhenRunIsNotComputed() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.PENDING);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
         assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
+                .isInstanceOf(IllegalStateException.class);
 
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
+        then(recommendationRunRepository).should().findDetailById(RUN_ID);
     }
 
     @Test
-    @DisplayName("RUNNING 상태면 추천 결과 조회 시 IllegalStateException이 발생한다")
-    void getRecommendationResults_throwsWhenRunIsRunning() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
+    @DisplayName("추천 결과 조회 시 후보별 최신 매칭 상태/ID를 포함한다")
+    void getRecommendationResults_includesLatestMatchingSummary() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.COMPUTED);
         given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
 
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("FAILED 상태면 추천 결과 조회 시 IllegalStateException이 발생한다")
-    void getRecommendationResults_throwsWhenRunIsFailed() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.FAILED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("추천 실행(run)이 존재하지 않으면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
-    void getRecommendationResults_throwsWhenRunNotFound() {
-        // given
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("추천 실행 정보를 찾을 수 없습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("run이 다른 proposal에 속하면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
-    void getRecommendationResults_throwsWhenProposalDoesNotMatch() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationResults(999L, RUN_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("잘못된 추천 실행 접근입니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("제안서 소유자 이메일과 다르면 추천 결과 조회 시 IllegalArgumentException이 발생한다")
-    void getRecommendationResults_throwsWhenEmailDoesNotMatchOwner() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        // when / then
-        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, "other@example.com"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("접근 권한이 없습니다.");
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("COMPUTED 상태에서도 결과가 없으면 빈 후보 리스트를 반환한다")
-    void getRecommendationResults_returnsEmptyCandidatesWhenNoResults() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of());
-
-        // when
-        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
-        assertThat(view.runId()).isEqualTo(RUN_ID);
-        assertThat(view.proposalTitle()).isEqualTo("추천 테스트 제안서");
-        assertThat(view.positionTitle()).isEqualTo("백엔드 개발자");
-        assertThat(view.topK()).isEqualTo(3);
-        assertThat(view.candidateCount()).isEqualTo(3);
-        assertThat(view.candidates()).isEmpty();
-
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
-    }
-
-    @Test
-    @DisplayName("COMPUTED 상태면 추천 결과 ViewModel을 조립하고 후보 정보를 마스킹하여 반환한다")
-    void getRecommendationResults_returnsViewModelWithCandidates() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+        long resumeId = 500L;
+        long matchingId = 9001L;
 
         Member candidateMember = org.mockito.Mockito.mock(Member.class);
-        given(candidateMember.getNickname()).willReturn("닉네임");
+        given(candidateMember.getNickname()).willReturn("홍길동");
 
         Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
+        given(candidateResume.getId()).willReturn(resumeId);
         given(candidateResume.getMember()).willReturn(candidateMember);
         given(candidateResume.getIntroduction()).willReturn(null);
         given(candidateResume.getPreferredWorkType()).willReturn(WorkType.REMOTE);
 
         ReasonFacts facts = new ReasonFacts(
                 List.of("Java", "Spring"),
-                List.of("플랫폼"),
+                List.of(),
                 7,
                 List.of("대규모 트래픽 처리 경험")
         );
@@ -379,29 +109,22 @@ class RecommendationRunQueryServiceTest {
                 new BigDecimal("0.8800"),
                 facts
         );
-        result.markLlmReady("추천 사유입니다.");
+        ReflectionTestUtils.setField(result, "id", RESULT_ID);
 
         given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
-        given(matchingRepository.getLatestMatchingStatusMap(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.anyCollection()
-        )).willReturn(Map.of());
+        given(matchingRepository.getLatestMatchingSummaryMap(eq(PROPOSAL_POSITION_ID), anyCollection()))
+                .willReturn(Map.of(resumeId, new LatestMatchingSummary(matchingId, MatchingStatus.PROPOSED)));
 
-        // when
         RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
 
-        // then
         assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
         assertThat(view.runId()).isEqualTo(RUN_ID);
-        assertThat(view.proposalTitle()).isEqualTo("추천 테스트 제안서");
-        assertThat(view.positionTitle()).isEqualTo("백엔드 개발자");
-        assertThat(view.topK()).isEqualTo(3);
-        assertThat(view.candidateCount()).isEqualTo(3);
         assertThat(view.candidates()).hasSize(1);
 
         var item = view.candidates().get(0);
+        assertThat(item.resultId()).isEqualTo(RESULT_ID);
         assertThat(item.rank()).isEqualTo(1);
-        assertThat(item.maskedName()).isEqualTo("닉*임");
+        assertThat(item.maskedName()).isEqualTo("홍*동");
         assertThat(item.introduction()).isEmpty();
         assertThat(item.careerYears()).isEqualTo(7);
         assertThat(item.preferredWorkTypeLabel()).isEqualTo(WorkType.REMOTE.getDescription());
@@ -409,239 +132,199 @@ class RecommendationRunQueryServiceTest {
         assertThat(item.embeddingScorePercent()).isEqualTo(88);
         assertThat(item.matchedSkills()).containsExactly("Java", "Spring");
         assertThat(item.highlights()).containsExactly("대규모 트래픽 처리 경험");
-        assertThat(item.llmReason()).isEqualTo("추천 사유입니다.");
-        assertThat(item.llmStatusLabel()).isEqualTo(LlmStatus.READY.getDescription());
-        assertThat(item.llmReady()).isTrue();
-        assertThat(item.matchingStatus()).isNull();  // 매칭 없음 → null
+        assertThat(item.matchingId()).isEqualTo(matchingId);
+        assertThat(item.matchingStatus()).isEqualTo("PROPOSED");
 
-        verify(recommendationRunRepository).findDetailById(RUN_ID);
-        verify(recommendationResultRepository).findByRunIdWithResume(RUN_ID);
-        verify(matchingRepository).getLatestMatchingStatusMap(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.anyCollection()
-        );
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
+        then(recommendationRunRepository).should().findDetailById(RUN_ID);
+        then(recommendationResultRepository).should().findByRunIdWithResume(RUN_ID);
+        then(matchingRepository).should().getLatestMatchingSummaryMap(eq(PROPOSAL_POSITION_ID), anyCollection());
     }
 
     @Test
-    @DisplayName("매칭이 PROPOSED 상태면 후보의 matchingStatus는 'PROPOSED'이다")
-    void getRecommendationResults_setsMatchingStatusProposedWhenMatchingExists() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+    @DisplayName("추천 후보 이력서 상세 조회 시 최신 매칭 상태/ID를 포함한다")
+    void getRecommendationCandidateResume_includesLatestMatchingSummary() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.COMPUTED);
 
         long resumeId = 500L;
+        long matchingId = 9001L;
 
         Member candidateMember = org.mockito.Mockito.mock(Member.class);
-        given(candidateMember.getNickname()).willReturn("테스터");
+        given(candidateMember.getNickname()).willReturn("이순신");
 
-        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
-        given(candidateResume.getId()).willReturn(resumeId);
-        given(candidateResume.getMember()).willReturn(candidateMember);
-        given(candidateResume.getIntroduction()).willReturn(null);
-        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.REMOTE);
+        Resume resume = org.mockito.Mockito.mock(Resume.class);
+        given(resume.getId()).willReturn(resumeId);
+        given(resume.getMember()).willReturn(candidateMember);
+        given(resume.getIntroduction()).willReturn("소개글");
+        given(resume.getPreferredWorkType()).willReturn(WorkType.HYBRID);
+        given(resume.getPortfolioUrl()).willReturn("https://example.com");
+        given(resume.getSkills()).willReturn(null);
+        given(resume.getCareer()).willReturn(null);
 
-        RecommendationResult result = RecommendationResult.create(
-                run, candidateResume, 1,
-                new BigDecimal("0.9000"), new BigDecimal("0.8000"),
-                new ReasonFacts(List.of(), List.of(), 3, List.of())
-        );
-
-        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
-
-        given(matchingRepository.getLatestMatchingStatusMap(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.anyCollection()
-        )).willReturn(Map.of(resumeId, MatchingStatus.PROPOSED));
-
-        // when
-        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertThat(view.candidates()).hasSize(1);
-        assertThat(view.candidates().get(0).matchingStatus()).isEqualTo("PROPOSED");
-    }
-
-    @Test
-    @DisplayName("매칭이 ACCEPTED 상태면 후보의 matchingStatus는 'ACCEPTED'이다")
-    void getRecommendationResults_setsMatchingStatusAcceptedWhenMatchingIsAccepted() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
-
-        long resumeId = 501L;
-
-        Member candidateMember = org.mockito.Mockito.mock(Member.class);
-        given(candidateMember.getNickname()).willReturn("수락자");
-
-        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
-        given(candidateResume.getId()).willReturn(resumeId);
-        given(candidateResume.getMember()).willReturn(candidateMember);
-        given(candidateResume.getIntroduction()).willReturn(null);
-        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.SITE);
-
-        RecommendationResult result = RecommendationResult.create(
-                run, candidateResume, 1,
-                new BigDecimal("0.8500"), new BigDecimal("0.7500"),
-                new ReasonFacts(List.of(), List.of(), 2, List.of())
-        );
-
-        given(recommendationResultRepository.findByRunIdWithResume(RUN_ID)).willReturn(List.of(result));
-
-        given(matchingRepository.getLatestMatchingStatusMap(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.anyCollection()
-        )).willReturn(Map.of(resumeId, MatchingStatus.ACCEPTED));
-
-        // when
-        RecommendationResultsViewModel view = service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
-
-        // then
-        assertThat(view.candidates()).hasSize(1);
-        assertThat(view.candidates().get(0).matchingStatus()).isEqualTo("ACCEPTED");
-    }
-
-    @Test
-    @DisplayName("COMPUTED 상태면 추천 후보 이력서 상세 ViewModel을 조립하여 반환한다")
-    void getRecommendationCandidateResume_returnsDetailViewModel() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.COMPUTED);
-
-        Member candidateMember = org.mockito.Mockito.mock(Member.class);
-        given(candidateMember.getNickname()).willReturn(null);
-        given(candidateMember.getName()).willReturn("홍길동");
-
-        Resume candidateResume = org.mockito.Mockito.mock(Resume.class);
-        given(candidateResume.getMember()).willReturn(candidateMember);
-        given(candidateResume.getIntroduction()).willReturn("소개");
-        given(candidateResume.getPreferredWorkType()).willReturn(WorkType.HYBRID);
-        given(candidateResume.getPortfolioUrl()).willReturn("https://example.com");
-
-        SortedSet<ResumeSkill> skills = new TreeSet<>(Comparator.comparing(rs -> rs.getSkill().getName()));
-        skills.add(ResumeSkill.create(candidateResume, Skill.create("Java", null), Proficiency.ADVANCED));
-        skills.add(ResumeSkill.create(candidateResume, Skill.create("Spring", null), Proficiency.INTERMEDIATE));
-        given(candidateResume.getSkills()).willReturn(skills);
-
-        CareerItemPayload item = new CareerItemPayload();
-        item.setCompanyName("ACME");
-        item.setPosition("Backend");
-        item.setEmploymentType(com.generic4.itda.domain.resume.CareerEmploymentType.FULL_TIME);
-        item.setStartYearMonth("2024-01");
-        item.setEndYearMonth("2025-12");
-        item.setCurrentlyWorking(false);
-        item.setSummary("요약");
-        item.setTechStack(List.of("Java", "Spring"));
-
-        CareerPayload career = new CareerPayload();
-        career.setItems(List.of(item));
-        given(candidateResume.getCareer()).willReturn(career);
-
-        ReasonFacts facts = new ReasonFacts(
-                List.of("Java", "Spring"),
-                List.of(),
-                7,
-                List.of("강점")
-        );
+        ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 3, List.of());
 
         RecommendationResult result = RecommendationResult.create(
                 run,
-                candidateResume,
+                resume,
                 1,
                 new BigDecimal("0.9000"),
                 new BigDecimal("0.8000"),
                 facts
         );
         ReflectionTestUtils.setField(result, "id", RESULT_ID);
-        result.markLlmReady("사유");
 
         given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(result));
-        given(matchingRepository.getLatestMatchingStatus(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any()
-        )).willReturn(Optional.empty());
+        given(matchingRepository.getLatestMatchingSummary(eq(PROPOSAL_POSITION_ID), eq(resumeId)))
+                .willReturn(Optional.of(new LatestMatchingSummary(matchingId, MatchingStatus.IN_PROGRESS)));
 
-        // when
         RecommendationResumeDetailViewModel view = service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL);
 
-        // then
         assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
         assertThat(view.runId()).isEqualTo(RUN_ID);
         assertThat(view.resultId()).isEqualTo(RESULT_ID);
-        assertThat(view.backUrl()).isEqualTo("/proposals/10/recommendations/results?runId=301");
-        assertThat(view.candidate().maskedName()).isEqualTo("홍*동");
-        assertThat(view.candidate().matchingStatus()).isNull();  // 매칭 없음 → null
-        assertThat(view.resumeSkills()).extracting("name").contains("Java", "Spring");
-        assertThat(view.careerItems()).hasSize(1);
-        assertThat(view.careerItems().get(0).companyName()).isEqualTo("ACME");
+        assertThat(view.candidate().matchingId()).isEqualTo(matchingId);
+        assertThat(view.candidate().matchingStatus()).isEqualTo("IN_PROGRESS");
 
-        verify(recommendationResultRepository).findDetailById(RESULT_ID);
-        verify(matchingRepository).getLatestMatchingStatus(
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any()
-        );
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
+        then(recommendationResultRepository).should().findDetailById(RESULT_ID);
+        then(matchingRepository).should().getLatestMatchingSummary(PROPOSAL_POSITION_ID, resumeId);
     }
 
     @Test
-    @DisplayName("COMPUTED 상태가 아니면 추천 후보 이력서 상세 조회 시 IllegalStateException이 발생한다")
-    void getRecommendationCandidateResume_throwsWhenNotComputed() {
-        // given
-        RecommendationRun run = createOwnedRunWithStatus(RecommendationRunStatus.RUNNING);
+    @DisplayName("추천 실행 상태 조회 시 상태별 nextActionUrl/autoRefresh 값을 설정한다")
+    void getRecommendationRunStatus_setsNextActionUrlByStatus() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        RecommendationRunStatusViewModel view = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(view.runId()).isEqualTo(RUN_ID);
+        assertThat(view.status()).isEqualTo(RecommendationRunStatus.COMPUTED);
+        assertThat(view.nextActionUrl()).isEqualTo("/proposals/10/recommendations/results?runId=301");
+        assertThat(view.autoRefresh()).isFalse();
+
+        then(recommendationRunRepository).should().findDetailById(RUN_ID);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RecommendationRunStatus.class, names = {"PENDING", "RUNNING"})
+    @DisplayName("추천 실행 상태가 PENDING/RUNNING이면 autoRefresh=true이고 nextActionUrl이 runs 경로이다")
+    void getRecommendationRunStatus_pendingOrRunning_autoRefreshTrueAndRunsUrl(RecommendationRunStatus status) {
+        RecommendationRun run = createOwnedRun(status);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        RecommendationRunStatusViewModel view = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        assertThat(view.status()).isEqualTo(status);
+        assertThat(view.autoRefresh()).isTrue();
+        assertThat(view.nextActionUrl()).isEqualTo("/proposals/10/runs/301");
+    }
+
+    @Test
+    @DisplayName("추천 실행 상태가 FAILED이면 autoRefresh=false이고 nextActionUrl이 recommendations 경로이다")
+    void getRecommendationRunStatus_failed_autoRefreshFalseAndRecommendationsUrl() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.FAILED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        RecommendationRunStatusViewModel view = service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL);
+
+        assertThat(view.status()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(view.autoRefresh()).isFalse();
+        assertThat(view.nextActionUrl()).isEqualTo("/proposals/10/recommendations");
+    }
+
+    @Test
+    @DisplayName("추천 실행 조회 시 runId가 존재하지 않으면 예외를 던진다")
+    void getRecommendationRunStatus_runNotFound_throwsException() {
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("추천 실행 조회 시 다른 제안서의 runId로 접근하면 예외를 던진다")
+    void getRecommendationRunStatus_wrongProposalId_throwsException() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(999L, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("추천 실행 조회 시 소유자가 아닌 이메일로 접근하면 예외를 던진다")
+    void getRecommendationRunStatus_wrongOwner_throwsException() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.COMPUTED);
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.of(run));
+
+        assertThatThrownBy(() -> service.getRecommendationRunStatus(PROPOSAL_ID, RUN_ID, "other@example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("추천 결과 조회 시 runId가 존재하지 않으면 예외를 던진다")
+    void getRecommendationResults_runNotFound_throwsException() {
+        given(recommendationRunRepository.findDetailById(RUN_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getRecommendationResults(PROPOSAL_ID, RUN_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("추천 후보 이력서 조회 시 COMPUTED 상태가 아니면 예외를 던진다")
+    void getRecommendationCandidateResume_notComputed_throwsException() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.PENDING);
 
         Resume resume = org.mockito.Mockito.mock(Resume.class);
-
+        ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 0, List.of());
         RecommendationResult result = RecommendationResult.create(
-                run,
-                resume,
-                1,
-                new BigDecimal("0.5000"),
-                new BigDecimal("0.5000"),
-                new ReasonFacts(List.of(), List.of(), 1, List.of())
-        );
+                run, resume, 1, new BigDecimal("0.9"), new BigDecimal("0.8"), facts);
         ReflectionTestUtils.setField(result, "id", RESULT_ID);
 
         given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.of(result));
 
-        // when / then
         assertThatThrownBy(() -> service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("추천 결과가 아직 준비되지 않았습니다.");
-
-        verify(recommendationResultRepository).findDetailById(RESULT_ID);
-        verifyNoMoreInteractions(recommendationRunRepository);
-        verifyNoMoreInteractions(recommendationResultRepository);
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    private void assertViewModel(
-            RecommendationRunStatusViewModel viewModel,
-            RecommendationRunStatus status,
-            String title,
-            String message,
-            String nextActionLabel,
-            String nextActionUrl,
-            boolean autoRefresh
-    ) {
-        assertThat(viewModel.proposalId()).isEqualTo(PROPOSAL_ID);
-        assertThat(viewModel.runId()).isEqualTo(RUN_ID);
-        assertThat(viewModel.proposalTitle()).isEqualTo("추천 테스트 제안서");
-        assertThat(viewModel.status()).isEqualTo(status);
-        assertThat(viewModel.title()).isEqualTo(title);
-        assertThat(viewModel.message()).isEqualTo(message);
-        assertThat(viewModel.nextActionLabel()).isEqualTo(nextActionLabel);
-        assertThat(viewModel.nextActionUrl()).isEqualTo(nextActionUrl);
-        assertThat(viewModel.autoRefresh()).isEqualTo(autoRefresh);
+    @Test
+    @DisplayName("추천 후보 이력서 조회 시 resultId가 존재하지 않으면 예외를 던진다")
+    void getRecommendationCandidateResume_resultNotFound_throwsException() {
+        given(recommendationResultRepository.findDetailById(RESULT_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getRecommendationCandidateResume(PROPOSAL_ID, RESULT_ID, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    private RecommendationRun createOwnedRunWithStatus(RecommendationRunStatus status) {
-        Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
-        Proposal proposal = createProposal(owner, PROPOSAL_ID);
-        ProposalPosition proposalPosition = addPosition(proposal, 21L, "백엔드 개발자");
+    private RecommendationRun createOwnedRun(RecommendationRunStatus status) {
+        Member owner = Member.create(OWNER_EMAIL, "hashed", "Owner", null, null, "010-0000-0000");
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        Proposal proposal = Proposal.create(owner, "Test Proposal", "raw", "desc", 3_000_000L, 5_000_000L, 3L);
+        proposal.startMatching();
+        ReflectionTestUtils.setField(proposal, "id", PROPOSAL_ID);
+        ReflectionTestUtils.setField(proposal, "status", ProposalStatus.MATCHING);
+
+        Position position = Position.create("Backend");
+        ReflectionTestUtils.setField(position, "id", 1001L);
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "Backend Dev",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(proposalPosition, "id", PROPOSAL_POSITION_ID);
 
         RecommendationRun run = RecommendationRun.create(
                 proposalPosition,
-                "fp-abc123",
+                "fp-test",
                 RecommendationAlgorithm.HEURISTIC_V1,
                 3
         );
@@ -651,68 +334,19 @@ class RecommendationRunQueryServiceTest {
         return run;
     }
 
-    private void applyStatus(RecommendationRun run, RecommendationRunStatus status) {
+    private static void applyStatus(RecommendationRun run, RecommendationRunStatus status) {
         switch (status) {
             case PENDING -> {
-                return;
             }
             case RUNNING -> run.markRunning();
             case COMPUTED -> {
                 run.markRunning();
-                run.markCompleted(new HardFilterStat(12, 3));
+                run.markCompleted(new HardFilterStat(10, 1));
             }
             case FAILED -> {
                 run.markRunning();
                 run.markFailed("추천 생성 실패");
             }
         }
-    }
-
-    private Proposal createProposal(Member member, Long proposalId) {
-        Proposal proposal = Proposal.create(
-                member,
-                "추천 테스트 제안서",
-                "raw-input",
-                "description",
-                3_000_000L,
-                5_000_000L,
-                3L
-        );
-        ReflectionTestUtils.setField(proposal, "id", proposalId);
-        ReflectionTestUtils.setField(proposal, "status", ProposalStatus.MATCHING);
-        return proposal;
-    }
-
-    private ProposalPosition addPosition(Proposal proposal, Long proposalPositionId, String positionName) {
-        Position position = Position.create(positionName);
-        ReflectionTestUtils.setField(position, "id", proposalPositionId + 1000);
-
-        ProposalPosition proposalPosition = proposal.addPosition(
-                position,
-                positionName,
-                null,
-                1L,
-                1_000_000L,
-                2_000_000L,
-                null,
-                null,
-                null,
-                null
-        );
-        ReflectionTestUtils.setField(proposalPosition, "id", proposalPositionId);
-        return proposalPosition;
-    }
-
-    private Member createMemberWithId(Long memberId, String email) {
-        Member member = Member.create(
-                email,
-                "hashed-password",
-                "테스터",
-                null,
-                null,
-                "010-1234-5678"
-        );
-        ReflectionTestUtils.setField(member, "id", memberId);
-        return member;
     }
 }


### PR DESCRIPTION
## 🔎 What


1. 프리랜서 진입 플로우 연결
    - 프리랜서 대시보드 아이템의 ... 메뉴 추가
    - 프리랜서 대시보드 아이템 ... 메뉴에 “매칭 결과 보기” 추가 → /matchings/{matchingId}
    - 프리랜서가 수락한 제안서 상세에서 “매칭 결과 보기” 링크/버튼 추가
2. 클라이언트 진입 플로우 연결
    - 클라이언트 대시보드 카드 ... 메뉴에 “매칭 결과 보기” 진입점 추가
    - 클라이언트 제안서 상세(추천/매칭 진행중)에서 “매칭 결과 보기” 진입점 추가
    - 제안서 -> 포지션 -> 추천결과 페이지에서 추천받은 프리랜서에 대한 카드의 "매칭 진행 중" 진입점 추가
3. 클라이언트용 선택 플로우 구현(여러 매칭 요청 대응)
    - “매칭 요청을 보낸 포지션 선택” 페이지 구현
        - 정렬: OPEN → FULL → CLOSED 우선순위로 노출 (상태 값은 ProposalPositionStatus 기준)
        - 필터: 전체보기 / 모집중만 보기(OPEN만)
        - 포지션 카드에 “요청 보낸 프리랜서 수/진행중 수” 등 카운트 표시
        - 포지션 선택 시 “프리랜서 단계”로 이동(해당 proposalPositionId 전달)

    - “포지션별 매칭 요청 프리랜서(매칭) 선택” 페이지 구현
        - 정렬(상태 우선순위): PROPOSED → IN_PROGRESS → ACCEPTED → REJECTED → COMPLETED → CANCELED
        (상태 값은 MatchingStatus 기준)
        - 필터: 전체보기 / 제안됨(ACCEPTED) / 수락됨(ACCEPTED) / 협의 중(IN_PROGRESS) / 완료됨(COMPLETED)
        - 각 항목에서 /matchings/{matchingId}로 진입(매칭결과 단계)
4. redirectTo/errorRedirectTo 규칙 통일
    - 진입 경로별 redirectTo 지정(대시보드/제안서 상세/추천 결과)
    - 실패 시 errorRedirectTo가 자연스럽게 복귀하도록 정리
5. 권한/예외 UX 보강
    - 권한 없음/미존재 시 사용자 친화 메시지 + fallback 경로(클라이언트/프리랜서 분리)
6. 테스트 보강
    - 클라이언트/프리랜서 각각 “진입 플로우” 라우팅 테스트
    - 선택 플로우(포지션→프리랜서→matchingId) 테스트
        - 포지션 단계 정렬/필터 케이스
        - 프리랜서 단계 정렬/필터 케이스
        - 단계별 라우팅/권한(클라이언트 본인 제안서만) 케이스
    - 권한/미존재 케이스 테스트

## 🔗 Issue

- Closes: #117 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?