### PR TITLE
[Refactor] AI 브리프/AI 인터뷰 Position 자동 생성 방지 및 기존 Position 기준 매핑 처리

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -19,11 +19,14 @@
 - `proposal`은 프로젝트 전체 수준의 문서다.
 - `proposal_position`은 실제 모집 단위다.
 - `position`은 공용 직무 마스터다.
+- `position`은 현재 `백엔드 개발자`, `프론트엔드 개발자`, `풀스택 개발자`, `모바일 앱 개발자`, `AI 엔지니어`, `데이터 엔지니어`, `DevOps 엔지니어`, `UI/UX 디자이너`, `서비스 기획자`, `QA 엔지니어` 10종의 canonical 직무 마스터를 사용한다.
 - `proposal_position_skill`은 실제 모집 단위별 요구 스킬 집합이다.
 - 요구 스킬 테이블의 FK 기준은 `proposal_position.id`다.
 - 같은 제안서 안에서도 같은 직무 마스터를 여러 번 사용할 수 있고, 구체 구분은 `proposal_position.title`로 한다.
 - `proposal_position`은 `title`, `work_type`, `expected_period`, `career_min_years`, `career_max_years`, `work_place`를 포함하는 상세 모집 단위로 확장한다.
 - `proposal_position_skill.importance`는 null 저장을 허용하지 않고, 입력이 비어 있으면 `PREFERENCE`를 기본값으로 사용한다.
+- 제안서 수동 입력과 AI 브리프/AI 인터뷰는 모두 같은 `position` 마스터를 사용한다.
+- AI 직무 카테고리는 alias 정규화 후 canonical `position`으로 매핑하고, 매핑에 실패하면 신규 `position`을 만들지 않고 해당 모집 단위를 저장하지 않는다.
 
 ### AI 브리프 저장 모델
 

--- a/docs/domain-spec.md
+++ b/docs/domain-spec.md
@@ -71,6 +71,8 @@
   `expected_period`, `career_min_years`, `career_max_years`, `work_place`, `status`를 가진다.
 - `proposal_position.status`는 `OPEN`, `FULL`, `CLOSED`를 저장한다.
 - `proposal_position_skills`는 `proposal_position`별 요구 스킬을 저장한다.
+- `position`은 현재 `백엔드 개발자`, `프론트엔드 개발자`, `풀스택 개발자`, `모바일 앱 개발자`, `AI 엔지니어`, `데이터 엔지니어`, `DevOps 엔지니어`, `UI/UX 디자이너`, `서비스 기획자`, `QA 엔지니어` 10종의 canonical 마스터를 사용한다.
+- AI 브리프/AI 인터뷰는 alias 정규화 후 canonical `position`에 매핑되는 경우에만 모집 단위를 반영하며, 목록 밖 직무로 신규 `position`을 생성하지 않는다.
 - `matching`은 `proposal_position`과 `resume`의 조합을 표현하되, 당사자 판정 anchor로 `client_member_id`, `freelancer_member_id`를 함께 가진다.
 - `matching`은 `status` 단일 필드와 참여자별 계약 시작 확인, 취소 요청, 후기, 완료 확인 필드로 흐름을 관리한다.
 - 현재 ERD에는 `initiator_type`, `participation_status`, 시작/종료 승인 시각이 없다.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -29,6 +29,8 @@
 - `proposal`의 `work_type`, `work_place`는 두지 않고, 근무 형태와 근무지는 `proposal_position`에 둔다.
 - `proposal_position`은 `title`, `work_type`, `expected_period`, `career_min/max_years`, `work_place`를 포함하는 상세 모집 단위다.
 - 같은 제안서 안에서도 같은 직무 마스터를 여러 번 사용할 수 있고, 세부 구분은 `proposal_position.title`로 처리한다.
+- `position` 공용 마스터는 현재 `백엔드 개발자`, `프론트엔드 개발자`, `풀스택 개발자`, `모바일 앱 개발자`, `AI 엔지니어`, `데이터 엔지니어`, `DevOps 엔지니어`, `UI/UX 디자이너`, `서비스 기획자`, `QA 엔지니어` 10종 canonical 직무로 제한한다.
+- AI 브리프/AI 인터뷰는 이 canonical 목록으로만 직무를 반영하고, 목록 밖 카테고리는 신규 생성하지 않는다.
 - MVP에서는 별도 `project` 테이블 없이 `matching.status` 단일 모델로 진행 흐름을 관리한다.
 - `matching`은 `proposal_position_id`, `resume_id`와 함께 `client_member_id`, `freelancer_member_id`를 유지한다.
 - `ACCEPTED -> IN_PROGRESS`는 양측 계약 시작 확인, `IN_PROGRESS -> COMPLETED`는 양측 후기 작성과 완료 확인을 조건으로 둔다.

--- a/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
+++ b/src/main/java/com/generic4/itda/config/SeedDataInitializer.java
@@ -27,18 +27,22 @@ import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.repository.ProposalPositionRepository;
 import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import com.generic4.itda.repository.ResumeRepository;
 import com.generic4.itda.repository.SkillRepository;
