### PR TITLE
[Refactor] 추천 후보 프로필 구조 정리 및 공통 프로필 셸 기반 분리

### DIFF
--- a/src/main/java/com/generic4/itda/dto/profile/ProfileAccessLevel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileAccessLevel.java
@@ -1,0 +1,22 @@
+package com.generic4.itda.dto.profile;
+
+public enum ProfileAccessLevel {
+    PREVIEW("미리보기", "추천/요청 판단에 필요한 정보만 공개됩니다."),
+    FULL("전체 공개", "매칭 성립 후 협업에 필요한 정보까지 공개됩니다.");
+
+    private final String label;
+    private final String guideMessage;
+
+    ProfileAccessLevel(String label, String guideMessage) {
+        this.label = label;
+        this.guideMessage = guideMessage;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public String guideMessage() {
+        return guideMessage;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileCareerItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileCareerItemViewModel.java
@@ -1,0 +1,16 @@
+package com.generic4.itda.dto.profile;
+
+import java.util.List;
+
+public record ProfileCareerItemViewModel(
+        String companyName,
+        String position,
+        String employmentTypeLabel,
+        String periodLabel,
+        String summary,
+        List<String> techStack
+) {
+    public ProfileCareerItemViewModel {
+        techStack = techStack != null ? List.copyOf(techStack) : List.of();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileClientBodyViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileClientBodyViewModel.java
@@ -1,0 +1,9 @@
+package com.generic4.itda.dto.profile;
+
+public record ProfileClientBodyViewModel(
+        String displayName,
+        String userTypeLabel,
+        String memo,
+        ProfileProjectSummaryViewModel project
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileContextType.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileContextType.java
@@ -1,0 +1,16 @@
+package com.generic4.itda.dto.profile;
+
+public enum ProfileContextType {
+    RECOMMENDATION("추천 후보 검토"),
+    MATCHING("매칭 상대 검토");
+
+    private final String label;
+
+    ProfileContextType(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileFreelancerBodyViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileFreelancerBodyViewModel.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.dto.profile;
+
+import java.util.List;
+
+public record ProfileFreelancerBodyViewModel(
+        String displayName,
+        String headline,
+        String introduction,
+        Integer careerYears,
+        String preferredWorkTypeLabel,
+        String portfolioUrl,
+        List<ProfileSkillItemViewModel> skills,
+        List<ProfileCareerItemViewModel> careerItems
+) {
+    public ProfileFreelancerBodyViewModel {
+        skills = skills != null ? List.copyOf(skills) : List.of();
+        careerItems = careerItems != null ? List.copyOf(careerItems) : List.of();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileMatchingContextViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileMatchingContextViewModel.java
@@ -1,0 +1,26 @@
+package com.generic4.itda.dto.profile;
+
+public record ProfileMatchingContextViewModel(
+        Long matchingId,
+        String viewerRole,
+        String matchingStatus,
+        boolean contactVisible,
+        String statusLabel,
+        String helperMessage,
+        String matchingDetailUrl,
+        String proposalDetailUrl,
+        String acceptActionUrl,
+        String rejectActionUrl
+) {
+    public boolean proposed() {
+        return "PROPOSED".equals(matchingStatus);
+    }
+
+    public boolean freelancerViewer() {
+        return "FREELANCER".equals(viewerRole);
+    }
+
+    public boolean canRespond() {
+        return proposed() && freelancerViewer();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileProjectSummaryViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileProjectSummaryViewModel.java
@@ -1,0 +1,20 @@
+package com.generic4.itda.dto.profile;
+
+import java.util.List;
+
+public record ProfileProjectSummaryViewModel(
+        Long proposalId,
+        String proposalTitle,
+        String description,
+        String positionTitle,
+        String workTypeLabel,
+        String budgetText,
+        String expectedPeriodText,
+        List<String> essentialSkills,
+        List<String> preferredSkills
+) {
+    public ProfileProjectSummaryViewModel {
+        essentialSkills = essentialSkills != null ? List.copyOf(essentialSkills) : List.of();
+        preferredSkills = preferredSkills != null ? List.copyOf(preferredSkills) : List.of();
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileRecommendationContextViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileRecommendationContextViewModel.java
@@ -1,0 +1,51 @@
+package com.generic4.itda.dto.profile;
+
+import java.util.List;
+
+public record ProfileRecommendationContextViewModel(
+        Long proposalId,
+        Long runId,
+        Long resultId,
+        Long matchingId,
+        String matchingStatus,
+        int rank,
+        int finalScorePercent,
+        int embeddingScorePercent,
+        List<String> matchedSkills,
+        List<String> highlights,
+        String llmReason,
+        String llmStatusLabel,
+        boolean llmReady,
+        String requestRedirectUrl,
+        String requestErrorRedirectUrl,
+        String matchingDetailUrl
+) {
+    public ProfileRecommendationContextViewModel {
+        matchedSkills = matchedSkills != null ? List.copyOf(matchedSkills) : List.of();
+        highlights = highlights != null ? List.copyOf(highlights) : List.of();
+    }
+
+    public boolean requestable() {
+        return matchingStatus == null;
+    }
+
+    public boolean proposed() {
+        return "PROPOSED".equals(matchingStatus);
+    }
+
+    public boolean active() {
+        return "ACCEPTED".equals(matchingStatus) || "IN_PROGRESS".equals(matchingStatus);
+    }
+
+    public boolean rejected() {
+        return "REJECTED".equals(matchingStatus);
+    }
+
+    public boolean closed() {
+        return "COMPLETED".equals(matchingStatus) || "CANCELED".equals(matchingStatus);
+    }
+
+    public boolean hasMatchingDetail() {
+        return matchingId != null && matchingDetailUrl != null;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileShellViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileShellViewModel.java
@@ -1,0 +1,31 @@
+package com.generic4.itda.dto.profile;
+
+public record ProfileShellViewModel(
+        ProfileSubjectType subjectType,
+        ProfileContextType contextType,
+        ProfileAccessLevel accessLevel,
+        String title,
+        String subtitle,
+        String statusLabel,
+        String backUrl,
+        ProfileFreelancerBodyViewModel freelancer,
+        ProfileClientBodyViewModel client,
+        ProfileMatchingContextViewModel matchingContext,
+        ProfileRecommendationContextViewModel recommendationContext
+) {
+    public boolean freelancerSubject() {
+        return subjectType == ProfileSubjectType.FREELANCER;
+    }
+
+    public boolean clientSubject() {
+        return subjectType == ProfileSubjectType.CLIENT;
+    }
+
+    public boolean hasRecommendationContext() {
+        return contextType == ProfileContextType.RECOMMENDATION && recommendationContext != null;
+    }
+
+    public boolean hasMatchingContext() {
+        return contextType == ProfileContextType.MATCHING && matchingContext != null;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileSkillItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileSkillItemViewModel.java
@@ -2,6 +2,10 @@ package com.generic4.itda.dto.profile;
 
 public record ProfileSkillItemViewModel(
         String name,
-        String proficiencyLabel
+        String proficiencyLabel,
+        String proficiencyCode
 ) {
+    public ProfileSkillItemViewModel(String name, String proficiencyLabel) {
+        this(name, proficiencyLabel, null);
+    }
 }

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileSkillItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileSkillItemViewModel.java
@@ -1,0 +1,7 @@
+package com.generic4.itda.dto.profile;
+
+public record ProfileSkillItemViewModel(
+        String name,
+        String proficiencyLabel
+) {
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileSubjectType.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileSubjectType.java
@@ -1,0 +1,16 @@
+package com.generic4.itda.dto.profile;
+
+public enum ProfileSubjectType {
+    FREELANCER("프리랜서"),
+    CLIENT("클라이언트");
+
+    private final String label;
+
+    ProfileSubjectType(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
@@ -42,7 +42,11 @@ public record RecommendationResumeDetailViewModel(
                         candidate.preferredWorkTypeLabel(),
                         portfolioUrl,
                         safeSkills.stream()
-                                .map(skill -> new ProfileSkillItemViewModel(skill.name(), skill.proficiencyLabel()))
+                                .map(skill -> new ProfileSkillItemViewModel(
+                                        skill.name(),
+                                        skill.proficiencyLabel(),
+                                        skill.proficiencyCode()
+                                ))
                                 .toList(),
                         safeCareers.stream()
                                 .map(career -> new ProfileCareerItemViewModel(

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
@@ -1,5 +1,13 @@
 package com.generic4.itda.dto.recommend;
 
+import com.generic4.itda.dto.profile.ProfileAccessLevel;
+import com.generic4.itda.dto.profile.ProfileCareerItemViewModel;
+import com.generic4.itda.dto.profile.ProfileContextType;
+import com.generic4.itda.dto.profile.ProfileFreelancerBodyViewModel;
+import com.generic4.itda.dto.profile.ProfileRecommendationContextViewModel;
+import com.generic4.itda.dto.profile.ProfileShellViewModel;
+import com.generic4.itda.dto.profile.ProfileSkillItemViewModel;
+import com.generic4.itda.dto.profile.ProfileSubjectType;
 import java.util.List;
 
 public record RecommendationResumeDetailViewModel(
@@ -13,5 +21,60 @@ public record RecommendationResumeDetailViewModel(
         String portfolioUrl,
         List<RecommendationResumeSkillItem> resumeSkills,
         List<RecommendationResumeCareerItem> careerItems
-) {}
+) {
+    public ProfileShellViewModel profile() {
+        List<RecommendationResumeSkillItem> safeSkills = resumeSkills != null ? resumeSkills : List.of();
+        List<RecommendationResumeCareerItem> safeCareers = careerItems != null ? careerItems : List.of();
 
+        return new ProfileShellViewModel(
+                ProfileSubjectType.FREELANCER,
+                ProfileContextType.RECOMMENDATION,
+                ProfileAccessLevel.PREVIEW,
+                "추천 후보 프로필",
+                proposalTitle + " · " + positionTitle,
+                "추천 미리보기",
+                backUrl,
+                new ProfileFreelancerBodyViewModel(
+                        candidate.maskedName(),
+                        "프리랜서 프로필",
+                        candidate.introduction(),
+                        candidate.careerYears(),
+                        candidate.preferredWorkTypeLabel(),
+                        portfolioUrl,
+                        safeSkills.stream()
+                                .map(skill -> new ProfileSkillItemViewModel(skill.name(), skill.proficiencyLabel()))
+                                .toList(),
+                        safeCareers.stream()
+                                .map(career -> new ProfileCareerItemViewModel(
+                                        career.companyName(),
+                                        career.position(),
+                                        career.employmentTypeLabel(),
+                                        career.periodLabel(),
+                                        career.summary(),
+                                        career.techStack()
+                                ))
+                                .toList()
+                ),
+                null,
+                null,
+                new ProfileRecommendationContextViewModel(
+                        proposalId,
+                        runId,
+                        resultId,
+                        candidate.matchingId(),
+                        candidate.matchingStatus(),
+                        candidate.rank(),
+                        candidate.finalScorePercent(),
+                        candidate.embeddingScorePercent(),
+                        candidate.matchedSkills(),
+                        candidate.highlights(),
+                        candidate.llmReason(),
+                        candidate.llmStatusLabel(),
+                        candidate.llmReady(),
+                        "/proposals/%d/recommendations/results/%d".formatted(proposalId, resultId),
+                        "/proposals/%d/recommendations/results/%d".formatted(proposalId, resultId),
+                        candidate.matchingId() != null ? "/matchings/%d".formatted(candidate.matchingId()) : null
+                )
+        );
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeSkillItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeSkillItem.java
@@ -2,6 +2,10 @@ package com.generic4.itda.dto.recommend;
 
 public record RecommendationResumeSkillItem(
         String name,
-        String proficiencyLabel
-) {}
-
+        String proficiencyLabel,
+        String proficiencyCode
+) {
+    public RecommendationResumeSkillItem(String name, String proficiencyLabel) {
+        this(name, proficiencyLabel, null);
+    }
+}

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -214,7 +214,8 @@ public class RecommendationRunQueryService {
         return skills.stream()
                 .map(skill -> new RecommendationResumeSkillItem(
                         skill.getSkill().getName(),
-                        skill.getProficiency().getDescription()
+                        skill.getProficiency().getDescription(),
+                        skill.getProficiency().name()
                 ))
                 .toList();
     }

--- a/src/main/resources/templates/fragments/profileFragments.html
+++ b/src/main/resources/templates/fragments/profileFragments.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+<th:block th:fragment="profileHeader(profile)">
+    <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
+        <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
+            <div class="flex items-center gap-4">
+                <a th:href="${profile.backUrl}"
+                   class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
+                    <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                </a>
+                <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <h1 class="text-lg font-bold text-slate-900" th:text="${profile.title}">프로필</h1>
+                        <span class="rounded-full border border-blue-100 bg-blue-50 px-2.5 py-1 text-[11px] font-bold text-blue-700"
+                              th:text="${profile.statusLabel}">미리보기</span>
+                    </div>
+                    <p class="mt-0.5 text-xs text-slate-400" th:text="${profile.subtitle}">제안서 · 포지션</p>
+                    <p class="mt-0.5 text-[11px] font-semibold text-slate-400"
+                       th:text="${profile.contextType.label() + ' · ' + profile.subjectType.label()}">
+                        추천 후보 검토 · 프리랜서
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</th:block>
+
+<th:block th:fragment="profileAlerts">
+    <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
+        <section th:if="${errorMessage != null}"
+                 class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+            <p th:text="${errorMessage}">오류 메시지</p>
+        </section>
+        <section th:if="${noticeMessage != null}"
+                 class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+            <p th:text="${noticeMessage}">안내 메시지</p>
+        </section>
+    </div>
+</th:block>
+
+<th:block th:fragment="freelancerBody(profile)" th:with="body=${profile.freelancer}">
+    <section class="space-y-6">
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">FREELANCER PROFILE</p>
+                    <h2 class="mt-2 text-2xl font-black tracking-tight text-slate-950" th:text="${body.displayName}">
+                        김*수
+                    </h2>
+                    <p class="mt-2 text-sm leading-relaxed text-slate-500" th:text="${body.headline}">
+                        프리랜서 프로필
+                    </p>
+                </div>
+                <a th:if="${body.portfolioUrl != null}"
+                   th:href="${body.portfolioUrl}"
+                   target="_blank" rel="noreferrer noopener"
+                   class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
+                    <i data-lucide="link" class="h-3.5 w-3.5"></i>
+                    포트폴리오
+                </a>
+            </div>
+
+            <div class="mt-6 grid gap-3 sm:grid-cols-3">
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">경력</p>
+                    <p class="mt-2 text-base font-bold text-slate-900"
+                       th:text="${body.careerYears != null ? body.careerYears + '년' : '미정'}">5년</p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">선호 근무 형태</p>
+                    <p class="mt-2 text-base font-bold text-slate-900" th:text="${body.preferredWorkTypeLabel}">
+                        원격
+                    </p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">공개 범위</p>
+                    <p class="mt-2 text-base font-bold text-slate-900" th:text="${profile.accessLevel.label()}">
+                        미리보기
+                    </p>
+                </div>
+            </div>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <h2 class="text-base font-bold text-slate-900">자기소개</h2>
+            <p class="mt-3 rounded-2xl bg-slate-50 px-5 py-4 text-sm leading-relaxed text-slate-700"
+               th:text="${#strings.isEmpty(body.introduction) ? '등록된 자기소개가 없습니다.' : body.introduction}">
+                자기소개
+            </p>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <h2 class="mb-3 text-base font-bold text-slate-900">보유 기술</h2>
+            <div th:if="${#lists.isEmpty(body.skills)}"
+                 class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+                등록된 기술이 없습니다.
+            </div>
+            <div th:unless="${#lists.isEmpty(body.skills)}" class="flex flex-wrap gap-2">
+                <span th:each="skill : ${body.skills}"
+                      class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                    <span class="font-semibold" th:text="${skill.name}">Spring</span>
+                    <span class="rounded-md bg-slate-50 px-2 py-0.5 text-xs font-bold text-slate-500"
+                          th:text="${skill.proficiencyLabel}">중급</span>
+                </span>
+            </div>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <h2 class="mb-3 text-base font-bold text-slate-900">경력</h2>
+            <div th:if="${#lists.isEmpty(body.careerItems)}"
+                 class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+                등록된 경력이 없습니다.
+            </div>
+            <div th:unless="${#lists.isEmpty(body.careerItems)}" class="space-y-4">
+                <div th:each="career : ${body.careerItems}"
+                     class="rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
+                    <p class="text-sm font-bold text-slate-900"
+                       th:text="${career.companyName + ' · ' + career.position}">회사 · 직무</p>
+                    <p class="mt-0.5 text-xs text-slate-500"
+                       th:text="${career.employmentTypeLabel + ' · ' + career.periodLabel}">고용형태 · 기간</p>
+                    <p th:if="${career.summary != null and !#strings.isEmpty(career.summary)}"
+                       class="mt-3 text-sm leading-relaxed text-slate-700"
+                       th:text="${career.summary}">요약</p>
+                    <div class="mt-3 flex flex-wrap gap-1.5" th:if="${!#lists.isEmpty(career.techStack)}">
+                        <span th:each="tech : ${career.techStack}"
+                              class="rounded-md border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                              th:text="${tech}">Java</span>
+                    </div>
+                </div>
+            </div>
+        </article>
+    </section>
+</th:block>
+
+<th:block th:fragment="clientBody(profile)" th:with="body=${profile.client}, project=${profile.client != null ? profile.client.project : null}">
+    <section class="space-y-6">
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">CLIENT PROFILE</p>
+            <h2 class="mt-2 text-2xl font-black tracking-tight text-slate-950"
+                th:text="${body != null ? body.displayName : '클라이언트'}">클라이언트</h2>
+            <p class="mt-2 text-sm text-slate-500"
+               th:text="${body != null ? body.userTypeLabel : '회원 유형 미정'}">개인 회원</p>
+            <p class="mt-5 rounded-2xl bg-slate-50 px-5 py-4 text-sm leading-relaxed text-slate-600"
+               th:text="${body != null and !#strings.isEmpty(body.memo) ? body.memo : '클라이언트 소개는 추후 확장 예정입니다.'}">
+                클라이언트 소개
+            </p>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <h2 class="text-base font-bold text-slate-900">요청 프로젝트 요약</h2>
+            <div th:if="${project == null}"
+                 class="mt-4 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+                연결된 프로젝트 요약이 없습니다.
+            </div>
+            <div th:if="${project != null}" class="mt-4 space-y-4">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">제안서</p>
+                    <p class="mt-1 text-lg font-bold text-slate-900" th:text="${project.proposalTitle}">제안서 제목</p>
+                    <p class="mt-2 text-sm leading-relaxed text-slate-600"
+                       th:text="${#strings.isEmpty(project.description) ? '제안서 설명이 없습니다.' : project.description}">
+                        제안서 설명
+                    </p>
+                </div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">포지션</p>
+                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.positionTitle}">백엔드</p>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
+                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.workTypeLabel}">원격</p>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
+                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.budgetText}">미정</p>
+                    </div>
+                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예상 기간</p>
+                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.expectedPeriodText}">미정</p>
+                    </div>
+                </div>
+            </div>
+        </article>
+    </section>
+</th:block>
+
+<th:block th:fragment="recommendationContextPanel(profile)" th:with="ctx=${profile.recommendationContext}">
+    <aside class="space-y-6">
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <div class="flex items-start justify-between gap-3">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">RECOMMENDATION CONTEXT</p>
+                    <h2 class="mt-2 text-lg font-bold text-slate-900">추천 판단 정보</h2>
+                </div>
+                <span class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-600"
+                      th:text="${'TOP ' + ctx.rank}">TOP 1</span>
+            </div>
+
+            <div class="mt-5 grid grid-cols-2 gap-3">
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">최종 점수</p>
+                    <p th:classappend="${ctx.finalScorePercent >= 80} ? 'text-blue-600' :
+                                        (${ctx.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-700')"
+                       class="mt-2 text-2xl font-black tracking-tight"
+                       th:text="${ctx.finalScorePercent + '%'}">92%</p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">매칭 점수</p>
+                    <p class="mt-2 text-2xl font-black tracking-tight text-slate-800"
+                       th:text="${ctx.embeddingScorePercent + '%'}">88%</p>
+                </div>
+            </div>
+
+            <div class="mt-5" th:if="${!#lists.isEmpty(ctx.matchedSkills)}">
+                <p class="text-xs font-bold text-slate-500">일치 기술</p>
+                <div class="mt-2 flex flex-wrap gap-1.5">
+                    <span th:each="skill : ${ctx.matchedSkills}"
+                          class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
+                          th:text="${skill}">Java</span>
+                </div>
+            </div>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">ACTIONS</p>
+            <h2 class="mt-2 text-lg font-bold text-slate-900">현재 가능한 작업</h2>
+
+            <form th:if="${ctx.requestable()}"
+                  class="mt-5"
+                  th:action="@{/recommendation-results/{id}/matchings(id=${ctx.resultId})}"
+                  method="post">
+                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                <input type="hidden" name="redirectTo" th:value="${ctx.requestRedirectUrl}">
+                <input type="hidden" name="errorRedirectTo" th:value="${ctx.requestErrorRedirectUrl}">
+                <button type="submit"
+                        class="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-blue-700">
+                    <i data-lucide="send" class="h-4 w-4"></i>
+                    매칭 요청하기
+                </button>
+            </form>
+
+            <div th:if="${ctx.proposed()}"
+                 class="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm font-bold text-amber-700">
+                <div class="flex items-center gap-2">
+                    <i data-lucide="clock" class="h-4 w-4"></i>
+                    수락 대기 중
+                </div>
+                <a th:if="${ctx.hasMatchingDetail()}"
+                   th:href="${ctx.matchingDetailUrl}"
+                   class="mt-3 inline-flex items-center gap-1.5 text-xs font-bold text-amber-700 transition hover:text-amber-800">
+                    매칭 상세 보기
+                    <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+                </a>
+            </div>
+
+            <div th:if="${ctx.active()}"
+                 class="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-bold text-emerald-700">
+                <div class="flex items-center gap-2">
+                    <i data-lucide="check-circle" class="h-4 w-4"></i>
+                    매칭 진행 중
+                </div>
+                <a th:if="${ctx.hasMatchingDetail()}"
+                   th:href="${ctx.matchingDetailUrl}"
+                   class="mt-3 inline-flex items-center gap-1.5 text-xs font-bold text-emerald-700 transition hover:text-emerald-800">
+                    매칭 상세 보기
+                    <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+                </a>
+            </div>
+
+            <div th:if="${ctx.rejected()}"
+                 class="mt-5 flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm font-bold text-slate-400">
+                <i data-lucide="x-circle" class="h-4 w-4"></i>
+                거절됨
+            </div>
+
+            <div th:if="${ctx.closed()}"
+                 class="mt-5 flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4 text-sm font-bold text-slate-400">
+                <i data-lucide="archive" class="h-4 w-4"></i>
+                <span th:text="${ctx.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
+            </div>
+
+            <a th:href="${profile.backUrl}"
+               class="mt-4 inline-flex items-center gap-2 text-sm font-bold text-slate-500 transition hover:text-slate-700">
+                <i data-lucide="arrow-left" class="h-4 w-4"></i>
+                추천 결과로 돌아가기
+            </a>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <div class="mb-2 flex items-center gap-2">
+                <i data-lucide="sparkles" class="h-4 w-4 text-blue-400"></i>
+                <h2 class="text-sm font-bold text-slate-900">AI 추천 사유</h2>
+            </div>
+            <p th:if="${ctx.llmReady and ctx.llmReason != null}"
+               class="text-sm leading-relaxed text-slate-700"
+               th:text="${ctx.llmReason}">AI 추천 사유</p>
+            <p th:unless="${ctx.llmReady and ctx.llmReason != null}"
+               class="text-xs italic text-slate-400">AI 분석을 준비 중입니다.</p>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50"
+                 th:if="${!#lists.isEmpty(ctx.highlights)}">
+            <div class="mb-2 flex items-center gap-2">
+                <i data-lucide="star" class="h-4 w-4 text-emerald-500"></i>
+                <h2 class="text-sm font-bold text-slate-900">주요 강점</h2>
+            </div>
+            <ul class="space-y-2">
+                <li th:each="highlight : ${ctx.highlights}"
+                    class="rounded-xl bg-emerald-50/70 px-4 py-3 text-sm text-slate-700"
+                    th:text="${highlight}">강점</li>
+            </ul>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <div class="flex items-start gap-3">
+                <i data-lucide="shield-check" class="mt-0.5 h-4 w-4 shrink-0 text-slate-400"></i>
+                <div>
+                    <p class="text-sm font-bold text-slate-800" th:text="${profile.accessLevel.label()}">미리보기</p>
+                    <p class="mt-1 text-sm leading-relaxed text-slate-500"
+                       th:text="${profile.accessLevel.guideMessage()}">
+                        추천/요청 판단에 필요한 정보만 공개됩니다.
+                    </p>
+                </div>
+            </div>
+        </article>
+    </aside>
+</th:block>
+
+<th:block th:fragment="matchingContextPanel(profile)" th:with="ctx=${profile.matchingContext}">
+    <aside class="space-y-6">
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">MATCHING CONTEXT</p>
+            <h2 class="mt-2 text-lg font-bold text-slate-900">매칭 상태</h2>
+            <div class="mt-5 rounded-2xl bg-slate-50 px-5 py-4">
+                <p class="text-sm font-bold text-slate-800" th:text="${ctx.statusLabel}">매칭 요청</p>
+                <p class="mt-2 text-sm leading-relaxed text-slate-500" th:text="${ctx.helperMessage}">
+                    매칭 상태 안내입니다.
+                </p>
+            </div>
+            <div class="mt-4 flex items-center gap-2 rounded-2xl border px-5 py-4 text-sm font-bold"
+                 th:classappend="${ctx.contactVisible} ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-500'">
+                <i th:if="${ctx.contactVisible}" data-lucide="phone" class="h-4 w-4"></i>
+                <i th:unless="${ctx.contactVisible}" data-lucide="phone-off" class="h-4 w-4"></i>
+                <span th:text="${ctx.contactVisible ? '연락처 공개됨' : '연락처 비공개'}">연락처 비공개</span>
+            </div>
+        </article>
+
+        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+            <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">ACTIONS</p>
+            <h2 class="mt-2 text-lg font-bold text-slate-900">현재 가능한 작업</h2>
+
+            <div th:if="${ctx.canRespond()}" class="mt-5 space-y-3">
+                <form th:action="${ctx.acceptActionUrl}" method="post">
+                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                    <input type="hidden" name="redirectTo" th:value="${ctx.matchingDetailUrl}">
+                    <input type="hidden" name="errorRedirectTo" th:value="${ctx.matchingDetailUrl}">
+                    <button type="submit"
+                            class="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-blue-700">
+                        <i data-lucide="check" class="h-4 w-4"></i>
+                        매칭 요청 수락
+                    </button>
+                </form>
+                <form th:action="${ctx.rejectActionUrl}" method="post">
+                    <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                    <input type="hidden" name="redirectTo" th:value="${ctx.matchingDetailUrl}">
+                    <input type="hidden" name="errorRedirectTo" th:value="${ctx.matchingDetailUrl}">
+                    <button type="submit"
+                            class="flex w-full items-center justify-center gap-2 rounded-2xl border border-rose-200 bg-white px-4 py-3 text-sm font-bold text-rose-600 transition hover:bg-rose-50">
+                        <i data-lucide="x" class="h-4 w-4"></i>
+                        매칭 요청 거절
+                    </button>
+                </form>
+            </div>
+
+            <a th:href="${ctx.matchingDetailUrl}"
+               class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                <i data-lucide="users" class="h-4 w-4"></i>
+                매칭 상세 보기
+            </a>
+            <a th:href="${ctx.proposalDetailUrl}"
+               class="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                <i data-lucide="file-text" class="h-4 w-4"></i>
+                제안서 보기
+            </a>
+        </article>
+    </aside>
+</th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/profileFragments.html
+++ b/src/main/resources/templates/fragments/profileFragments.html
@@ -101,7 +101,13 @@
                 <span th:each="skill : ${body.skills}"
                       class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
                     <span class="font-semibold" th:text="${skill.name}">Spring</span>
-                    <span class="rounded-md bg-slate-50 px-2 py-0.5 text-xs font-bold text-slate-500"
+                    <span class="rounded-md border px-2 py-0.5 text-xs font-bold transition-colors"
+                          th:classappend="${
+                              skill.proficiencyCode == 'BEGINNER' ? 'border-emerald-200 bg-emerald-50 text-emerald-600' :
+                              skill.proficiencyCode == 'INTERMEDIATE' ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                              skill.proficiencyCode == 'ADVANCED' ? 'border-amber-200 bg-amber-50 text-amber-600' :
+                              'border-slate-200 bg-slate-50 text-slate-500'
+                          }"
                           th:text="${skill.proficiencyLabel}">중급</span>
                 </span>
             </div>

--- a/src/main/resources/templates/recommendation/resume.html
+++ b/src/main/resources/templates/recommendation/resume.html
@@ -3,251 +3,32 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 <head>
-    <title th:text="${view.proposalTitle} + ' | 추천 후보 이력서'">추천 후보 이력서 | IT-da</title>
+  <title th:text="${view.profile().title} + ' | IT-da'">추천 후보 프로필 | IT-da</title>
 </head>
 <body>
 <div layout:fragment="content">
-    <main class="min-h-screen bg-slate-50">
+  <main class="min-h-screen bg-slate-50" th:with="profile=${view.profile()}">
 
-        <!-- 상단 바 -->
-        <div class="sticky top-0 z-10 border-b border-slate-200 bg-white/95 px-6 py-4 backdrop-blur">
-            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
-                <div class="flex items-center gap-4">
-                    <a th:href="${view.backUrl}"
-                       class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
-                        <i data-lucide="arrow-left" class="h-4 w-4"></i>
-                    </a>
-                    <div>
-                        <h1 class="text-lg font-bold text-slate-900">추천 후보 이력서</h1>
-                        <p class="mt-0.5 text-xs text-slate-400"
-                           th:text="${view.proposalTitle + ' · ' + view.positionTitle}">제안서 · 포지션</p>
-                        <p class="mt-0.5 text-[11px] font-semibold text-slate-400">상세보기 &gt;</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <th:block th:replace="~{fragments/profileFragments :: profileHeader(profile=${profile})}"></th:block>
+    <th:block th:replace="~{fragments/profileFragments :: profileAlerts}"></th:block>
 
-        <div class="mx-auto max-w-7xl px-4 pt-5 lg:px-6">
-            <section th:if="${errorMessage != null}"
-                     class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
-                <p th:text="${errorMessage}">오류 메시지</p>
-            </section>
-            <section th:if="${noticeMessage != null}"
-                     class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
-                <p th:text="${noticeMessage}">안내 메시지</p>
-            </section>
-        </div>
+    <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+      <div class="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(320px,0.85fr)]">
 
-        <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
-            <div class="grid gap-6 lg:grid-cols-5">
+        <th:block th:if="${profile.freelancerSubject()}"
+                  th:replace="~{fragments/profileFragments :: freelancerBody(profile=${profile})}">
+        </th:block>
 
-                <!-- 좌측: 후보 요약/사유/강점 -->
-                <section class="lg:col-span-2 space-y-6">
-                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
-                        <div class="flex items-center justify-between">
-                            <div class="flex items-center gap-2">
-                                <span class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-600"
-                                      th:text="${'TOP ' + view.candidate.rank}">TOP 1</span>
-                            </div>
-                            <p th:classappend="${view.candidate.finalScorePercent >= 80} ? 'text-blue-600' :
-                                                (${view.candidate.finalScorePercent >= 60} ? 'text-indigo-500' : 'text-slate-600')"
-                               class="text-2xl font-black tracking-tight"
-                               th:text="${view.candidate.finalScorePercent + '%'}">92%</p>
-                        </div>
+        <th:block th:if="${profile.clientSubject()}"
+                  th:replace="~{fragments/profileFragments :: clientBody(profile=${profile})}">
+        </th:block>
 
-                        <div class="mt-4">
-                            <p class="text-base font-bold text-slate-900" th:text="${view.candidate.maskedName}">김*수</p>
-                            <p class="mt-1 text-sm text-slate-500" th:text="${view.candidate.introduction}">자기소개</p>
-                        </div>
-
-                        <div class="mt-4 grid grid-cols-[1fr_1.6fr_1fr] gap-2">
-                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
-                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">경력</p>
-                                <p class="mt-1 text-sm font-bold text-slate-800" th:text="${view.candidate.careerYears} + '년'">5년</p>
-                            </div>
-                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
-                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">선호 근무 형태</p>
-                                <p class="mt-1 text-xs font-bold leading-tight text-slate-800"
-                                   th:text="${view.candidate.preferredWorkTypeLabel}">원격</p>
-                            </div>
-                            <div class="rounded-xl bg-slate-50 px-3 py-2 text-center">
-                                <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">매칭 점수</p>
-                                <p class="mt-1 text-sm font-bold text-slate-800" th:text="${view.candidate.embeddingScorePercent + '%'}">88%</p>
-                            </div>
-                        </div>
-
-                        <div class="mt-4 flex flex-wrap gap-1.5" th:if="${!#lists.isEmpty(view.candidate.matchedSkills)}">
-                            <span th:each="skill : ${view.candidate.matchedSkills}"
-                                  class="rounded-md border border-slate-100 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-600"
-                                  th:text="${skill}">Java</span>
-                        </div>
-
-                        <!-- 매칭 없음: 요청 버튼 -->
-                        <th:block th:if="${view.candidate.matchingStatus == null}">
-                            <form class="mt-4"
-                                  th:action="@{/recommendation-results/{id}/matchings(id=${view.resultId})}"
-                                  method="post">
-                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                <input type="hidden" name="redirectTo"
-                                       th:value="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${view.resultId})}">
-                                <input type="hidden" name="errorRedirectTo"
-                                       th:value="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${view.resultId})}">
-                                <button type="submit"
-                                        class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
-                                    <i data-lucide="send" class="h-4 w-4"></i>
-                                    매칭 요청하기
-                                </button>
-                            </form>
-                        </th:block>
-
-                        <!-- 수락 대기 중(PROPOSED) -->
-                        <th:block th:if="${view.candidate.matchingStatus == 'PROPOSED'}">
-                            <a th:if="${view.candidate.matchingId != null}"
-                               th:href="@{/matchings/{id}(id=${view.candidate.matchingId})}"
-                               class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700 transition hover:bg-amber-100">
-                                <i data-lucide="clock" class="h-4 w-4"></i>
-                                수락 대기 중
-                                <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
-                            </a>
-                            <div th:unless="${view.candidate.matchingId != null}"
-                                 class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-700">
-                                <i data-lucide="clock" class="h-4 w-4"></i>
-                                수락 대기 중
-                            </div>
-                        </th:block>
-
-                        <!-- 매칭 진행 중(ACCEPTED / IN_PROGRESS) -->
-                        <th:block th:if="${view.candidate.matchingStatus == 'ACCEPTED' or view.candidate.matchingStatus == 'IN_PROGRESS'}">
-                            <a th:if="${view.candidate.matchingId != null}"
-                               th:href="@{/matchings/{id}(id=${view.candidate.matchingId})}"
-                               class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700 transition hover:bg-emerald-100">
-                                <i data-lucide="check-circle" class="h-4 w-4"></i>
-                                매칭 진행 중
-                                <i data-lucide="chevron-right" class="h-4 w-4 opacity-60"></i>
-                            </a>
-                            <div th:unless="${view.candidate.matchingId != null}"
-                                 class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm font-bold text-emerald-700">
-                                <i data-lucide="check-circle" class="h-4 w-4"></i>
-                                매칭 진행 중
-                            </div>
-                        </th:block>
-
-
-                        <!-- 거절됨 (REJECTED) -->
-                        <div th:if="${view.candidate.matchingStatus == 'REJECTED'}"
-                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                            <i data-lucide="x-circle" class="h-4 w-4"></i>
-                            거절됨
-                        </div>
-
-                        <!-- 완료 / 취소 (COMPLETED / CANCELED) -->
-                        <div th:if="${view.candidate.matchingStatus == 'COMPLETED' or view.candidate.matchingStatus == 'CANCELED'}"
-                             class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm font-bold text-slate-400">
-                            <i data-lucide="archive" class="h-4 w-4"></i>
-                            <span th:text="${view.candidate.matchingStatus == 'COMPLETED'} ? '매칭 완료' : '취소됨'">매칭 완료</span>
-                        </div>
-                    </article>
-
-                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
-                        <div class="mb-2 flex items-center gap-2">
-                            <i data-lucide="sparkles" class="h-4 w-4 text-blue-400"></i>
-                            <h2 class="text-sm font-bold text-slate-900">AI 추천 사유</h2>
-                        </div>
-                        <p th:if="${view.candidate.llmReady and view.candidate.llmReason != null}"
-                           class="text-sm leading-relaxed text-slate-700"
-                           th:text="${view.candidate.llmReason}">AI 추천 사유 내용</p>
-                        <p th:unless="${view.candidate.llmReady and view.candidate.llmReason != null}"
-                           class="text-xs text-slate-400 italic">AI 분석을 준비 중입니다.</p>
-                    </article>
-
-                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50"
-                             th:if="${!#lists.isEmpty(view.candidate.highlights)}">
-                        <div class="mb-2 flex items-center gap-2">
-                            <i data-lucide="star" class="h-4 w-4 text-emerald-500"></i>
-                            <h2 class="text-sm font-bold text-slate-900">주요 강점</h2>
-                        </div>
-                        <ul class="space-y-2">
-                            <li th:each="h : ${view.candidate.highlights}"
-                                class="rounded-xl bg-emerald-50/70 px-4 py-3 text-sm text-slate-700"
-                                th:text="${h}">강점</li>
-                        </ul>
-                    </article>
-                </section>
-
-                <!-- 우측: 이력서 상세 -->
-                <section class="lg:col-span-3 space-y-6">
-                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
-                        <div class="mb-3 flex items-center justify-between">
-                            <h2 class="text-base font-bold text-slate-900">이력서</h2>
-                            <a th:if="${view.portfolioUrl != null}"
-                               th:href="${view.portfolioUrl}"
-                               target="_blank" rel="noreferrer noopener"
-                               class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
-                                <i data-lucide="link" class="h-3.5 w-3.5"></i>
-                                포트폴리오
-                            </a>
-                        </div>
-
-                        <div class="space-y-3">
-                            <div class="rounded-xl bg-slate-50 px-4 py-3">
-                                <p class="text-xs font-bold text-slate-500">자기소개</p>
-                                <p class="mt-1 text-sm leading-relaxed text-slate-800"
-                                   th:text="${view.candidate.introduction}">소개</p>
-                            </div>
-                        </div>
-                    </article>
-
-                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
-                        <h2 class="mb-3 text-base font-bold text-slate-900">보유 기술</h2>
-                        <div th:if="${#lists.isEmpty(view.resumeSkills)}"
-                             class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
-                            등록된 기술이 없습니다.
-                        </div>
-                        <div th:unless="${#lists.isEmpty(view.resumeSkills)}"
-                             class="flex flex-wrap gap-2">
-                            <span th:each="skill : ${view.resumeSkills}"
-                                  class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
-                                <span class="font-semibold" th:text="${skill.name}">Spring</span>
-                                <span class="rounded-md bg-slate-50 px-2 py-0.5 text-xs font-bold text-slate-500"
-                                      th:text="${skill.proficiencyLabel}">중급</span>
-                            </span>
-                        </div>
-                    </article>
-
-                    <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
-                        <h2 class="mb-3 text-base font-bold text-slate-900">경력</h2>
-                        <div th:if="${#lists.isEmpty(view.careerItems)}"
-                             class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
-                            등록된 경력이 없습니다.
-                        </div>
-                        <div th:unless="${#lists.isEmpty(view.careerItems)}" class="space-y-4">
-                            <div th:each="c : ${view.careerItems}"
-                                 class="rounded-2xl border border-slate-100 bg-slate-50 px-5 py-4">
-                                <div class="flex flex-wrap items-center justify-between gap-2">
-                                    <div>
-                                        <p class="text-sm font-bold text-slate-900"
-                                           th:text="${c.companyName + ' · ' + c.position}">회사 · 직무</p>
-                                        <p class="mt-0.5 text-xs text-slate-500"
-                                           th:text="${c.employmentTypeLabel + ' · ' + c.periodLabel}">고용형태 · 기간</p>
-                                    </div>
-                                </div>
-
-                                <p th:if="${c.summary != null and !#strings.isEmpty(c.summary)}"
-                                   class="mt-3 text-sm leading-relaxed text-slate-700"
-                                   th:text="${c.summary}">요약</p>
-
-                                <div class="mt-3 flex flex-wrap gap-1.5" th:if="${!#lists.isEmpty(c.techStack)}">
-                                    <span th:each="t : ${c.techStack}"
-                                          class="rounded-md border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-600"
-                                          th:text="${t}">Java</span>
-                                </div>
-                            </div>
-                        </div>
-                    </article>
-                </section>
-            </div>
-        </div>
-    </main>
+        <th:block th:if="${profile.hasRecommendationContext()}"
+                  th:replace="~{fragments/profileFragments :: recommendationContextPanel(profile=${profile})}">
+        </th:block>
+      </div>
+    </div>
+  </main>
 </div>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -1,11 +1,13 @@
 package com.generic4.itda.controller;
 
 import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -169,7 +171,7 @@ class RecommendationControllerTest {
                         "PROPOSED"   // matchingStatus
                 ),
                 "https://example.com",
-                List.of(new RecommendationResumeSkillItem("Java", "고급")),
+                List.of(new RecommendationResumeSkillItem("Java", "고급", "ADVANCED")),
                 List.of(new RecommendationResumeCareerItem(
                         "ACME",
                         "Backend",
@@ -192,7 +194,8 @@ class RecommendationControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("recommendation/resume"))
-                .andExpect(model().attributeExists("view"));
+                .andExpect(model().attributeExists("view"))
+                .andExpect(content().string(containsString("text-amber-600")));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com"));

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -20,8 +20,12 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationAlgorithm;
 import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.domain.recommendation.vo.HardFilterStat;
 import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
+import com.generic4.itda.domain.resume.Proficiency;
 import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeSkill;
+import com.generic4.itda.domain.resume.ResumeSkillComparator;
 import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.matching.LatestMatchingSummary;
 import com.generic4.itda.dto.profile.ProfileAccessLevel;
 import com.generic4.itda.dto.profile.ProfileContextType;
@@ -36,6 +40,8 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -160,7 +166,9 @@ class RecommendationRunQueryServiceTest {
         given(resume.getIntroduction()).willReturn("소개글");
         given(resume.getPreferredWorkType()).willReturn(WorkType.HYBRID);
         given(resume.getPortfolioUrl()).willReturn("https://example.com");
-        given(resume.getSkills()).willReturn(null);
+        given(resume.getSkills()).willReturn(skills(
+                ResumeSkill.create(resume, Skill.create("Java", null), Proficiency.ADVANCED)
+        ));
         given(resume.getCareer()).willReturn(null);
 
         ReasonFacts facts = new ReasonFacts(List.of(), List.of(), 3, List.of());
@@ -186,6 +194,9 @@ class RecommendationRunQueryServiceTest {
         assertThat(view.resultId()).isEqualTo(RESULT_ID);
         assertThat(view.candidate().matchingId()).isEqualTo(matchingId);
         assertThat(view.candidate().matchingStatus()).isEqualTo("IN_PROGRESS");
+        assertThat(view.resumeSkills()).hasSize(1);
+        assertThat(view.resumeSkills().get(0).proficiencyLabel()).isEqualTo("고급");
+        assertThat(view.resumeSkills().get(0).proficiencyCode()).isEqualTo("ADVANCED");
 
         var profile = view.profile();
         assertThat(profile.subjectType()).isEqualTo(ProfileSubjectType.FREELANCER);
@@ -195,6 +206,7 @@ class RecommendationRunQueryServiceTest {
         assertThat(profile.subtitle()).isEqualTo("Test Proposal · Backend Dev");
         assertThat(profile.freelancer().displayName()).isEqualTo("이*신");
         assertThat(profile.freelancer().introduction()).isEqualTo("소개글");
+        assertThat(profile.freelancer().skills().get(0).proficiencyCode()).isEqualTo("ADVANCED");
         assertThat(profile.recommendationContext().matchingId()).isEqualTo(matchingId);
         assertThat(profile.recommendationContext().matchingStatus()).isEqualTo("IN_PROGRESS");
         assertThat(profile.recommendationContext().active()).isTrue();
@@ -364,5 +376,11 @@ class RecommendationRunQueryServiceTest {
                 run.markFailed("추천 생성 실패");
             }
         }
+    }
+
+    private static SortedSet<ResumeSkill> skills(ResumeSkill... items) {
+        SortedSet<ResumeSkill> skills = new TreeSet<>(new ResumeSkillComparator());
+        skills.addAll(List.of(items));
+        return skills;
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -23,6 +23,9 @@ import com.generic4.itda.domain.recommendation.vo.ReasonFacts;
 import com.generic4.itda.domain.resume.Resume;
 import com.generic4.itda.domain.resume.WorkType;
 import com.generic4.itda.dto.matching.LatestMatchingSummary;
+import com.generic4.itda.dto.profile.ProfileAccessLevel;
+import com.generic4.itda.dto.profile.ProfileContextType;
+import com.generic4.itda.dto.profile.ProfileSubjectType;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
@@ -183,6 +186,19 @@ class RecommendationRunQueryServiceTest {
         assertThat(view.resultId()).isEqualTo(RESULT_ID);
         assertThat(view.candidate().matchingId()).isEqualTo(matchingId);
         assertThat(view.candidate().matchingStatus()).isEqualTo("IN_PROGRESS");
+
+        var profile = view.profile();
+        assertThat(profile.subjectType()).isEqualTo(ProfileSubjectType.FREELANCER);
+        assertThat(profile.contextType()).isEqualTo(ProfileContextType.RECOMMENDATION);
+        assertThat(profile.accessLevel()).isEqualTo(ProfileAccessLevel.PREVIEW);
+        assertThat(profile.title()).isEqualTo("추천 후보 프로필");
+        assertThat(profile.subtitle()).isEqualTo("Test Proposal · Backend Dev");
+        assertThat(profile.freelancer().displayName()).isEqualTo("이*신");
+        assertThat(profile.freelancer().introduction()).isEqualTo("소개글");
+        assertThat(profile.recommendationContext().matchingId()).isEqualTo(matchingId);
+        assertThat(profile.recommendationContext().matchingStatus()).isEqualTo("IN_PROGRESS");
+        assertThat(profile.recommendationContext().active()).isTrue();
+        assertThat(profile.recommendationContext().matchingDetailUrl()).isEqualTo("/matchings/9001");
 
         then(recommendationResultRepository).should().findDetailById(RESULT_ID);
         then(matchingRepository).should().getLatestMatchingSummary(PROPOSAL_POSITION_ID, resumeId);


### PR DESCRIPTION
## 🔎 What

추천 후보 프로필 화면을 기준으로 공통으로 사용할 **프로필 셸 구조를 도입하고**, 프로필 본문과 문맥(추천/매칭) 영역을 분리했습니다.

기존에는 추천 후보 프로필(`resume.html`)에서 이력서 본문, 추천 점수, AI 사유, 매칭 요청 CTA가 하나의 템플릿과 ViewModel에 섞여 있었고, 매칭 상세는 별도의 구조에서 상태/CTA를 관리하고 있어 재사용이 어려운 상태였습니다.

이번 작업에서는 다음과 같이 구조를 정리했습니다:

* 프로필 화면을 하나의 조립 단위로 표현하는 `ProfileShellViewModel` 도입
* subjectType 기반으로 프리랜서/클라이언트 **본문 DTO 분리**

  * `ProfileFreelancerBodyViewModel`
  * `ProfileClientBodyViewModel`
* contextType 기반으로 **문맥 DTO 분리**

  * `ProfileRecommendationContextViewModel`
* `resume.html`에서 프로필 본문과 추천 문맥(점수, 사유, CTA) 영역을 분리하여 **좌측(본문) / 우측(문맥 패널)** 구조로 정리
* 기존 `RecommendationResumeDetailViewModel`의 책임을 축소하고, 프로필/문맥 데이터로 역할 분리

이를 통해 프로필을 “페이지”가 아닌 **본문 + 문맥 조합 구조**로 재구성했으며, 이후 매칭 영역에서도 동일한 구조를 재사용할 수 있는 기반을 마련했습니다.

---

## 🔗 Issue

* Closes: #124 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?

---

## 💡 Note

* 이번 PR에서는 **추천 후보 프로필 화면 기준으로 구조를 정리**하는 것까지 포함합니다.
* 매칭 상세(`MatchingDetailViewModel`, `MatchingQueryService`)는 기존 구조를 유지하며,
  `/matchings/{matchingId}/counterpart-profile` 기반 프로필 통합은 후속 이슈에서 진행합니다.
* 최종적으로는 추천/매칭 모두 `ProfileShellViewModel`을 기준으로 렌더링하도록 확장할 예정입니다.