+import com.generic4.itda.service.PositionResolver;
 import com.generic4.itda.service.ResumeEmbeddingService;
 import com.generic4.itda.service.recommend.RecommendationFingerprintGenerator;
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,11 +84,13 @@ public class SeedDataInitializer implements ApplicationRunner {
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
     private final ResumeRepository resumeRepository;
+    private final ProposalPositionRepository proposalPositionRepository;
     private final ProposalRepository proposalRepository;
     private final MatchingRepository matchingRepository;
     private final RecommendationRunRepository recommendationRunRepository;
     private final RecommendationResultRepository recommendationResultRepository;
     private final RecommendationFingerprintGenerator recommendationFingerprintGenerator;
+    private final PositionResolver positionResolver;
     private final ResumeEmbeddingService resumeEmbeddingService;
     private final PasswordEncoder passwordEncoder;
 
@@ -94,6 +100,9 @@ public class SeedDataInitializer implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         Map<String, Position> positions = ensurePositions();
+        normalizeProposalPositionCategories(positions);
+        cleanupUnusedLegacyPositions(positions);
+        positions = ensurePositions();
         Map<String, Skill> skills = ensureSkills();
 
         Member client = ensureMember(SEED_CLIENT_EMAIL, "시드 클라이언트", "추천 테스트용 발주자", "010-9000-1000");
@@ -867,10 +876,65 @@ public class SeedDataInitializer implements ApplicationRunner {
 
     private Map<String, Position> ensurePositions() {
         Map<String, Position> positions = new LinkedHashMap<>();
-        positions.put("백엔드 개발자", ensurePosition("백엔드 개발자"));
-        positions.put("프론트엔드 개발자", ensurePosition("프론트엔드 개발자"));
-        positions.put("AI 엔지니어", ensurePosition("AI 엔지니어"));
+        for (String positionName : positionResolver.findAllowedCategoryNames()) {
+            positions.put(positionName, ensurePosition(positionName));
+        }
         return positions;
+    }
+
+    private void normalizeProposalPositionCategories(Map<String, Position> canonicalPositions) {
+        List<ProposalPosition> proposalPositions = proposalPositionRepository.findAll();
+
+        for (ProposalPosition proposalPosition : proposalPositions) {
+            Position currentPosition = proposalPosition.getPosition();
+            if (currentPosition == null || currentPosition.getName() == null) {
+                continue;
+            }
+
+            Optional<String> canonicalName = positionResolver.resolveCanonicalName(currentPosition.getName());
+            if (canonicalName.isEmpty()) {
+                continue;
+            }
+
+            Position canonicalPosition = canonicalPositions.get(canonicalName.get());
+            if (canonicalPosition == null || hasSamePosition(currentPosition, canonicalPosition)) {
+                continue;
+            }
+
+            proposalPosition.update(
+                    canonicalPosition,
+                    proposalPosition.getTitle(),
+                    proposalPosition.getWorkType(),
+                    proposalPosition.getHeadCount(),
+                    proposalPosition.getUnitBudgetMin(),
+                    proposalPosition.getUnitBudgetMax(),
+                    proposalPosition.getExpectedPeriod(),
+                    proposalPosition.getCareerMinYears(),
+                    proposalPosition.getCareerMaxYears(),
+                    proposalPosition.getWorkPlace()
+            );
+        }
+    }
+
+    private void cleanupUnusedLegacyPositions(Map<String, Position> canonicalPositions) {
+        Set<Long> usedPositionIds = new HashSet<>();
+        for (ProposalPosition proposalPosition : proposalPositionRepository.findAll()) {
+            if (proposalPosition.getPosition() != null && proposalPosition.getPosition().getId() != null) {
+                usedPositionIds.add(proposalPosition.getPosition().getId());
+            }
+        }
+
+        for (Position position : positionRepository.findAll()) {
+            if (canonicalPositions.containsKey(position.getName())) {
+                continue;
+            }
+
+            if (position.getId() != null && usedPositionIds.contains(position.getId())) {
+                continue;
+            }
+
+            positionRepository.delete(position);
+        }
     }
 
     private Map<String, Skill> ensureSkills() {
@@ -1422,6 +1486,16 @@ public class SeedDataInitializer implements ApplicationRunner {
     private Position ensurePosition(String name) {
         return positionRepository.findByName(name)
                 .orElseGet(() -> positionRepository.save(Position.create(name)));
+    }
+
+    private boolean hasSamePosition(Position source, Position target) {
+        if (source == target) {
+            return true;
+        }
+        if (source.getId() != null && target.getId() != null) {
+            return source.getId().equals(target.getId());
+        }
+        return source.getName().equals(target.getName());
     }
 
     private Skill ensureSkill(String name, String description) {

--- a/src/main/java/com/generic4/itda/controller/PositionSearchController.java
+++ b/src/main/java/com/generic4/itda/controller/PositionSearchController.java
@@ -1,0 +1,30 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.service.PositionResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PositionSearchController {
+
+    private final PositionResolver positionResolver;
+
+    @GetMapping("/api/positions")
+    public List<PositionSearchResponse> search(@RequestParam(name = "query", required = false) String query) {
+        return positionResolver.search(query).stream()
+                .map(PositionSearchResponse::from)
+                .toList();
+    }
+
+    public record PositionSearchResponse(Long id, String name) {
+
+        private static PositionSearchResponse from(Position position) {
+            return new PositionSearchResponse(position.getId(), position.getName());
+        }
+    }
+}

--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -11,8 +11,8 @@ import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.MatchingRepository;
-import com.generic4.itda.repository.PositionRepository;
 import com.generic4.itda.service.ProposalAiInterviewService;
+import com.generic4.itda.service.PositionResolver;
 import com.generic4.itda.service.ProposalService;
 import jakarta.validation.Valid;
 import java.util.HashSet;
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -46,7 +45,7 @@ public class ProposalController {
 
     private final ProposalService proposalService;
     private final ProposalAiInterviewService proposalAiInterviewService;
-    private final PositionRepository positionRepository;
+    private final PositionResolver positionResolver;
     private final MatchingRepository matchingRepository;
 
     @GetMapping("/new")
@@ -331,7 +330,7 @@ public class ProposalController {
 
     private void addCommonAttributes(Model model) {
         model.addAttribute("workTypes", ProposalWorkType.values());
-        model.addAttribute("positionOptions", positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name")));
+        model.addAttribute("positionOptions", positionResolver.findAllowedPositions());
     }
 
     private void addMemberAttributes(Model model, ItDaPrincipal principal) {

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -10,7 +10,6 @@ import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.proposal.AiBriefPositionResult;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.dto.proposal.AiBriefSkillResult;
-import com.generic4.itda.repository.PositionRepository;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -31,7 +30,7 @@ public class AiBriefProposalMapper {
     private static final ProposalWorkType DEFAULT_WORK_TYPE = ProposalWorkType.REMOTE;
     private static final String DEFAULT_WORK_PLACE = "협의";
 
-    private final PositionRepository positionRepository;
+    private final PositionResolver positionResolver;
     private final SkillResolver skillResolver;
 
     public void apply(Proposal proposal, AiBriefResult aiBriefResult) {
@@ -74,6 +73,9 @@ public class AiBriefProposalMapper {
 
         Map<String, ProposalPosition> existingByPositionName = existingPositionsByPositionName(proposal);
         List<PositionApplication> applications = mergePositionApplicationsByPositionName(positionResults);
+        if (applications.isEmpty()) {
+            return;
+        }
         Set<ProposalPosition> appliedPositions = new HashSet<>();
 
         for (PositionApplication application : applications) {
@@ -229,7 +231,12 @@ public class AiBriefProposalMapper {
         Map<String, PositionApplication> merged = new LinkedHashMap<>();
 
         for (AiBriefPositionResult positionResult : positionResults) {
-            Position position = findOrCreatePosition(positionResult.getPositionCategoryName());
+            Optional<Position> resolvedPosition = positionResolver.resolve(positionResult.getPositionCategoryName());
+            if (resolvedPosition.isEmpty()) {
+                continue;
+            }
+
+            Position position = resolvedPosition.get();
             merged.put(normalizeKey(position.getName()), new PositionApplication(position, positionResult));
         }
 
@@ -308,11 +315,6 @@ public class AiBriefProposalMapper {
         }
 
         return desiredSkills;
-    }
-
-    private Position findOrCreatePosition(String positionCategoryName) {
-        return positionRepository.findByName(positionCategoryName)
-                .orElseGet(() -> positionRepository.save(Position.create(positionCategoryName)));
     }
 
     private String resolveTitle(Proposal proposal, AiBriefResult aiBriefResult) {

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -49,7 +49,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - REMOTE인 경우 workPlace는 null로 둔다.
             - SITE 또는 HYBRID인데 근무지를 알 수 없으면 workPlace는 "협의"로 둔다.
             - headCount가 명확하지 않으면 1로 둔다.
-            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 프론트엔드 개발자, 앱 개발자
+            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 모바일 앱 개발자, QA 엔지니어
             - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Java Spring 백엔드 개발자, React 프론트엔드 개발자
             - 같은 positionCategoryName을 중복 생성하지 않는다.
             - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
@@ -126,14 +126,16 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final AiBriefProperties properties;
+    private final PositionResolver positionResolver;
 
     public OpenAiAiBriefGenerator(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
-                                  AiBriefProperties properties) {
+                                  AiBriefProperties properties, PositionResolver positionResolver) {
         Assert.hasText(properties.getApiKey(), "AI 브리프 API 키는 필수값입니다.");
 
         this.restClient = restClientBuilder.build();
         this.objectMapper = objectMapper;
         this.properties = properties;
+        this.positionResolver = positionResolver;
     }
 
     @Override
@@ -170,7 +172,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
     private Map<String, Object> buildRequestBody(AiBriefGenerateRequest request) {
         Map<String, Object> requestBody = new LinkedHashMap<>();
         requestBody.put("model", properties.getModel());
-        requestBody.put("instructions", BRIEF_GENERATION_INSTRUCTIONS);
+        requestBody.put("instructions", buildInstructions());
         requestBody.put("input", request.getRawInputText());
         requestBody.put("max_output_tokens", properties.getMaxOutputTokens());
 
@@ -179,6 +181,25 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
         requestBody.put("text", text);
 
         return requestBody;
+    }
+
+    private String buildInstructions() {
+        String positionCategoryGuide = positionResolver.findAllowedCategoryNames().stream()
+                .map(name -> "- " + name)
+                .reduce((left, right) -> left + System.lineSeparator() + right)
+                .orElse("");
+
+        return BRIEF_GENERATION_INSTRUCTIONS + """
+
+                허용 가능한 Position 카테고리 목록:
+                %s
+
+                Position 카테고리 추가 규칙:
+                - positionCategoryName은 반드시 허용 가능한 Position 카테고리 목록 중 하나만 사용한다.
+                - 목록에 없는 직무 카테고리는 절대 새로 만들거나 비슷하게 지어내지 않는다.
+                - 사용자의 표현이 목록과 다르면 가장 가까운 기존 Position 카테고리로만 매핑한다.
+                - 어떤 기존 Position 카테고리에도 안전하게 매핑되지 않으면 그 포지션은 positions에 포함하지 않는다.
+                """.formatted(positionCategoryGuide);
     }
 
     private Map<String, Object> buildJsonSchemaFormat() {
@@ -218,6 +239,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
 
     private Map<String, Object> buildPositionSchema() {
         Map<String, Object> schema = objectSchema();
+        List<String> allowedCategoryNames = positionResolver.findAllowedCategoryNames();
         schema.put("required", List.of(
                 "positionCategoryName",
                 "title",
@@ -232,7 +254,7 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
                 "skills"
         ));
         Map<String, Object> properties = new LinkedHashMap<>();
-        properties.put("positionCategoryName", Map.of("type", "string"));
+        properties.put("positionCategoryName", enumSchema(allowedCategoryNames));
         properties.put("title", Map.of("type", "string"));
         properties.put("workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"));
         properties.put("headCount", nullableIntegerSchema());
@@ -273,6 +295,13 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
 
     private Map<String, Object> nullableIntegerSchema() {
         return Map.of("type", List.of("integer", "null"));
+    }
+
+    private Map<String, Object> enumSchema(List<String> values) {
+        return Map.of(
+                "type", "string",
+                "enum", values
+        );
     }
 
     private Map<String, Object> nullableEnumSchema(String... values) {

--- a/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
@@ -53,7 +53,7 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
             - REMOTE인 경우 workPlace는 null로 둔다.
             - SITE 또는 HYBRID인데 근무지를 알 수 없으면 workPlace는 "협의"로 둔다.
             - headCount가 명확하지 않으면 1로 둔다.
-            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 프론트엔드 개발자, 앱 개발자
+            - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 모바일 앱 개발자, QA 엔지니어
             - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Java Spring 백엔드 개발자, React 프론트엔드 개발자
             - 같은 positionCategoryName을 중복 생성하지 않는다.
             - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
@@ -138,17 +138,20 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final AiBriefProperties properties;
+    private final PositionResolver positionResolver;
 
     public OpenAiAiInterviewGenerator(
             RestClient.Builder restClientBuilder,
             ObjectMapper objectMapper,
-            AiBriefProperties properties
+            AiBriefProperties properties,
+            PositionResolver positionResolver
     ) {
         Assert.hasText(properties.getApiKey(), "AI 브리프 API 키는 필수값입니다.");
 
         this.restClient = restClientBuilder.build();
         this.objectMapper = objectMapper;
         this.properties = properties;
+        this.positionResolver = positionResolver;
     }
 
     @Override
@@ -185,7 +188,7 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
     private Map<String, Object> buildRequestBody(AiInterviewGenerateRequest request) {
         Map<String, Object> requestBody = new LinkedHashMap<>();
         requestBody.put("model", properties.getModel());
-        requestBody.put("instructions", INTERVIEW_GENERATION_INSTRUCTIONS);
+        requestBody.put("instructions", buildInstructions());
         requestBody.put("input", buildInput(request));
         requestBody.put("max_output_tokens", properties.getMaxOutputTokens());
 
@@ -194,6 +197,25 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
         requestBody.put("text", text);
 
         return requestBody;
+    }
+
+    private String buildInstructions() {
+        String positionCategoryGuide = positionResolver.findAllowedCategoryNames().stream()
+                .map(name -> "- " + name)
+                .reduce((left, right) -> left + System.lineSeparator() + right)
+                .orElse("");
+
+        return INTERVIEW_GENERATION_INSTRUCTIONS + """
+
+                허용 가능한 Position 카테고리 목록:
+                %s
+
+                Position 카테고리 추가 규칙:
+                - positionCategoryName은 반드시 허용 가능한 Position 카테고리 목록 중 하나만 사용한다.
+                - 목록에 없는 직무 카테고리는 절대 새로 만들거나 비슷하게 지어내지 않는다.
+                - 사용자의 표현이 목록과 다르면 가장 가까운 기존 Position 카테고리로만 매핑한다.
+                - 어떤 기존 Position 카테고리에도 안전하게 매핑되지 않으면 그 포지션은 positions에 포함하지 않는다.
+                """.formatted(positionCategoryGuide);
     }
 
     private String buildInput(AiInterviewGenerateRequest request) {
@@ -275,6 +297,7 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
 
     private Map<String, Object> buildPositionSchema() {
         Map<String, Object> schema = objectSchema();
+        List<String> allowedCategoryNames = positionResolver.findAllowedCategoryNames();
 
         schema.put("required", List.of(
                 "positionCategoryName",
@@ -291,7 +314,7 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
         ));
 
         Map<String, Object> properties = new LinkedHashMap<>();
-        properties.put("positionCategoryName", Map.of("type", "string"));
+        properties.put("positionCategoryName", enumSchema(allowedCategoryNames));
         properties.put("title", Map.of("type", "string"));
         properties.put("workType", nullableEnumSchema("SITE", "REMOTE", "HYBRID"));
         properties.put("headCount", nullableIntegerSchema());
@@ -333,6 +356,13 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
 
     private Map<String, Object> nullableIntegerSchema() {
         return Map.of("type", List.of("integer", "null"));
+    }
+
+    private Map<String, Object> enumSchema(List<String> values) {
+        return Map.of(
+                "type", "string",
+                "enum", values
+        );
     }
 
     private Map<String, Object> nullableEnumSchema(String... values) {

--- a/src/main/java/com/generic4/itda/service/PositionResolver.java
+++ b/src/main/java/com/generic4/itda/service/PositionResolver.java
@@ -45,6 +45,12 @@ public class PositionResolver {
         return ALLOWED_CATEGORY_NAMES;
     }
 
+    public boolean isAllowedPosition(Position position) {
+        return position != null
+                && StringUtils.hasText(position.getName())
+                && ALLOWED_CATEGORY_NAMES.contains(position.getName());
+    }
+
     public List<Position> findAllowedPositions() {
         return ALLOWED_CATEGORY_NAMES.stream()
                 .map(positionRepository::findByName)

--- a/src/main/java/com/generic4/itda/service/PositionResolver.java
+++ b/src/main/java/com/generic4/itda/service/PositionResolver.java
@@ -1,0 +1,159 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.repository.PositionRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class PositionResolver {
+
+    private static final List<String> REMOVABLE_SUFFIXES = List.of(
+            "developer",
+            "engineer",
+            "designer",
+            "manager",
+            "lead",
+            "개발자",
+            "개발",
+            "엔지니어",
+            "디자이너",
+            "기획자",
+            "매니저",
+            "리드"
+    );
+
+    private final PositionRepository positionRepository;
+
+    public Optional<Position> resolve(String positionCategoryName) {
+        if (!StringUtils.hasText(positionCategoryName)) {
+            return Optional.empty();
+        }
+
+        List<Position> positions = positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
+        if (positions.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, Position> exactIndex = new LinkedHashMap<>();
+        Map<String, Position> aliasIndex = new LinkedHashMap<>();
+        Set<String> ambiguousAliases = new LinkedHashSet<>();
+
+        for (Position position : positions) {
+            indexPosition(exactIndex, aliasIndex, ambiguousAliases, position);
+        }
+
+        String normalizedInput = normalize(positionCategoryName);
+        Position exactMatch = exactIndex.get(normalizedInput);
+        if (exactMatch != null) {
+            return Optional.of(exactMatch);
+        }
+
+        for (String alias : buildAliases(positionCategoryName)) {
+            if (ambiguousAliases.contains(alias)) {
+                continue;
+            }
+
+            Position resolved = aliasIndex.get(alias);
+            if (resolved != null) {
+                return Optional.of(resolved);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public List<String> findAllowedCategoryNames() {
+        return positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name")).stream()
+                .map(Position::getName)
+                .toList();
+    }
+
+    private void indexPosition(
+            Map<String, Position> exactIndex,
+            Map<String, Position> aliasIndex,
+            Set<String> ambiguousAliases,
+            Position position
+    ) {
+        String exactKey = normalize(position.getName());
+        exactIndex.putIfAbsent(exactKey, position);
+
+        for (String alias : buildAliases(position.getName())) {
+            Position existing = aliasIndex.get(alias);
+            if (existing == null) {
+                aliasIndex.put(alias, position);
+                continue;
+            }
+
+            if (!isSamePosition(existing, position)) {
+                aliasIndex.remove(alias);
+                ambiguousAliases.add(alias);
+            }
+        }
+    }
+
+    private boolean isSamePosition(Position source, Position target) {
+        if (source == target) {
+            return true;
+        }
+        if (source.getId() != null && target.getId() != null) {
+            return source.getId().equals(target.getId());
+        }
+        return source.getName().equals(target.getName());
+    }
+
+    private List<String> buildAliases(String value) {
+        String normalized = normalize(value);
+        if (!StringUtils.hasText(normalized)) {
+            return List.of();
+        }
+
+        Set<String> aliases = new LinkedHashSet<>();
+        aliases.add(normalized);
+
+        String stripped = stripSuffix(normalized);
+        if (StringUtils.hasText(stripped)) {
+            aliases.add(stripped);
+        }
+
+        return new ArrayList<>(aliases);
+    }
+
+    private String stripSuffix(String normalized) {
+        String current = normalized;
+        boolean changed = true;
+
+        while (changed) {
+            changed = false;
+            for (String suffix : REMOVABLE_SUFFIXES) {
+                if (current.endsWith(suffix) && current.length() > suffix.length()) {
+                    current = current.substring(0, current.length() - suffix.length());
+                    changed = true;
+                    break;
+                }
+            }
+        }
+
+        return current;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.toLowerCase()
+                .replaceAll("[\\s/_-]+", "")
+                .trim();
+    }
+}

--- a/src/main/java/com/generic4/itda/service/PositionResolver.java
+++ b/src/main/java/com/generic4/itda/service/PositionResolver.java
@@ -2,6 +2,7 @@ package com.generic4.itda.service;
 
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.repository.PositionRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -51,6 +52,17 @@ public class PositionResolver {
                 .toList();
     }
 
+    public List<Position> search(String query) {
+        String normalizedQuery = normalizeQuery(query);
+
+        return findAllowedPositions().stream()
+                .filter(position -> matchesSearch(position, normalizedQuery))
+                .sorted(Comparator
+                        .comparingInt((Position position) -> searchScore(position, normalizedQuery))
+                        .thenComparing(Position::getName, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
     public Optional<String> resolveCanonicalName(String positionCategoryName) {
         if (!StringUtils.hasText(positionCategoryName)) {
             return Optional.empty();
@@ -72,6 +84,50 @@ public class PositionResolver {
 
     private String normalize(String value) {
         return normalizeStatic(value);
+    }
+
+    private boolean matchesSearch(Position position, String normalizedQuery) {
+        return searchScore(position, normalizedQuery) < Integer.MAX_VALUE;
+    }
+
+    private int searchScore(Position position, String normalizedQuery) {
+        String positionName = position.getName();
+        if (!ALLOWED_CATEGORY_NAMES.contains(positionName)) {
+            return Integer.MAX_VALUE;
+        }
+
+        String normalizedPositionName = normalize(positionName);
+        if (!StringUtils.hasText(normalizedQuery)) {
+            return 0;
+        }
+
+        String resolvedCanonicalName = CANONICAL_ALIAS_TO_NAME.get(normalizedQuery);
+        if (positionName.equals(resolvedCanonicalName) || normalizedPositionName.equals(normalizedQuery)) {
+            return 0;
+        }
+
+        for (Map.Entry<String, String> entry : CANONICAL_ALIAS_TO_NAME.entrySet()) {
+            if (!entry.getValue().equals(positionName)) {
+                continue;
+            }
+
+            String alias = entry.getKey();
+            if (alias.equals(normalizedQuery)) {
+                return 0;
+            }
+            if (alias.startsWith(normalizedQuery) || normalizedPositionName.startsWith(normalizedQuery)) {
+                return 1;
+            }
+            if (alias.contains(normalizedQuery) || normalizedPositionName.contains(normalizedQuery)) {
+                return 2;
+            }
+        }
+
+        return Integer.MAX_VALUE;
+    }
+
+    private String normalizeQuery(String value) {
+        return StringUtils.hasText(value) ? normalize(value) : "";
     }
 
     private static Map<String, String> createAliasMap() {

--- a/src/main/java/com/generic4/itda/service/PositionResolver.java
+++ b/src/main/java/com/generic4/itda/service/PositionResolver.java
@@ -2,15 +2,11 @@ package com.generic4.itda.service;
 
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.repository.PositionRepository;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -18,136 +14,53 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class PositionResolver {
 
-    private static final List<String> REMOVABLE_SUFFIXES = List.of(
-            "developer",
-            "engineer",
-            "designer",
-            "manager",
-            "lead",
-            "개발자",
-            "개발",
-            "엔지니어",
-            "디자이너",
-            "기획자",
-            "매니저",
-            "리드"
+    private static final List<String> ALLOWED_CATEGORY_NAMES = List.of(
+            "백엔드 개발자",
+            "프론트엔드 개발자",
+            "풀스택 개발자",
+            "모바일 앱 개발자",
+            "AI 엔지니어",
+            "데이터 엔지니어",
+            "DevOps 엔지니어",
+            "UI/UX 디자이너",
+            "서비스 기획자",
+            "QA 엔지니어"
     );
+
+    private static final Map<String, String> CANONICAL_ALIAS_TO_NAME = createAliasMap();
 
     private final PositionRepository positionRepository;
 
     public Optional<Position> resolve(String positionCategoryName) {
+        Optional<String> canonicalName = resolveCanonicalName(positionCategoryName);
+        if (canonicalName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return positionRepository.findByName(canonicalName.get());
+    }
+
+    public List<String> findAllowedCategoryNames() {
+        return ALLOWED_CATEGORY_NAMES;
+    }
+
+    public List<Position> findAllowedPositions() {
+        return ALLOWED_CATEGORY_NAMES.stream()
+                .map(positionRepository::findByName)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    public Optional<String> resolveCanonicalName(String positionCategoryName) {
         if (!StringUtils.hasText(positionCategoryName)) {
             return Optional.empty();
         }
 
-        List<Position> positions = positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
-        if (positions.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Map<String, Position> exactIndex = new LinkedHashMap<>();
-        Map<String, Position> aliasIndex = new LinkedHashMap<>();
-        Set<String> ambiguousAliases = new LinkedHashSet<>();
-
-        for (Position position : positions) {
-            indexPosition(exactIndex, aliasIndex, ambiguousAliases, position);
-        }
-
-        String normalizedInput = normalize(positionCategoryName);
-        Position exactMatch = exactIndex.get(normalizedInput);
-        if (exactMatch != null) {
-            return Optional.of(exactMatch);
-        }
-
-        for (String alias : buildAliases(positionCategoryName)) {
-            if (ambiguousAliases.contains(alias)) {
-                continue;
-            }
-
-            Position resolved = aliasIndex.get(alias);
-            if (resolved != null) {
-                return Optional.of(resolved);
-            }
-        }
-
-        return Optional.empty();
+        String canonicalName = CANONICAL_ALIAS_TO_NAME.get(normalize(positionCategoryName));
+        return Optional.ofNullable(canonicalName);
     }
 
-    public List<String> findAllowedCategoryNames() {
-        return positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name")).stream()
-                .map(Position::getName)
-                .toList();
-    }
-
-    private void indexPosition(
-            Map<String, Position> exactIndex,
-            Map<String, Position> aliasIndex,
-            Set<String> ambiguousAliases,
-            Position position
-    ) {
-        String exactKey = normalize(position.getName());
-        exactIndex.putIfAbsent(exactKey, position);
-
-        for (String alias : buildAliases(position.getName())) {
-            Position existing = aliasIndex.get(alias);
-            if (existing == null) {
-                aliasIndex.put(alias, position);
-                continue;
-            }
-
-            if (!isSamePosition(existing, position)) {
-                aliasIndex.remove(alias);
-                ambiguousAliases.add(alias);
-            }
-        }
-    }
-
-    private boolean isSamePosition(Position source, Position target) {
-        if (source == target) {
-            return true;
-        }
-        if (source.getId() != null && target.getId() != null) {
-            return source.getId().equals(target.getId());
-        }
-        return source.getName().equals(target.getName());
-    }
-
-    private List<String> buildAliases(String value) {
-        String normalized = normalize(value);
-        if (!StringUtils.hasText(normalized)) {
-            return List.of();
-        }
-
-        Set<String> aliases = new LinkedHashSet<>();
-        aliases.add(normalized);
-
-        String stripped = stripSuffix(normalized);
-        if (StringUtils.hasText(stripped)) {
-            aliases.add(stripped);
-        }
-
-        return new ArrayList<>(aliases);
-    }
-
-    private String stripSuffix(String normalized) {
-        String current = normalized;
-        boolean changed = true;
-
-        while (changed) {
-            changed = false;
-            for (String suffix : REMOVABLE_SUFFIXES) {
-                if (current.endsWith(suffix) && current.length() > suffix.length()) {
-                    current = current.substring(0, current.length() - suffix.length());
-                    changed = true;
-                    break;
-                }
-            }
-        }
-
-        return current;
-    }
-
-    private String normalize(String value) {
+    private static String normalizeStatic(String value) {
         if (value == null) {
             return "";
         }
@@ -155,5 +68,70 @@ public class PositionResolver {
         return value.toLowerCase()
                 .replaceAll("[\\s/_-]+", "")
                 .trim();
+    }
+
+    private String normalize(String value) {
+        return normalizeStatic(value);
+    }
+
+    private static Map<String, String> createAliasMap() {
+        Map<String, String> aliases = new LinkedHashMap<>();
+
+        registerAliases(aliases, "백엔드 개발자",
+                "백엔드 개발자", "백엔드", "backend", "backenddeveloper", "backendengineer",
+                "서버 개발자", "서버 엔지니어", "api 개발자", "apideveloper", "java 백엔드",
+                "spring 백엔드", "플랫폼 백엔드", "platformbackend");
+
+        registerAliases(aliases, "프론트엔드 개발자",
+                "프론트엔드 개발자", "프론트엔드", "frontend", "frontenddeveloper",
+                "frontendengineer", "웹 프론트엔드", "webfrontend", "react 개발자",
+                "reactdeveloper", "vue 개발자", "angular 개발자");
+
+        registerAliases(aliases, "풀스택 개발자",
+                "풀스택 개발자", "풀스택", "fullstack", "fullstackdeveloper",
+                "fullstackengineer", "웹 개발자", "webdeveloper");
+
+        registerAliases(aliases, "모바일 앱 개발자",
+                "모바일 앱 개발자", "모바일 개발자", "앱 개발자", "앱개발자", "mobile",
+                "mobiledeveloper", "mobileappdeveloper", "appdeveloper", "ios 개발자",
+                "iosdeveloper", "android 개발자", "androiddeveloper", "flutter 개발자",
+                "flutterdeveloper", "react native 개발자", "reactnativedeveloper");
+
+        registerAliases(aliases, "AI 엔지니어",
+                "AI 엔지니어", "AI", "AI 개발자", "aiengineer", "aideveloper",
+                "ML 엔지니어", "mlengineer", "머신러닝 엔지니어", "llm 엔지니어",
+                "llmengineer", "prompt engineer", "프롬프트 엔지니어", "mlops 엔지니어");
+
+        registerAliases(aliases, "데이터 엔지니어",
+                "데이터 엔지니어", "데이터", "dataengineer", "data engineer",
+                "데이터 플랫폼 엔지니어", "dataplatformengineer", "etl 개발자",
+                "etldeveloper", "analytics engineer");
+
+        registerAliases(aliases, "DevOps 엔지니어",
+                "DevOps 엔지니어", "devops", "devopsengineer", "SRE", "site reliability engineer",
+                "platform engineer", "플랫폼 엔지니어", "인프라 엔지니어", "infra engineer",
+                "cloud engineer", "클라우드 엔지니어");
+
+        registerAliases(aliases, "UI/UX 디자이너",
+                "UI/UX 디자이너", "uiuxdesigner", "ui designer", "ux designer",
+                "product designer", "프로덕트 디자이너", "웹 디자이너", "앱 디자이너",
+                "디자이너");
+
+        registerAliases(aliases, "서비스 기획자",
+                "서비스 기획자", "서비스기획자", "기획자", "planner", "serviceplanner",
+                "product manager", "productmanager", "PM", "PO", "product owner");
+
+        registerAliases(aliases, "QA 엔지니어",
+                "QA 엔지니어", "QA", "qaengineer", "test engineer", "testengineer",
+                "test automation engineer", "quality assurance", "품질보증",
+                "테스트 엔지니어", "테스트 자동화 엔지니어");
+
+        return Map.copyOf(aliases);
+    }
+
+    private static void registerAliases(Map<String, String> aliases, String canonicalName, String... names) {
+        for (String name : names) {
+            aliases.put(normalizeStatic(name), canonicalName);
+        }
     }
 }

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -50,6 +50,7 @@ public class ProposalService {
     private final ProposalRepository proposalRepository;
     private final MemberRepository memberRepository;
     private final PositionRepository positionRepository;
+    private final PositionResolver positionResolver;
     private final SkillResolver skillResolver;
     private final MatchingRepository matchingRepository;
     private final ProposalAiInterviewMessageRepository aiInterviewMessageRepository;
@@ -516,8 +517,14 @@ public class ProposalService {
     }
 
     private Position getPosition(Long positionId) {
-        return positionRepository.findById(positionId)
+        Position position = positionRepository.findById(positionId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직무입니다. id=" + positionId));
+
+        if (!positionResolver.isAllowedPosition(position)) {
+            throw new IllegalArgumentException("존재하지 않는 직무입니다. id=" + positionId);
+        }
+
+        return position;
     }
 
     private Proposal getOwnedProposal(Long proposalId, String memberEmail) {

--- a/src/main/resources/templates/client/proposalForm.html
+++ b/src/main/resources/templates/client/proposalForm.html
@@ -488,13 +488,39 @@
                         <div class="grid gap-6 md:grid-cols-2">
                             <div>
                                 <label class="ml-1 text-[11px] font-black uppercase tracking-widest text-slate-400">직무</label>
-                                <select x-model="currentPosition.positionId"
-                                        class="mt-3 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm font-semibold text-slate-900 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100">
-                                    <option value="">직무를 선택해주세요</option>
-                                    <template x-for="option in positionOptions" :key="option.id">
-                                        <option :value="String(option.id)" x-text="option.name"></option>
-                                    </template>
-                                </select>
+                                <div class="relative mt-3">
+                                    <input type="text"
+                                           x-model="currentPosition.positionSearchDraft"
+                                           @focus="openPositionSearch()"
+                                           @input.debounce.200ms="handlePositionSearchInput()"
+                                           @keydown.enter.prevent="selectFirstPosition()"
+                                           @keydown.escape.prevent="closePositionSearch()"
+                                           @blur="closePositionSearchWithDelay()"
+                                           placeholder="직무 이름 검색"
+                                           autocomplete="off"
+                                           class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm font-semibold text-slate-900 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100">
+                                    <div x-show="positionSearchOpen"
+                                         x-cloak
+                                         class="absolute left-0 right-0 top-full z-20 mt-2 max-h-56 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-2 shadow-xl shadow-slate-900/10">
+                                        <div x-show="positionSearchLoading"
+                                             class="px-4 py-3 text-sm font-semibold text-slate-400">
+                                            검색 중입니다.
+                                        </div>
+                                        <template x-if="!positionSearchLoading && positionSearchResults.length === 0">
+                                            <div class="px-4 py-3 text-sm font-semibold text-slate-400">
+                                                선택할 수 있는 직무가 없습니다.
+                                            </div>
+                                        </template>
+                                        <template x-for="option in positionSearchResults" :key="`position-option-${option.id}`">
+                                            <button type="button"
+                                                    @mousedown.prevent="selectPosition(option)"
+                                                    class="flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left text-sm font-semibold text-slate-700 transition hover:bg-slate-50">
+                                                <span x-text="option.name"></span>
+                                                <i data-lucide="chevron-right" class="h-4 w-4 text-slate-300"></i>
+                                            </button>
+                                        </template>
+                                    </div>
+                                </div>
                             </div>
 
                             <div>
@@ -790,6 +816,10 @@
                 editingIndex: null,
                 currentPosition: null,
                 positionErrors: [],
+                positionSearchResults: [],
+                positionSearchOpen: false,
+                positionSearchLoading: false,
+                positionSearchRequestSequence: 0,
                 skillSearchResults: {
                     essential: [],
                     preferred: []
@@ -1196,6 +1226,7 @@
                     this.editingIndex = null;
                     this.currentPosition = this.blankPosition();
                     this.positionErrors = [];
+                    this.resetPositionSearchState();
                     this.resetSkillSearchState();
                     this.positionModalOpen = true;
                     this.refreshIcons();
@@ -1205,6 +1236,7 @@
                     this.editingIndex = index;
                     this.currentPosition = this.normalizePosition(JSON.parse(JSON.stringify(this.positions[index])));
                     this.positionErrors = [];
+                    this.resetPositionSearchState();
                     this.resetSkillSearchState();
                     this.positionModalOpen = true;
                     this.refreshIcons();
@@ -1214,6 +1246,7 @@
                     this.positionModalOpen = false;
                     this.currentPosition = this.blankPosition();
                     this.positionErrors = [];
+                    this.resetPositionSearchState();
                     this.resetSkillSearchState();
                     this.refreshIcons();
                 },
@@ -1237,6 +1270,97 @@
 
                 removePosition(index) {
                     this.positions.splice(index, 1);
+                    this.refreshIcons();
+                },
+
+                openPositionSearch() {
+                    this.positionSearchOpen = true;
+                    this.searchPositions();
+                },
+
+                closePositionSearch() {
+                    this.positionSearchOpen = false;
+                },
+
+                closePositionSearchWithDelay() {
+                    window.setTimeout(() => {
+                        this.closePositionSearch();
+                    }, 150);
+                },
+
+                handlePositionSearchInput() {
+                    if (!this.currentPosition) {
+                        return;
+                    }
+
+                    this.currentPosition.positionId = '';
+                    this.searchPositions();
+                },
+
+                async searchPositions() {
+                    if (!this.currentPosition) {
+                        return;
+                    }
+
+                    const query = (this.currentPosition.positionSearchDraft || '').trim();
+                    const requestSequence = ++this.positionSearchRequestSequence;
+
+                    this.positionSearchOpen = true;
+                    this.positionSearchLoading = true;
+
+                    try {
+                        const response = await fetch(`/api/positions?query=${encodeURIComponent(query)}`, {
+                            headers: {
+                                'Accept': 'application/json'
+                            }
+                        });
+
+                        if (!response.ok) {
+                            throw new Error('직무 목록을 불러오지 못했습니다.');
+                        }
+
+                        const positions = await response.json();
+                        if (requestSequence !== this.positionSearchRequestSequence) {
+                            return;
+                        }
+
+                        this.positionSearchResults = (positions || [])
+                            .filter(position => position && position.id && position.name);
+                    } catch (error) {
+                        if (requestSequence === this.positionSearchRequestSequence) {
+                            this.positionSearchResults = [];
+                            this.positionErrors = [error.message || '직무 목록을 불러오지 못했습니다.'];
+                        }
+                    } finally {
+                        if (requestSequence === this.positionSearchRequestSequence) {
+                            this.positionSearchLoading = false;
+                            this.refreshIcons();
+                        }
+                    }
+                },
+
+                selectFirstPosition() {
+                    if (this.positionSearchResults.length > 0) {
+                        this.selectPosition(this.positionSearchResults[0]);
+                        return;
+                    }
+
+                    const draft = (this.currentPosition.positionSearchDraft || '').trim();
+                    if (draft) {
+                        this.positionErrors = ['검색 결과에서 직무를 선택해주세요.'];
+                    }
+                },
+
+                selectPosition(position) {
+                    if (!position || !position.id || !position.name) {
+                        return;
+                    }
+
+                    this.currentPosition.positionId = String(position.id);
+                    this.currentPosition.positionSearchDraft = position.name.trim();
+                    this.positionSearchResults = [];
+                    this.positionSearchOpen = false;
+                    this.positionErrors = [];
                     this.refreshIcons();
                 },
 
@@ -1368,6 +1492,13 @@
                     };
                 },
 
+                resetPositionSearchState() {
+                    this.positionSearchResults = [];
+                    this.positionSearchOpen = false;
+                    this.positionSearchLoading = false;
+                    this.positionSearchRequestSequence = 0;
+                },
+
                 removeSkill(type, index) {
                     const listKey = type === 'essential' ? 'essentialSkillNames' : 'preferredSkillNames';
                     this.currentPosition[listKey].splice(index, 1);
@@ -1395,6 +1526,7 @@
                         id: null,
                         clientKey: this.generateKey(),
                         positionId: '',
+                        positionSearchDraft: '',
                         title: '',
                         workType: '',
                         headCount: '',
@@ -1418,6 +1550,7 @@
                         id: position.id ?? null,
                         clientKey: position.clientKey || this.generateKey(),
                         positionId: position.positionId != null ? String(position.positionId) : '',
+                        positionSearchDraft: this.positionNameById(position.positionId) || '',
                         title: (position.title || '').trim(),
                         workType,
                         headCount: this.normalizeNumberField(position.headCount),

--- a/src/test/java/com/generic4/itda/controller/PositionSearchControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/PositionSearchControllerTest.java
@@ -1,0 +1,57 @@
+package com.generic4.itda.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.service.PositionResolver;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PositionSearchControllerTest {
+
+    @Mock
+    private PositionResolver positionResolver;
+
+    @InjectMocks
+    private PositionSearchController positionSearchController;
+
+    @Test
+    @DisplayName("직무 검색 결과를 id와 name 응답으로 반환한다")
+    void search_returnsPositionSearchResponses() {
+        Position mobile = Position.create("모바일 앱 개발자");
+        ReflectionTestUtils.setField(mobile, "id", 4L);
+        given(positionResolver.search("react native")).willReturn(List.of(mobile));
+
+        List<PositionSearchController.PositionSearchResponse> responses = positionSearchController.search("react native");
+
+        assertThat(responses)
+                .extracting(PositionSearchController.PositionSearchResponse::id, PositionSearchController.PositionSearchResponse::name)
+                .containsExactly(tuple(4L, "모바일 앱 개발자"));
+        then(positionResolver).should().search("react native");
+    }
+
+    @Test
+    @DisplayName("검색어가 없어도 PositionResolver에 그대로 위임한다")
+    void search_delegatesNullQueryToPositionResolver() {
+        Position backend = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(backend, "id", 1L);
+        given(positionResolver.search(null)).willReturn(List.of(backend));
+
+        List<PositionSearchController.PositionSearchResponse> responses = positionSearchController.search(null);
+
+        assertThat(responses)
+                .extracting(PositionSearchController.PositionSearchResponse::id, PositionSearchController.PositionSearchResponse::name)
+                .containsExactly(tuple(1L, "백엔드 개발자"));
+        then(positionResolver).should().search(null);
+    }
+}

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -35,14 +35,13 @@ import java.time.LocalDateTime;
 import org.springframework.security.access.AccessDeniedException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
-import com.generic4.itda.repository.PositionRepository;
+import com.generic4.itda.service.PositionResolver;
 import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.ProposalService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -61,7 +60,7 @@ class ProposalControllerTest {
     private ProposalAiInterviewService proposalAiInterviewService;
 
     @MockitoBean
-    private PositionRepository positionRepository;
+    private PositionResolver positionResolver;
 
     @MockitoBean
     private MemberRepository memberRepository;
@@ -75,7 +74,7 @@ class ProposalControllerTest {
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
         );
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
 
         mockMvc.perform(get("/proposals/new")
@@ -96,7 +95,7 @@ class ProposalControllerTest {
     void saveDraftAndRedirectToEdit() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
-        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(positionResolver.findAllowedPositions()).willReturn(List.of());
         given(proposalService.saveDraft(anyString(), any(ProposalForm.class))).willReturn(proposal);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -124,7 +123,7 @@ class ProposalControllerTest {
     void saveDraftAndRedirectToEditWithAiBriefRequested() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
-        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(positionResolver.findAllowedPositions()).willReturn(List.of());
         given(proposalService.saveDraft(anyString(), any(ProposalForm.class))).willReturn(proposal);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -153,7 +152,7 @@ class ProposalControllerTest {
     void registerAndRedirectToRecommendationEntry() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(3L);
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         // register 검증 로직에서 총 예산 계산이 null 이면 실패로 처리되므로, 성공 흐름을 위해 stub 한다.
         given(proposalService.calculateTotalBudgetMin(any(ProposalForm.class))).willReturn(3_000_000L);
@@ -195,7 +194,7 @@ class ProposalControllerTest {
         ItDaPrincipal principal = ItDaPrincipal.from(
                 createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
         );
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
 
         mockMvc.perform(post("/proposals/new")
@@ -238,7 +237,7 @@ class ProposalControllerTest {
                 null,
                 6L
         );
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
         given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
@@ -275,7 +274,7 @@ class ProposalControllerTest {
                 null,
                 null
         );
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
         given(proposalService.findOwnedProposalForm(1L, "client@example.com"))
@@ -307,7 +306,7 @@ class ProposalControllerTest {
     void updateDraftAndRedirectToEditWithAiBriefRequested() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
-        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(positionResolver.findAllowedPositions()).willReturn(List.of());
         given(proposalService.saveDraft(any(Long.class), anyString(), any(ProposalForm.class))).willReturn(proposal);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -336,7 +335,7 @@ class ProposalControllerTest {
     void updateDraftAndRedirectToEdit() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
-        given(positionRepository.findAll(any(Sort.class))).willReturn(List.of());
+        given(positionResolver.findAllowedPositions()).willReturn(List.of());
         given(proposalService.saveDraft(any(Long.class), anyString(), any(ProposalForm.class))).willReturn(proposal);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -364,7 +363,7 @@ class ProposalControllerTest {
     void registerAfterUpdateAndRedirectToRecommendationEntry() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         given(proposalService.calculateTotalBudgetMin(any(ProposalForm.class))).willReturn(3_000_000L);
         given(proposalService.calculateTotalBudgetMax(any(ProposalForm.class))).willReturn(4_000_000L);
@@ -402,7 +401,7 @@ class ProposalControllerTest {
     @Test
     @DisplayName("수정 요청에서 register 조건을 만족하지 못하면 편집기에 머무르며 이유를 보여준다")
     void stayOnFormWhenUpdateRegisterValidationFails() throws Exception {
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -479,7 +478,7 @@ class ProposalControllerTest {
     @Test
     @DisplayName("수정 요청 처리 중 예외가 발생하면 편집기에 머무르며 이유를 보여준다")
     void stayOnFormWhenUpdateFailsWithIllegalState() throws Exception {
-        given(positionRepository.findAll(any(Sort.class)))
+        given(positionResolver.findAllowedPositions())
                 .willReturn(List.of(Position.create("백엔드 개발자")));
         willThrow(new IllegalStateException("저장 중 오류가 발생했습니다."))
                 .given(proposalService).saveDraft(eq(1L), eq("client@example.com"), any(ProposalForm.class));

--- a/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefGeneratorConfigurationTest.java
@@ -78,6 +78,7 @@ class AiBriefGeneratorConfigurationTest {
             DisabledAiInterviewGenerator.class,
             OpenAiAiBriefGenerator.class,
             OpenAiAiInterviewGenerator.class,
+            PositionResolver.class,
             SkillResolver.class,
             AiBriefProposalMapper.class,
             ProposalAiBriefService.class

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -3,7 +3,6 @@ package com.generic4.itda.service;
 import static com.generic4.itda.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -17,7 +16,6 @@ import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.proposal.AiBriefPositionResult;
 import com.generic4.itda.dto.proposal.AiBriefResult;
 import com.generic4.itda.dto.proposal.AiBriefSkillResult;
-import com.generic4.itda.repository.PositionRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -31,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class AiBriefProposalMapperTest {
 
     @Mock
-    private PositionRepository positionRepository;
+    private PositionResolver positionResolver;
 
     @Mock
     private SkillResolver skillResolver;
@@ -44,6 +42,7 @@ class AiBriefProposalMapperTest {
     void apply_updatesProposalFieldsAndSynchronizesPositionsByAiResult() {
         Proposal proposal = createProposal();
         Position oldPosition = Position.create("디자이너");
+        Position backend = Position.create("백엔드 개발자");
         Skill oldSkill = Skill.create("Figma", null);
         Skill java = Skill.create("Java", null);
         ProposalPosition oldProposalPosition = proposal.addPosition(
@@ -60,8 +59,7 @@ class AiBriefProposalMapperTest {
         );
         oldProposalPosition.addSkill(oldSkill, ProposalPositionSkillImportance.ESSENTIAL);
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.empty());
-        given(positionRepository.save(any(Position.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
         given(skillResolver.resolve("Java")).willReturn(Optional.of(java));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -130,7 +128,7 @@ class AiBriefProposalMapperTest {
         );
         existingPosition.addSkill(oldSkill, ProposalPositionSkillImportance.ESSENTIAL);
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
         given(skillResolver.resolve("Java")).willReturn(Optional.of(newSkill));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -197,7 +195,7 @@ class AiBriefProposalMapperTest {
         );
         existingPosition.addSkill(java, ProposalPositionSkillImportance.PREFERENCE);
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
         given(skillResolver.resolve("Java")).willReturn(Optional.of(java));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -238,7 +236,7 @@ class AiBriefProposalMapperTest {
         Proposal proposal = createProposal();
         Position backend = Position.create("백엔드 개발자");
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
                 "새 제목",
@@ -344,7 +342,7 @@ class AiBriefProposalMapperTest {
         Position backend = Position.create("백엔드 개발자");
         Skill java = Skill.create("Java", null);
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
         given(skillResolver.resolve("Java")).willReturn(Optional.of(java));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -376,7 +374,7 @@ class AiBriefProposalMapperTest {
         assertThat(proposal.getPositions().get(0).getPosition()).isSameAs(backend);
         assertThat(proposal.getPositions().get(0).getSkills()).hasSize(1);
         assertThat(proposal.getPositions().get(0).getSkills().get(0).getSkill()).isSameAs(java);
-        then(positionRepository).should(never()).save(any(Position.class));
+        then(positionResolver).should().resolve("백엔드 개발자");
     }
 
     @Test
@@ -386,7 +384,7 @@ class AiBriefProposalMapperTest {
         Position frontend = Position.create("프론트엔드 개발자");
         Skill react = Skill.create("React", null);
 
-        given(positionRepository.findByName("프론트엔드 개발자")).willReturn(Optional.of(frontend));
+        given(positionResolver.resolve("프론트엔드 개발자")).willReturn(Optional.of(frontend));
         given(skillResolver.resolve("React.js")).willReturn(Optional.of(react));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -428,7 +426,7 @@ class AiBriefProposalMapperTest {
         Proposal proposal = createProposal();
         Position backend = Position.create("백엔드 개발자");
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
         given(skillResolver.resolve("Unknown Skill")).willReturn(Optional.empty());
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
@@ -493,7 +491,7 @@ class AiBriefProposalMapperTest {
                 null
         );
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
                 "새 제목",
@@ -571,8 +569,8 @@ class AiBriefProposalMapperTest {
                 null
         );
 
-        given(positionRepository.findByName("백엔드 개발자")).willReturn(Optional.of(backend));
-        given(positionRepository.findByName("프론트엔드 개발자")).willReturn(Optional.of(frontend));
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
+        given(positionResolver.resolve("프론트엔드 개발자")).willReturn(Optional.of(frontend));
 
         AiBriefResult aiBriefResult = AiBriefResult.of(
                 "새 제목",
@@ -621,6 +619,58 @@ class AiBriefProposalMapperTest {
         assertThat(findProposalPosition(proposal, "프론트엔드 개발자").getHeadCount()).isEqualTo(1L);
         assertThat(proposal.getPositions())
                 .noneMatch(position -> position.getPosition().getName().equals("UI/UX 디자이너"));
+    }
+
+    @Test
+    @DisplayName("AI가 기존 Position 마스터에 없는 카테고리를 반환하면 저장하지 않고 기존 모집 단위를 유지한다")
+    void apply_skipsUnknownPositionCategoryWithoutRemovingExistingPositions() {
+        Proposal proposal = createProposal();
+        Position existingPosition = Position.create("백엔드 개발자");
+        proposal.addPosition(
+                existingPosition,
+                "기존 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                1_000_000L,
+                2_000_000L,
+                3L,
+                null,
+                null,
+                null
+        );
+
+        given(positionResolver.resolve("플랫폼 개발자")).willReturn(Optional.empty());
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "AI가 정리한 제목",
+                "AI가 정리한 설명",
+                null,
+                null,
+                null,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "플랫폼 개발자",
+                                "플랫폼 엔지니어",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        assertThat(proposal.getPositions()).hasSize(1);
+        assertThat(proposal.getPositions().get(0).getPosition()).isSameAs(existingPosition);
+        assertThat(proposal.getPositions().get(0).getTitle()).isEqualTo("기존 백엔드 개발자");
+        assertThat(proposal.getTitle()).isEqualTo("AI가 정리한 제목");
+        assertThat(proposal.getDescription()).isEqualTo("AI가 정리한 설명");
     }
 
     private ProposalPosition findProposalPosition(Proposal proposal, String positionName) {

--- a/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiBriefGeneratorTest.java
@@ -31,11 +31,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
+import org.mockito.Mockito;
 
 class OpenAiAiBriefGeneratorTest {
 
     private static final String API_URL = "https://api.openai.com/v1/responses";
     private static final String API_KEY = "test-api-key";
+    private static final List<String> ALLOWED_POSITIONS = List.of(
+            "백엔드 개발자",
+            "프론트엔드 개발자",
+            "풀스택 개발자",
+            "모바일 앱 개발자",
+            "AI 엔지니어",
+            "데이터 엔지니어",
+            "DevOps 엔지니어",
+            "UI/UX 디자이너",
+            "서비스 기획자",
+            "QA 엔지니어"
+    );
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -54,7 +67,10 @@ class OpenAiAiBriefGeneratorTest {
 
         RestClient.Builder builder = RestClient.builder();
         server = MockRestServiceServer.bindTo(builder).build();
-        generator = new OpenAiAiBriefGenerator(builder, objectMapper, properties);
+        PositionResolver positionResolver = Mockito.mock(PositionResolver.class);
+        Mockito.when(positionResolver.findAllowedCategoryNames())
+                .thenReturn(ALLOWED_POSITIONS);
+        generator = new OpenAiAiBriefGenerator(builder, objectMapper, properties, positionResolver);
     }
 
     @AfterEach
@@ -101,6 +117,13 @@ class OpenAiAiBriefGeneratorTest {
                 .andExpect(jsonPath("$.instructions").value(containsString("expectedPeriod는 주 단위 기준 정수로 반환한다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("skills.skillName은 반드시 아래 정규 Skill 목록 중 하나만 사용한다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("정규 Skill 목록에 없는 스킬은 절대 생성, 제안, 추가, 반환하지 않는다.")))
+                .andExpect(jsonPath("$.instructions").value(containsString("허용 가능한 Position 카테고리 목록:")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 백엔드 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 프론트엔드 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 모바일 앱 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- AI 엔지니어")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- QA 엔지니어")))
+                .andExpect(jsonPath("$.instructions").value(containsString("목록에 없는 직무 카테고리는 절대 새로 만들거나 비슷하게 지어내지 않는다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("- React")))
                 .andExpect(jsonPath("$.instructions").value(containsString("- Spring Boot")))
                 .andExpect(jsonPath("$.text.format.type").value("json_schema"))
@@ -129,6 +152,8 @@ class OpenAiAiBriefGeneratorTest {
                         "workPlace",
                         "skills"
                 )))
+                .andExpect(jsonPath("$.text.format.schema.properties.positions.items.properties.positionCategoryName.enum[*]")
+                        .value(containsInAnyOrder(ALLOWED_POSITIONS.toArray())))
                 .andExpect(jsonPath("$.text.format.schema.properties.positions.items.properties.skills.items.required[*]")
                         .value(containsInAnyOrder("skillName", "importance")))
                 .andRespond(withSuccess(

--- a/src/test/java/com/generic4/itda/service/OpenAiAiInterviewGeneratorTest.java
+++ b/src/test/java/com/generic4/itda/service/OpenAiAiInterviewGeneratorTest.java
@@ -32,11 +32,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
+import org.mockito.Mockito;
 
 class OpenAiAiInterviewGeneratorTest {
 
     private static final String API_URL = "https://api.openai.com/v1/responses";
     private static final String API_KEY = "test-api-key";
+    private static final List<String> ALLOWED_POSITIONS = List.of(
+            "백엔드 개발자",
+            "프론트엔드 개발자",
+            "풀스택 개발자",
+            "모바일 앱 개발자",
+            "AI 엔지니어",
+            "데이터 엔지니어",
+            "DevOps 엔지니어",
+            "UI/UX 디자이너",
+            "서비스 기획자",
+            "QA 엔지니어"
+    );
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -55,7 +68,10 @@ class OpenAiAiInterviewGeneratorTest {
 
         RestClient.Builder builder = RestClient.builder();
         server = MockRestServiceServer.bindTo(builder).build();
-        generator = new OpenAiAiInterviewGenerator(builder, objectMapper, properties);
+        PositionResolver positionResolver = Mockito.mock(PositionResolver.class);
+        Mockito.when(positionResolver.findAllowedCategoryNames())
+                .thenReturn(ALLOWED_POSITIONS);
+        generator = new OpenAiAiInterviewGenerator(builder, objectMapper, properties, positionResolver);
     }
 
     @AfterEach
@@ -110,6 +126,13 @@ class OpenAiAiInterviewGeneratorTest {
                 .andExpect(jsonPath("$.instructions").value(containsString("skills.skillName은 반드시 아래 정규 Skill 목록 중 하나만 사용한다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("정규 Skill 목록에 없는 스킬은 절대 생성, 제안, 추가, 반환하지 않는다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("assistantMessage에서도 정규 Skill 목록에 없는 스킬을 먼저 제안하거나 추가해드릴지 묻지 않는다.")))
+                .andExpect(jsonPath("$.instructions").value(containsString("허용 가능한 Position 카테고리 목록:")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 백엔드 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 프론트엔드 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- 모바일 앱 개발자")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- AI 엔지니어")))
+                .andExpect(jsonPath("$.instructions").value(containsString("- QA 엔지니어")))
+                .andExpect(jsonPath("$.instructions").value(containsString("목록에 없는 직무 카테고리는 절대 새로 만들거나 비슷하게 지어내지 않는다.")))
                 .andExpect(jsonPath("$.instructions").value(containsString("- React")))
                 .andExpect(jsonPath("$.instructions").value(containsString("- Spring Boot")))
                 .andExpect(jsonPath("$.text.format.type").value("json_schema"))
@@ -139,6 +162,8 @@ class OpenAiAiInterviewGeneratorTest {
                                 "workPlace",
                                 "skills"
                         )))
+                .andExpect(jsonPath("$.text.format.schema.properties.aiBriefResult.properties.positions.items.properties.positionCategoryName.enum[*]")
+                        .value(containsInAnyOrder(ALLOWED_POSITIONS.toArray())))
                 .andExpect(jsonPath("$.text.format.schema.properties.aiBriefResult.properties.positions.items.properties.skills.items.required[*]")
                         .value(containsInAnyOrder("skillName", "importance")))
                 .andRespond(withSuccess(

--- a/src/test/java/com/generic4/itda/service/PositionResolverTest.java
+++ b/src/test/java/com/generic4/itda/service/PositionResolverTest.java
@@ -91,6 +91,14 @@ class PositionResolverTest {
     }
 
     @Test
+    @DisplayName("허용 Position 여부는 정규 카테고리 이름과 정확히 일치할 때만 true다")
+    void isAllowedPosition_returnsTrueOnlyForCanonicalPositions() {
+        assertThat(positionResolver.isAllowedPosition(Position.create("백엔드 개발자"))).isTrue();
+        assertThat(positionResolver.isAllowedPosition(Position.create("백엔드"))).isFalse();
+        assertThat(positionResolver.isAllowedPosition(null)).isFalse();
+    }
+
+    @Test
     @DisplayName("Position 검색은 영어 alias와 대소문자를 무시하고 정규 카테고리를 반환한다")
     void search_returnsCanonicalCategoriesByAlias() {
         Position mobile = Position.create("모바일 앱 개발자");

--- a/src/test/java/com/generic4/itda/service/PositionResolverTest.java
+++ b/src/test/java/com/generic4/itda/service/PositionResolverTest.java
@@ -1,21 +1,30 @@
 package com.generic4.itda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.repository.PositionRepository;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class PositionResolverTest {
+
+    private static final java.util.List<String> CANONICAL_POSITIONS = java.util.List.of(
+            "백엔드 개발자",
+            "프론트엔드 개발자",
+            "풀스택 개발자",
+            "모바일 앱 개발자",
+            "AI 엔지니어",
+            "데이터 엔지니어",
+            "DevOps 엔지니어",
+            "UI/UX 디자이너",
+            "서비스 기획자",
+            "QA 엔지니어"
+    );
 
     @Mock
     private PositionRepository positionRepository;
@@ -27,7 +36,8 @@ class PositionResolverTest {
     @DisplayName("기존 Position 이름과 정확히 일치하면 그대로 매핑한다")
     void resolve_returnsExactMatchedPosition() {
         Position backend = Position.create("백엔드 개발자");
-        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))).willReturn(List.of(backend));
+        org.mockito.BDDMockito.given(positionRepository.findByName("백엔드 개발자"))
+                .willReturn(java.util.Optional.of(backend));
 
         assertThat(positionResolver.resolve("백엔드 개발자")).contains(backend);
     }
@@ -36,19 +46,44 @@ class PositionResolverTest {
     @DisplayName("직무 접미사만 다른 AI 카테고리도 기존 Position으로 매핑한다")
     void resolve_mapsAliasByNormalizedSuffix() {
         Position aiEngineer = Position.create("AI 엔지니어");
-        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))).willReturn(List.of(aiEngineer));
+        org.mockito.BDDMockito.given(positionRepository.findByName("AI 엔지니어"))
+                .willReturn(java.util.Optional.of(aiEngineer));
 
         assertThat(positionResolver.resolve("AI 개발자")).contains(aiEngineer);
     }
 
     @Test
-    @DisplayName("동일 별칭으로 여러 Position이 겹치면 안전하게 매핑하지 않는다")
-    void resolve_returnsEmptyWhenAliasIsAmbiguous() {
-        Position aiEngineer = Position.create("AI 엔지니어");
-        Position aiPlanner = Position.create("AI 기획자");
-        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
-                .willReturn(List.of(aiEngineer, aiPlanner));
+    @DisplayName("영문과 대소문자가 섞여도 정규 Position 카테고리로 매핑한다")
+    void resolve_mapsEnglishAliasIgnoringCase() {
+        Position mobileDeveloper = Position.create("모바일 앱 개발자");
+        org.mockito.BDDMockito.given(positionRepository.findByName("모바일 앱 개발자"))
+                .willReturn(java.util.Optional.of(mobileDeveloper));
 
-        assertThat(positionResolver.resolve("AI 개발자")).isEmpty();
+        assertThat(positionResolver.resolve("ReAcT NaTiVe Developer")).contains(mobileDeveloper);
+        assertThat(positionResolver.resolveCanonicalName("ReAcT NaTiVe Developer"))
+                .contains("모바일 앱 개발자");
+    }
+
+    @Test
+    @DisplayName("기존 PM 계열 표현은 서비스 기획자 카테고리로 정규화한다")
+    void resolve_mapsPmAliasToServicePlanner() {
+        assertThat(positionResolver.resolveCanonicalName("Product Manager"))
+                .contains("서비스 기획자");
+        assertThat(positionResolver.resolveCanonicalName("pm"))
+                .contains("서비스 기획자");
+    }
+
+    @Test
+    @DisplayName("허용 Position 목록에 없는 카테고리는 매핑하지 않는다")
+    void resolve_returnsEmptyWhenCategoryIsNotAllowed() {
+        assertThat(positionResolver.resolve("데이터 분석가")).isEmpty();
+        assertThat(positionResolver.resolveCanonicalName("데이터 분석가")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("허용 Position 목록은 공식 열 개 카테고리만 반환한다")
+    void findAllowedCategoryNames_returnsCanonicalCategories() {
+        assertThat(positionResolver.findAllowedCategoryNames())
+                .containsExactlyElementsOf(CANONICAL_POSITIONS);
     }
 }

--- a/src/test/java/com/generic4/itda/service/PositionResolverTest.java
+++ b/src/test/java/com/generic4/itda/service/PositionResolverTest.java
@@ -1,14 +1,17 @@
 package com.generic4.itda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.repository.PositionRepository;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PositionResolverTest {
@@ -85,5 +88,35 @@ class PositionResolverTest {
     void findAllowedCategoryNames_returnsCanonicalCategories() {
         assertThat(positionResolver.findAllowedCategoryNames())
                 .containsExactlyElementsOf(CANONICAL_POSITIONS);
+    }
+
+    @Test
+    @DisplayName("Position 검색은 영어 alias와 대소문자를 무시하고 정규 카테고리를 반환한다")
+    void search_returnsCanonicalCategoriesByAlias() {
+        Position mobile = Position.create("모바일 앱 개발자");
+        ReflectionTestUtils.setField(mobile, "id", 4L);
+        Position planner = Position.create("서비스 기획자");
+        ReflectionTestUtils.setField(planner, "id", 9L);
+
+        org.mockito.BDDMockito.given(positionRepository.findByName("백엔드 개발자")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("프론트엔드 개발자")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("풀스택 개발자")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("모바일 앱 개발자")).willReturn(java.util.Optional.of(mobile));
+        org.mockito.BDDMockito.given(positionRepository.findByName("AI 엔지니어")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("데이터 엔지니어")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("DevOps 엔지니어")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("UI/UX 디자이너")).willReturn(java.util.Optional.empty());
+        org.mockito.BDDMockito.given(positionRepository.findByName("서비스 기획자")).willReturn(java.util.Optional.of(planner));
+        org.mockito.BDDMockito.given(positionRepository.findByName("QA 엔지니어")).willReturn(java.util.Optional.empty());
+
+        List<Position> mobileResults = positionResolver.search("ReAcT NaTiVe");
+        List<Position> plannerResults = positionResolver.search("pm");
+
+        assertThat(mobileResults)
+                .extracting(Position::getId, Position::getName)
+                .containsExactly(tuple(4L, "모바일 앱 개발자"));
+        assertThat(plannerResults)
+                .extracting(Position::getId, Position::getName)
+                .containsExactly(tuple(9L, "서비스 기획자"));
     }
 }

--- a/src/test/java/com/generic4/itda/service/PositionResolverTest.java
+++ b/src/test/java/com/generic4/itda/service/PositionResolverTest.java
@@ -1,0 +1,54 @@
+package com.generic4.itda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.repository.PositionRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class PositionResolverTest {
+
+    @Mock
+    private PositionRepository positionRepository;
+
+    @InjectMocks
+    private PositionResolver positionResolver;
+
+    @Test
+    @DisplayName("기존 Position 이름과 정확히 일치하면 그대로 매핑한다")
+    void resolve_returnsExactMatchedPosition() {
+        Position backend = Position.create("백엔드 개발자");
+        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))).willReturn(List.of(backend));
+
+        assertThat(positionResolver.resolve("백엔드 개발자")).contains(backend);
+    }
+
+    @Test
+    @DisplayName("직무 접미사만 다른 AI 카테고리도 기존 Position으로 매핑한다")
+    void resolve_mapsAliasByNormalizedSuffix() {
+        Position aiEngineer = Position.create("AI 엔지니어");
+        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))).willReturn(List.of(aiEngineer));
+
+        assertThat(positionResolver.resolve("AI 개발자")).contains(aiEngineer);
+    }
+
+    @Test
+    @DisplayName("동일 별칭으로 여러 Position이 겹치면 안전하게 매핑하지 않는다")
+    void resolve_returnsEmptyWhenAliasIsAmbiguous() {
+        Position aiEngineer = Position.create("AI 엔지니어");
+        Position aiPlanner = Position.create("AI 기획자");
+        given(positionRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
+                .willReturn(List.of(aiEngineer, aiPlanner));
+
+        assertThat(positionResolver.resolve("AI 개발자")).isEmpty();
+    }
+}

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -63,6 +63,9 @@ class ProposalServiceTest {
     private PositionRepository positionRepository;
 
     @Mock
+    private PositionResolver positionResolver;
+
+    @Mock
     private SkillResolver skillResolver;
 
     @Mock
@@ -86,6 +89,7 @@ class ProposalServiceTest {
                 .thenReturn(false);
         lenient().when(proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(any(Long.class), any()))
                 .thenReturn(Optional.empty());
+        lenient().when(positionResolver.isAllowedPosition(any(Position.class))).thenReturn(true);
         lenient().when(aiInterviewMessageRepository.findAllByProposalIdOrderBySequenceAsc(any(Long.class)))
                 .thenReturn(List.of());
         lenient().when(aiInterviewMessageRepository.saveAll(any()))
@@ -283,6 +287,33 @@ class ProposalServiceTest {
     }
 
     @Test
+    @DisplayName("제안서 저장은 허용 목록 밖 Position id가 와도 저장하지 않는다")
+    void saveDraft_throwsWhenPositionIsNotAllowed() {
+        Position legacyBackend = Position.create("백엔드");
+        ReflectionTestUtils.setField(legacyBackend, "id", 99L);
+
+        ProposalPositionForm positionForm = new ProposalPositionForm();
+        positionForm.setPositionId(99L);
+        positionForm.setTitle("백엔드 개발자");
+        positionForm.setWorkType(ProposalWorkType.REMOTE);
+        positionForm.setHeadCount(1L);
+
+        ProposalForm form = new ProposalForm();
+        form.setTitle("백엔드 프로젝트");
+        form.setRawInputText("");
+        form.getPositions().add(positionForm);
+
+        when(positionRepository.findById(99L)).thenReturn(Optional.of(legacyBackend));
+        when(positionResolver.isAllowedPosition(legacyBackend)).thenReturn(false);
+
+        assertThatThrownBy(() -> proposalService.saveDraft(EMAIL, form))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 직무입니다. id=99");
+
+        then(proposalRepository).should(never()).save(any(Proposal.class));
+    }
+
+    @Test
     @DisplayName("AI 인터뷰 draft 저장은 WRITING 상태가 아니면 실패한다")
     void saveInterviewDraft_blocksNonWritingProposal() {
         Proposal proposal = Proposal.create(
@@ -346,6 +377,44 @@ class ProposalServiceTest {
 
         assertThatThrownBy(() -> proposalService.saveInterviewDraft(99L, EMAIL, request))
                 .isInstanceOf(ProposalNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 draft 저장도 허용 목록 밖 Position id를 거부한다")
+    void saveInterviewDraft_throwsWhenPositionIsNotAllowed() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "기존 설명",
+                null,
+                null,
+                6L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        Position legacyBackend = Position.create("백엔드");
+        ReflectionTestUtils.setField(legacyBackend, "id", 99L);
+
+        ProposalPositionForm positionForm = new ProposalPositionForm();
+        positionForm.setPositionId(99L);
+        positionForm.setTitle("백엔드 개발자");
+        positionForm.setWorkType(ProposalWorkType.REMOTE);
+        positionForm.setHeadCount(1L);
+
+        AiInterviewDraftSaveRequest request = new AiInterviewDraftSaveRequest();
+        request.setTitle("수정된 프로젝트");
+        request.setDescription("수정된 설명");
+        request.setExpectedPeriod(6L);
+        request.setPositions(List.of(positionForm));
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(positionRepository.findById(99L)).thenReturn(Optional.of(legacyBackend));
+        when(positionResolver.isAllowedPosition(legacyBackend)).thenReturn(false);
+
+        assertThatThrownBy(() -> proposalService.saveInterviewDraft(1L, EMAIL, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 직무입니다. id=99");
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationCandidateFinderTest.java
@@ -206,7 +206,7 @@ class RecommendationCandidateFinderTest {
     }
 
     private ProposalPosition createProposalPosition(SkillRequirement... requirements) {
-        return createProposalPosition("백엔드", null, null, null, requirements);
+        return createProposalPosition("백엔드 개발자", null, null, null, requirements);
     }
 
     private ProposalPosition createProposalPosition(

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
@@ -41,9 +41,9 @@ class RecommendationEntryServiceIntegrationTest {
     @DisplayName("저장된 recommendation aggregate를 조회해 entry ViewModel을 조립한다")
     void getEntry_assemblesViewModelFromPersistedAggregate() {
         Member owner = memberRepository.save(createMember("entry-owner@test.com", "pw", "제안자", "010-0000-1111"));
-        Position designer = persist(Position.create("디자인"));
-        Position backend = persist(Position.create("백엔드"));
-        Position frontend = persist(Position.create("프론트엔드"));
+        Position designer = persist(Position.create("UI/UX 디자이너"));
+        Position backend = persist(Position.create("백엔드 개발자"));
+        Position frontend = persist(Position.create("프론트엔드 개발자"));
         Skill figma = persist(Skill.create("Figma", null));
         Skill java = persist(Skill.create("Java", null));
         Skill react = persist(Skill.create("React", null));
@@ -90,7 +90,7 @@ class RecommendationEntryServiceIntegrationTest {
 
         RecommendationEntryPositionItem first = result.positions().get(0);
         assertThat(first.positionTitle()).isEqualTo("프로덕트 디자이너");
-        assertThat(first.positionCategoryName()).isEqualTo("디자인");
+        assertThat(first.positionCategoryName()).isEqualTo("UI/UX 디자이너");
         assertThat(first.budgetText()).isEqualTo("예산 미정");
         assertThat(first.skills())
                 .singleElement()
@@ -101,7 +101,7 @@ class RecommendationEntryServiceIntegrationTest {
 
         RecommendationEntryPositionItem second = result.positions().get(1);
         assertThat(second.positionTitle()).isEqualTo("Node.js 백엔드 개발자");
-        assertThat(second.positionCategoryName()).isEqualTo("백엔드");
+        assertThat(second.positionCategoryName()).isEqualTo("백엔드 개발자");
         assertThat(second.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
         assertThat(second.expectedPeriod()).isEqualTo(5L);
         assertThat(second.skills())
@@ -144,7 +144,7 @@ class RecommendationEntryServiceIntegrationTest {
     void getEntry_rejectsNonOwner() {
         Member owner = memberRepository.save(createMember("entry-real-owner@test.com", "pw", "소유자", "010-0000-3333"));
         Member other = memberRepository.save(createMember("entry-other@test.com", "pw", "다른회원", "010-0000-4444"));
-        Position backend = persist(Position.create("통합 백엔드"));
+        Position backend = persist(Position.create("백엔드 개발자"));
 
         Proposal proposal = Proposal.create(
                 owner,

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
@@ -63,13 +63,13 @@ class RecommendationEntryServiceTest {
         Member owner = createMemberWithId(OWNER_ID);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
 
-        ProposalPosition designer = addPosition(proposal, 30L, "디자인", "프로덕트 디자이너", 1L, null, null, null);
+        ProposalPosition designer = addPosition(proposal, 30L, "UI/UX 디자이너", "프로덕트 디자이너", 1L, null, null, null);
         addSkill(designer, 201L, "Figma", ProposalPositionSkillImportance.PREFERENCE);
 
-        ProposalPosition backend = addPosition(proposal, 10L, "백엔드", "Node.js 백엔드 개발자", 3L, 1_000_000L, 2_000_000L, 3L);
+        ProposalPosition backend = addPosition(proposal, 10L, "백엔드 개발자", "Node.js 백엔드 개발자", 3L, 1_000_000L, 2_000_000L, 3L);
         addSkill(backend, 202L, "Java", ProposalPositionSkillImportance.ESSENTIAL);
 
-        ProposalPosition frontend = addPosition(proposal, 20L, "프론트엔드", "프론트엔드 개발자", 2L, 700_000L, 900_000L, 2L);
+        ProposalPosition frontend = addPosition(proposal, 20L, "프론트엔드 개발자", "프론트엔드 개발자", 2L, 700_000L, 900_000L, 2L);
         addSkill(frontend, 203L, "React", ProposalPositionSkillImportance.PREFERENCE);
 
         stubProposalDetailLoad(proposal);
@@ -97,7 +97,7 @@ class RecommendationEntryServiceTest {
 
         RecommendationEntryPositionItem firstPosition = result.positions().get(0);
         assertThat(firstPosition.positionTitle()).isEqualTo("Node.js 백엔드 개발자");
-        assertThat(firstPosition.positionCategoryName()).isEqualTo("백엔드");
+        assertThat(firstPosition.positionCategoryName()).isEqualTo("백엔드 개발자");
         assertThat(firstPosition.headCount()).isEqualTo(3L);
         assertThat(firstPosition.budgetText()).isEqualTo("1,000,000 ~ 2,000,000");
         assertThat(firstPosition.expectedPeriod()).isEqualTo(3L);
@@ -173,7 +173,7 @@ class RecommendationEntryServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        ProposalPosition position = addPosition(proposal, 100L, "백엔드", "백엔드 개발자", 1L, null, null, null);
+        ProposalPosition position = addPosition(proposal, 100L, "백엔드 개발자", "백엔드 개발자", 1L, null, null, null);
         ReflectionTestUtils.setField(position, "title", "   ");
 
         stubProposalDetailLoad(proposal);
@@ -183,8 +183,8 @@ class RecommendationEntryServiceTest {
         RecommendationEntryPositionItem result = service.getEntry(PROPOSAL_ID, OWNER_EMAIL).positions().get(0);
 
         // then
-        assertThat(result.positionTitle()).isEqualTo("백엔드");
-        assertThat(result.positionCategoryName()).isEqualTo("백엔드");
+        assertThat(result.positionTitle()).isEqualTo("백엔드 개발자");
+        assertThat(result.positionCategoryName()).isEqualTo("백엔드 개발자");
         verifyExpectedInteractions();
     }
 

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunServiceTest.java
@@ -81,8 +81,8 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
-        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, 10L, "UI/UX 디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
 
         RecommendationRun existingRun = RecommendationRun.create(
                 selectedPosition,
@@ -129,8 +129,8 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
-        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, 10L, "UI/UX 디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
@@ -184,8 +184,8 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
-        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, 10L, "UI/UX 디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
         List<Long> excludedResumeIds = List.of(1L, 2L, 3L);
 
         RecommendationRun existingRun = RecommendationRun.create(
@@ -258,8 +258,8 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, 10L, "디자이너", ProposalPositionStatus.OPEN);
-        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, 10L, "UI/UX 디자이너", ProposalPositionStatus.OPEN);
+        ProposalPosition selectedPosition = addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
         List<Long> excludedResumeIds = List.of(1L, 2L, 3L);
 
         stubProposalDetailLoad(proposal);
@@ -339,7 +339,7 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.FULL);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.FULL);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
@@ -380,7 +380,7 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(null);
@@ -406,7 +406,7 @@ class RecommendationRunServiceTest {
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Member other = createMemberWithId(2L, "other@example.com");
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value("other@example.com")).willReturn(other);
@@ -431,7 +431,7 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.WRITING);
-        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.OPEN);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.OPEN);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);
@@ -481,7 +481,7 @@ class RecommendationRunServiceTest {
         // given
         Member owner = createMemberWithId(OWNER_ID, OWNER_EMAIL);
         Proposal proposal = createProposalWithStatus(owner, PROPOSAL_ID, ProposalStatus.MATCHING);
-        addPosition(proposal, SELECTED_POSITION_ID, "백엔드", ProposalPositionStatus.FULL);
+        addPosition(proposal, SELECTED_POSITION_ID, "백엔드 개발자", ProposalPositionStatus.FULL);
 
         stubProposalDetailLoad(proposal);
         given(memberRepository.findByEmail_Value(OWNER_EMAIL)).willReturn(owner);


### PR DESCRIPTION
## 🔎 What

- AI 브리프/AI 인터뷰에서 `Position` 자동 생성 흐름 제거
- `positionCategoryName`을 기존 `Position` 기준으로 해석하는 매핑 로직 정리
- 필요 시 `PositionResolver` 또는 alias 매핑 로직 추가
- 허용 가능한 `Position` 카테고리 목록을 AI 프롬프트에 명시
- AI가 목록 밖 카테고리를 반환하지 않도록 프롬프트 보강
- 매핑 실패 시 처리 정책 정리
- 매핑 실패한 포지션이 제안서에 잘못 저장되지 않도록 보호
- AI 브리프 관련 테스트 수정
- AI 인터뷰 관련 테스트 수정
- 추천/후속 로직에서 `Position` 기준 정합성이 깨지지 않는지 확인

## 🔗 Issue

- Closes: #101 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?