### PR TITLE
[Feat] 매칭 상대 프로필 조회 API 및 ProfileShell 기반 렌더링 구현

### DIFF
--- a/src/main/java/com/generic4/itda/controller/MatchingProfileController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingProfileController.java
@@ -1,0 +1,63 @@
+package com.generic4.itda.controller;
+
+import com.generic4.itda.dto.profile.ProfileShellViewModel;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.service.MatchingProfileQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class MatchingProfileController {
+
+    private final MatchingProfileQueryService matchingProfileQueryService;
+
+    @GetMapping("/matchings/{matchingId}/counterpart-profile")
+    public String counterpartProfile(
+            @PathVariable Long matchingId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            ProfileShellViewModel view = matchingProfileQueryService
+                    .getCounterpartProfile(matchingId, principal.getEmail());
+
+            model.addAttribute("view", view.withBackUrl(resolveBackUrl(backUrl, view.backUrl())));
+
+            return "profile/shell";
+        } catch (IllegalArgumentException e) {
+            log.warn("상대 프로필 조회 실패. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 매칭입니다.");
+            return redirectTo(backUrl, "/matchings/" + matchingId);
+        } catch (AccessDeniedException e) {
+            log.warn("상대 프로필 접근 거부. matchingId={}, email={}",
+                    matchingId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다.");
+            return redirectTo(backUrl, "/matchings/" + matchingId);
+        }
+    }
+
+    private String redirectTo(String backUrl, String fallback) {
+        return "redirect:" + resolveBackUrl(backUrl, fallback);
+    }
+
+    private String resolveBackUrl(String backUrl, String fallback) {
+        if (StringUtils.hasText(backUrl) && backUrl.startsWith("/") && !backUrl.startsWith("//")) {
+            return backUrl;
+        }
+        return fallback;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileMatchingContextViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileMatchingContextViewModel.java
@@ -10,7 +10,9 @@ public record ProfileMatchingContextViewModel(
         String matchingDetailUrl,
         String proposalDetailUrl,
         String acceptActionUrl,
-        String rejectActionUrl
+        String rejectActionUrl,
+        String contactEmail,
+        String contactPhone
 ) {
     public boolean proposed() {
         return "PROPOSED".equals(matchingStatus);
@@ -22,5 +24,13 @@ public record ProfileMatchingContextViewModel(
 
     public boolean canRespond() {
         return proposed() && freelancerViewer();
+    }
+
+    public boolean hasContactDetails() {
+        return contactVisible
+                && contactEmail != null
+                && !contactEmail.isBlank()
+                && contactPhone != null
+                && !contactPhone.isBlank();
     }
 }

--- a/src/main/java/com/generic4/itda/dto/profile/ProfileShellViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/profile/ProfileShellViewModel.java
@@ -10,9 +10,27 @@ public record ProfileShellViewModel(
         String backUrl,
         ProfileFreelancerBodyViewModel freelancer,
         ProfileClientBodyViewModel client,
+        ProfileProjectSummaryViewModel projectSummary,
         ProfileMatchingContextViewModel matchingContext,
         ProfileRecommendationContextViewModel recommendationContext
 ) {
+    public ProfileShellViewModel withBackUrl(String backUrl) {
+        return new ProfileShellViewModel(
+                subjectType,
+                contextType,
+                accessLevel,
+                title,
+                subtitle,
+                statusLabel,
+                backUrl,
+                freelancer,
+                client,
+                projectSummary,
+                matchingContext,
+                recommendationContext
+        );
+    }
+
     public boolean freelancerSubject() {
         return subjectType == ProfileSubjectType.FREELANCER;
     }
@@ -27,5 +45,9 @@ public record ProfileShellViewModel(
 
     public boolean hasMatchingContext() {
         return contextType == ProfileContextType.MATCHING && matchingContext != null;
+    }
+
+    public boolean hasProjectSummary() {
+        return projectSummary != null;
     }
 }

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationResumeDetailViewModel.java
@@ -61,6 +61,7 @@ public record RecommendationResumeDetailViewModel(
                 ),
                 null,
                 null,
+                null,
                 new ProfileRecommendationContextViewModel(
                         proposalId,
                         runId,

--- a/src/main/java/com/generic4/itda/service/MatchingProfileQueryService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingProfileQueryService.java
@@ -1,0 +1,328 @@
+package com.generic4.itda.service;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingStatus;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.dto.profile.ProfileAccessLevel;
+import com.generic4.itda.dto.profile.ProfileCareerItemViewModel;
+import com.generic4.itda.dto.profile.ProfileClientBodyViewModel;
+import com.generic4.itda.dto.profile.ProfileContextType;
+import com.generic4.itda.dto.profile.ProfileFreelancerBodyViewModel;
+import com.generic4.itda.dto.profile.ProfileMatchingContextViewModel;
+import com.generic4.itda.dto.profile.ProfileProjectSummaryViewModel;
+import com.generic4.itda.dto.profile.ProfileShellViewModel;
+import com.generic4.itda.dto.profile.ProfileSkillItemViewModel;
+import com.generic4.itda.dto.profile.ProfileSubjectType;
+import com.generic4.itda.repository.MatchingRepository;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MatchingProfileQueryService {
+
+    private static final String VIEWER_ROLE_CLIENT = "CLIENT";
+    private static final String VIEWER_ROLE_FREELANCER = "FREELANCER";
+
+    private final MatchingRepository matchingRepository;
+
+    public ProfileShellViewModel getCounterpartProfile(Long matchingId, String email) {
+        Matching matching = matchingRepository.findDetailById(matchingId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=" + matchingId));
+
+        String viewerRole = resolveViewerRole(matching, email);
+        boolean contactVisible = isContactVisible(matching);
+
+        if (VIEWER_ROLE_CLIENT.equals(viewerRole)) {
+            return toFreelancerProfile(matching, viewerRole, contactVisible);
+        }
+
+        return toClientProfile(matching, viewerRole, contactVisible);
+    }
+
+    private ProfileShellViewModel toFreelancerProfile(Matching matching, String viewerRole, boolean contactVisible) {
+        Resume resume = matching.getResume();
+        Member freelancer = matching.getFreelancerMember();
+        ProposalPosition proposalPosition = matching.getProposalPosition();
+        ProfileProjectSummaryViewModel projectSummary = toProjectSummary(proposalPosition);
+
+        String displayName = resolveProfileDisplayName(freelancer, contactVisible);
+
+        return new ProfileShellViewModel(
+                ProfileSubjectType.FREELANCER,
+                ProfileContextType.MATCHING,
+                toAccessLevel(contactVisible),
+                displayName,
+                toSubtitle(proposalPosition),
+                matching.getStatus().getDescription(),
+                "/matchings/" + matching.getId(),
+                toFreelancerBody(resume, displayName),
+                null,
+                projectSummary,
+                toMatchingContext(matching, viewerRole, contactVisible),
+                null
+        );
+    }
+
+    private ProfileShellViewModel toClientProfile(Matching matching, String viewerRole, boolean contactVisible) {
+        Member client = matching.getClientMember();
+        ProposalPosition proposalPosition = matching.getProposalPosition();
+        ProfileProjectSummaryViewModel projectSummary = toProjectSummary(proposalPosition);
+
+        String displayName = resolveProfileDisplayName(client, contactVisible);
+
+        return new ProfileShellViewModel(
+                ProfileSubjectType.CLIENT,
+                ProfileContextType.MATCHING,
+                toAccessLevel(contactVisible),
+                displayName,
+                toSubtitle(proposalPosition),
+                matching.getStatus().getDescription(),
+                "/matchings/" + matching.getId(),
+                null,
+                toClientBody(client, displayName, projectSummary),
+                projectSummary,
+                toMatchingContext(matching, viewerRole, contactVisible),
+                null
+        );
+    }
+
+    private ProfileFreelancerBodyViewModel toFreelancerBody(Resume resume, String displayName) {
+        return new ProfileFreelancerBodyViewModel(
+                displayName,
+                "프리랜서 프로필",
+                resume.getIntroduction(),
+                resume.getCareerYears() != null ? resume.getCareerYears().intValue() : null,
+                resume.getPreferredWorkType() != null ? resume.getPreferredWorkType().getDescription() : "미정",
+                resume.getPortfolioUrl(),
+                resume.getSkills().stream()
+                        .map(skill -> new ProfileSkillItemViewModel(
+                                skill.getSkill().getName(),
+                                skill.getProficiency().getDescription(),
+                                skill.getProficiency().name()
+                        ))
+                        .toList(),
+                toCareerItems(resume)
+        );
+    }
+
+    private ProfileClientBodyViewModel toClientBody(
+            Member client,
+            String displayName,
+            ProfileProjectSummaryViewModel projectSummary
+    ) {
+        return new ProfileClientBodyViewModel(
+                displayName,
+                client.getType() != null ? client.getType().getDescription() : null,
+                client.getMemo(),
+                projectSummary
+        );
+    }
+
+    private ProfileMatchingContextViewModel toMatchingContext(
+            Matching matching,
+            String viewerRole,
+            boolean contactVisible
+    ) {
+        return new ProfileMatchingContextViewModel(
+                matching.getId(),
+                viewerRole,
+                matching.getStatus().name(),
+                contactVisible,
+                matching.getStatus().getDescription(),
+                resolveHelperMessage(matching, viewerRole),
+                "/matchings/" + matching.getId(),
+                "/proposals/" + matching.getProposalPosition().getProposal().getId(),
+                "/matchings/" + matching.getId() + "/accept",
+                "/matchings/" + matching.getId() + "/reject"
+        );
+    }
+
+    private List<ProfileCareerItemViewModel> toCareerItems(Resume resume) {
+        CareerPayload career = resume.getCareer();
+        if (career == null || career.getItems() == null) {
+            return List.of();
+        }
+
+        return career.getItems().stream()
+                .map(this::toCareerItem)
+                .toList();
+    }
+
+    private ProfileCareerItemViewModel toCareerItem(CareerItemPayload career) {
+        return new ProfileCareerItemViewModel(
+                career.getCompanyName(),
+                career.getPosition(),
+                career.getEmploymentType() != null ? career.getEmploymentType().getDescription() : "미정",
+                formatCareerPeriod(career),
+                career.getSummary(),
+                career.getTechStack()
+        );
+    }
+
+    private ProfileProjectSummaryViewModel toProjectSummary(ProposalPosition proposalPosition) {
+        Proposal proposal = proposalPosition.getProposal();
+        return new ProfileProjectSummaryViewModel(
+                proposal.getId(),
+                proposal.getTitle(),
+                proposal.getDescription(),
+                proposalPosition.getTitle(),
+                proposalPosition.getWorkType() != null ? proposalPosition.getWorkType().getDescription() : "미정",
+                formatBudgetText(proposalPosition.getUnitBudgetMin(), proposalPosition.getUnitBudgetMax()),
+                formatExpectedPeriod(proposalPosition.getExpectedPeriod()),
+                proposalPosition.getSkills().stream()
+                        .filter(skill -> skill.getImportance() == ProposalPositionSkillImportance.ESSENTIAL)
+                        .map(skill -> skill.getSkill().getName())
+                        .toList(),
+                proposalPosition.getSkills().stream()
+                        .filter(skill -> skill.getImportance() == ProposalPositionSkillImportance.PREFERENCE)
+                        .map(skill -> skill.getSkill().getName())
+                        .toList()
+        );
+    }
+
+    private ProfileAccessLevel toAccessLevel(boolean contactVisible) {
+        return contactVisible ? ProfileAccessLevel.FULL : ProfileAccessLevel.PREVIEW;
+    }
+
+    private String toSubtitle(ProposalPosition proposalPosition) {
+        return proposalPosition.getProposal().getTitle()
+                + " · "
+                + proposalPosition.getTitle();
+    }
+
+    private String resolveViewerRole(Matching matching, String email) {
+        if (matching.getClientMember().getEmail().getValue().equals(email)) {
+            return VIEWER_ROLE_CLIENT;
+        }
+
+        if (matching.getFreelancerMember().getEmail().getValue().equals(email)) {
+            return VIEWER_ROLE_FREELANCER;
+        }
+
+        throw new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다.");
+    }
+
+    private String resolveProfileDisplayName(Member member, boolean contactVisible) {
+        if (contactVisible) {
+            return resolveDisplayName(member);
+        }
+        return maskName(resolveDisplayName(member));
+    }
+
+    private String maskName(String name) {
+        if (!StringUtils.hasText(name)) {
+            return "익명";
+        }
+
+        name = name.trim();
+
+        if (name.length() == 1) {
+            return "*";
+        }
+
+        if (name.length() == 2) {
+            return name.charAt(0) + "*";
+        }
+
+        return name.charAt(0)
+                + "*".repeat(name.length() - 2)
+                + name.charAt(name.length() - 1);
+    }
+
+
+    private String resolveDisplayName(Member member) {
+        if (StringUtils.hasText(member.getNickname())) {
+            return member.getNickname().trim();
+        }
+        return member.getName().trim();
+    }
+
+    private String resolveHelperMessage(Matching matching, String viewerRole) {
+        MatchingStatus status = matching.getStatus();
+
+        return switch (status) {
+            case PROPOSED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다."
+                    : "요청 내용을 확인한 뒤 수락 또는 거절할 수 있습니다.";
+            case ACCEPTED -> "연락처가 공개되었습니다. 제안서를 다시 확인하고 협의를 이어가세요.";
+            case REJECTED -> VIEWER_ROLE_CLIENT.equals(viewerRole)
+                    ? "다른 추천 후보를 검토하거나 제안서 상태를 다시 확인해보세요."
+                    : "이 매칭은 종료 상태이며 추가 응답은 필요하지 않습니다.";
+            case IN_PROGRESS -> "프로젝트가 진행 중입니다. 연락처와 제안서 정보를 확인하며 협업을 이어가세요.";
+            case COMPLETED -> "완료된 매칭입니다. 프로젝트 진행 이력을 확인할 수 있습니다.";
+            case CANCELED -> isContractCancellation(matching)
+                    ? "취소된 계약입니다. 필요한 경우 진행 이력과 연락처 정보를 확인해보세요."
+                    : "취소된 매칭입니다. 필요한 경우 다른 추천 후보를 검토해보세요.";
+        };
+    }
+
+    private boolean isContactVisible(Matching matching) {
+        return switch (matching.getStatus()) {
+            case ACCEPTED, IN_PROGRESS, COMPLETED -> true;
+            case REJECTED, PROPOSED -> false;
+            case CANCELED -> isContractCancellation(matching);
+        };
+    }
+
+    private String formatCareerPeriod(CareerItemPayload career) {
+        String start = career.getStartYearMonth();
+        String end = Boolean.TRUE.equals(career.getCurrentlyWorking())
+                ? "재직 중"
+                : career.getEndYearMonth();
+
+        if (!StringUtils.hasText(start) && !StringUtils.hasText(end)) {
+            return "기간 미정";
+        }
+
+        if (!StringUtils.hasText(end)) {
+            return start + " ~";
+        }
+
+        return start + " ~ " + end;
+    }
+
+
+    private String formatExpectedPeriod(Long expectedPeriod) {
+        return expectedPeriod != null ? expectedPeriod + "주" : "미정";
+    }
+
+    private String formatBudgetText(Long budgetMin, Long budgetMax) {
+        if (budgetMin == null && budgetMax == null) {
+            return "미정";
+        }
+
+        NumberFormat formatter = NumberFormat.getNumberInstance(Locale.KOREA);
+
+        if (budgetMin == null) {
+            return "~ " + formatter.format(budgetMax) + "원";
+        }
+
+        if (budgetMax == null) {
+            return formatter.format(budgetMin) + "원 ~";
+        }
+
+        if (budgetMin.equals(budgetMax)) {
+            return formatter.format(budgetMin) + "원";
+        }
+
+        return formatter.format(budgetMin) + "원 ~ " + formatter.format(budgetMax) + "원";
+    }
+
+    private boolean isContractCancellation(Matching matching) {
+        return matching.getStatus() == MatchingStatus.CANCELED && matching.getContractDate() != null;
+    }
+}

--- a/src/main/java/com/generic4/itda/service/MatchingProfileQueryService.java
+++ b/src/main/java/com/generic4/itda/service/MatchingProfileQueryService.java
@@ -72,7 +72,7 @@ public class MatchingProfileQueryService {
                 toFreelancerBody(resume, displayName),
                 null,
                 projectSummary,
-                toMatchingContext(matching, viewerRole, contactVisible),
+                toMatchingContext(matching, viewerRole, contactVisible, freelancer),
                 null
         );
     }
@@ -95,7 +95,7 @@ public class MatchingProfileQueryService {
                 null,
                 toClientBody(client, displayName, projectSummary),
                 projectSummary,
-                toMatchingContext(matching, viewerRole, contactVisible),
+                toMatchingContext(matching, viewerRole, contactVisible, client),
                 null
         );
     }
@@ -135,7 +135,8 @@ public class MatchingProfileQueryService {
     private ProfileMatchingContextViewModel toMatchingContext(
             Matching matching,
             String viewerRole,
-            boolean contactVisible
+            boolean contactVisible,
+            Member counterpart
     ) {
         return new ProfileMatchingContextViewModel(
                 matching.getId(),
@@ -147,7 +148,9 @@ public class MatchingProfileQueryService {
                 "/matchings/" + matching.getId(),
                 "/proposals/" + matching.getProposalPosition().getProposal().getId(),
                 "/matchings/" + matching.getId() + "/accept",
-                "/matchings/" + matching.getId() + "/reject"
+                "/matchings/" + matching.getId() + "/reject",
+                resolveContactEmail(counterpart, contactVisible),
+                resolveContactPhone(counterpart, contactVisible)
         );
     }
 
@@ -251,6 +254,20 @@ public class MatchingProfileQueryService {
         return member.getName().trim();
     }
 
+    private String resolveContactEmail(Member member, boolean contactVisible) {
+        if (!contactVisible) {
+            return null;
+        }
+        return member.getEmail().getValue();
+    }
+
+    private String resolveContactPhone(Member member, boolean contactVisible) {
+        if (!contactVisible) {
+            return null;
+        }
+        return formatPhone(member.getPhone().getValue());
+    }
+
     private String resolveHelperMessage(Matching matching, String viewerRole) {
         MatchingStatus status = matching.getStatus();
 
@@ -298,6 +315,28 @@ public class MatchingProfileQueryService {
 
     private String formatExpectedPeriod(Long expectedPeriod) {
         return expectedPeriod != null ? expectedPeriod + "주" : "미정";
+    }
+
+    private String formatPhone(String phone) {
+        if (!StringUtils.hasText(phone)) {
+            return "-";
+        }
+        String digits = phone.replaceAll("[^0-9]", "");
+        if (digits.startsWith("02")) {
+            if (digits.length() == 9) {
+                return digits.substring(0, 2) + "-" + digits.substring(2, 5) + "-" + digits.substring(5);
+            }
+            if (digits.length() == 10) {
+                return digits.substring(0, 2) + "-" + digits.substring(2, 6) + "-" + digits.substring(6);
+            }
+        }
+        if (digits.length() == 10) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 6) + "-" + digits.substring(6);
+        }
+        if (digits.length() == 11) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
+        }
+        return digits;
     }
 
     private String formatBudgetText(Long budgetMin, Long budgetMax) {

--- a/src/main/resources/templates/fragments/profileFragments.html
+++ b/src/main/resources/templates/fragments/profileFragments.html
@@ -386,6 +386,37 @@
             </div>
         </article>
 
+        <article th:if="${ctx.hasContactDetails()}"
+                 class="rounded-[28px] border border-emerald-200 bg-white p-6 shadow-sm shadow-emerald-100/60">
+            <div class="flex items-start gap-3">
+                <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-600">
+                    <i data-lucide="badge-check" class="h-5 w-5"></i>
+                </div>
+                <div class="min-w-0 flex-1">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-emerald-600">CONTACT OPEN</p>
+                    <h2 class="mt-2 text-lg font-bold text-slate-900">공개된 연락처</h2>
+                    <p class="mt-2 text-sm leading-relaxed text-slate-500">
+                        연락처 공개 상태이므로 상대 프로필에서도 바로 확인할 수 있습니다.
+                    </p>
+                </div>
+            </div>
+
+            <div class="mt-5 grid gap-3">
+                <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">Email</p>
+                    <p class="mt-2 break-all text-sm font-bold text-slate-900" th:text="${ctx.contactEmail}">
+                        client@example.com
+                    </p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-5 py-4">
+                    <p class="text-[10px] font-bold uppercase tracking-widest text-slate-400">Phone</p>
+                    <p class="mt-2 text-sm font-bold text-slate-900" th:text="${ctx.contactPhone}">
+                        010-1234-5678
+                    </p>
+                </div>
+            </div>
+        </article>
+
         <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
             <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">ACTIONS</p>
             <h2 class="mt-2 text-lg font-bold text-slate-900">현재 가능한 작업</h2>

--- a/src/main/resources/templates/fragments/profileFragments.html
+++ b/src/main/resources/templates/fragments/profileFragments.html
@@ -140,7 +140,7 @@
     </section>
 </th:block>
 
-<th:block th:fragment="clientBody(profile)" th:with="body=${profile.client}, project=${profile.client != null ? profile.client.project : null}">
+<th:block th:fragment="clientBody(profile)" th:with="body=${profile.client}">
     <section class="space-y-6">
         <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
             <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">CLIENT PROFILE</p>
@@ -153,43 +153,76 @@
                 클라이언트 소개
             </p>
         </article>
-
-        <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
-            <h2 class="text-base font-bold text-slate-900">요청 프로젝트 요약</h2>
-            <div th:if="${project == null}"
-                 class="mt-4 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
-                연결된 프로젝트 요약이 없습니다.
-            </div>
-            <div th:if="${project != null}" class="mt-4 space-y-4">
-                <div>
-                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">제안서</p>
-                    <p class="mt-1 text-lg font-bold text-slate-900" th:text="${project.proposalTitle}">제안서 제목</p>
-                    <p class="mt-2 text-sm leading-relaxed text-slate-600"
-                       th:text="${#strings.isEmpty(project.description) ? '제안서 설명이 없습니다.' : project.description}">
-                        제안서 설명
-                    </p>
-                </div>
-                <div class="grid gap-3 sm:grid-cols-2">
-                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">포지션</p>
-                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.positionTitle}">백엔드</p>
-                    </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
-                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.workTypeLabel}">원격</p>
-                    </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
-                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.budgetText}">미정</p>
-                    </div>
-                    <div class="rounded-2xl bg-slate-50 px-4 py-4">
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예상 기간</p>
-                        <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.expectedPeriodText}">미정</p>
-                    </div>
-                </div>
-            </div>
-        </article>
     </section>
+</th:block>
+
+<th:block th:fragment="projectSummarySection(project)">
+    <article class="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/50">
+        <div class="flex items-start justify-between gap-4">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">REQUESTED PROJECT</p>
+                <h2 class="mt-2 text-base font-bold text-slate-900">요청 프로젝트 요약</h2>
+            </div>
+            <a th:if="${project != null and project.proposalId != null}"
+               th:href="@{/proposals/{id}(id=${project.proposalId})}"
+               class="inline-flex items-center gap-1.5 text-sm font-bold text-slate-500 transition hover:text-slate-700">
+                <i data-lucide="eye" class="h-4 w-4"></i>
+                제안서 보기
+            </a>
+        </div>
+
+        <div th:if="${project == null}"
+             class="mt-4 rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-center text-sm text-slate-500">
+            연결된 프로젝트 요약이 없습니다.
+        </div>
+
+        <div th:if="${project != null}" class="mt-4 space-y-4">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">제안서</p>
+                <p class="mt-1 text-lg font-bold text-slate-900" th:text="${project.proposalTitle}">제안서 제목</p>
+                <p class="mt-2 text-sm leading-relaxed text-slate-600"
+                   th:text="${#strings.isEmpty(project.description) ? '제안서 설명이 없습니다.' : project.description}">
+                    제안서 설명
+                </p>
+            </div>
+            <div class="grid gap-3 sm:grid-cols-2">
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">포지션</p>
+                    <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.positionTitle}">백엔드</p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
+                    <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.workTypeLabel}">원격</p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
+                    <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.budgetText}">미정</p>
+                </div>
+                <div class="rounded-2xl bg-slate-50 px-4 py-4">
+                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예상 기간</p>
+                    <p class="mt-2 text-sm font-bold text-slate-900" th:text="${project.expectedPeriodText}">미정</p>
+                </div>
+            </div>
+
+            <div th:if="${!#lists.isEmpty(project.essentialSkills)}">
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
+                <div class="mt-3 flex flex-wrap gap-2">
+                    <span th:each="skill : ${project.essentialSkills}"
+                          class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600"
+                          th:text="${skill}">Java</span>
+                </div>
+            </div>
+
+            <div th:if="${!#lists.isEmpty(project.preferredSkills)}">
+                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
+                <div class="mt-3 flex flex-wrap gap-2">
+                    <span th:each="skill : ${project.preferredSkills}"
+                          class="rounded-xl border border-blue-100 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700"
+                          th:text="${skill}">Docker</span>
+                </div>
+            </div>
+        </div>
+    </article>
 </th:block>
 
 <th:block th:fragment="recommendationContextPanel(profile)" th:with="ctx=${profile.recommendationContext}">

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -22,8 +22,7 @@
             <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4">
 
                 <div class="flex items-center gap-4">
-                    <a th:href="${view.viewerRole == 'CLIENT' ? '/client/dashboard' : '/freelancers/dashboard'}"
-                       onclick="if (window.history.length > 1) { history.back(); return false; }"
+                    <a th:href="${backUrl}"
                        class="flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
                         <i data-lucide="arrow-left" class="h-4 w-4"></i>
                     </a>
@@ -50,11 +49,19 @@
                     </div>
                 </div>
 
-                <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
-                   class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
-                    <i data-lucide="file-text" class="h-4 w-4"></i>
-                    제안서 보기
-                </a>
+                <div class="flex items-center gap-3">
+                    <a th:href="@{/matchings/{id}/counterpart-profile(id=${view.matchingId}, backUrl=${'/matchings/' + view.matchingId})}"
+                       class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                        <i data-lucide="user" class="h-4 w-4"></i>
+                        상대 프로필 보기
+                    </a>
+                    <a th:if="${view.project != null and view.project.proposalId != null}"
+                       th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                       class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
+                        <i data-lucide="file-text" class="h-4 w-4"></i>
+                        제안서 보기
+                    </a>
+                </div>
             </div>
         </div>
 
@@ -511,37 +518,45 @@
                             </p>
                         </div>
 
-                        <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                        <a th:if="${view.project != null and view.project.proposalId != null}"
+                           th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
                            class="mt-4 inline-flex items-center gap-2 text-sm font-bold text-slate-500 transition hover:text-slate-700">
                             <i data-lucide="arrow-right" class="h-4 w-4"></i>
                             제안서 상세로 이동
                         </a>
                     </section>
 
-                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60">
+                    <section class="rounded-[32px] border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60"
+                             th:with="project=${view.project}">
                         <div class="flex items-start justify-between gap-4">
                             <div>
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">PROJECT</p>
                                 <h3 class="mt-2 text-lg font-bold tracking-tight text-slate-900">프로젝트 요약</h3>
                             </div>
-                            <a th:href="@{/proposals/{id}(id=${view.project.proposalId})}"
+                            <a th:if="${project != null and project.proposalId != null}"
+                               th:href="@{/proposals/{id}(id=${project.proposalId})}"
                                class="inline-flex items-center gap-1.5 text-sm font-bold text-slate-500 transition hover:text-slate-700">
                                 <i data-lucide="eye" class="h-4 w-4"></i>
                                 제안서 보기
                             </a>
                         </div>
 
-                        <div class="mt-6 space-y-5">
+                        <div th:if="${project == null}"
+                             class="mt-6 rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-5 py-6 text-center text-sm text-slate-500">
+                            연결된 제안서 요약을 불러오지 못했습니다.
+                        </div>
+
+                        <div th:if="${project != null}" class="mt-6 space-y-5">
                             <div>
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">제목</p>
                                 <p class="mt-2 text-lg font-bold tracking-tight text-slate-900"
-                                   th:text="${view.project.proposalTitle}">온라인 쇼핑몰 모바일 앱 개발</p>
+                                   th:text="${project.proposalTitle}">온라인 쇼핑몰 모바일 앱 개발</p>
                             </div>
 
                             <div>
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">설명</p>
                                 <p class="mt-2 text-sm leading-relaxed text-slate-600"
-                                   th:text="${#strings.isEmpty(view.project.description) ? '제안서 설명이 없습니다.' : view.project.description}">
+                                   th:text="${#strings.isEmpty(project.description) ? '제안서 설명이 없습니다.' : project.description}">
                                     프로젝트 설명입니다.
                                 </p>
                             </div>
@@ -550,40 +565,40 @@
                                 <div class="rounded-2xl bg-slate-50 px-4 py-4">
                                     <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">포지션</p>
                                     <p class="mt-2 text-sm font-bold text-slate-900"
-                                       th:text="${view.project.positionTitle}">프론트엔드 개발자</p>
+                                       th:text="${project.positionTitle}">프론트엔드 개발자</p>
                                     <p class="mt-1 text-xs text-slate-500"
-                                       th:text="${view.project.positionCategory}">Frontend Developer</p>
+                                       th:text="${#strings.isEmpty(project.positionCategory) ? '분류 미정' : project.positionCategory}">Frontend Developer</p>
                                 </div>
                                 <div class="rounded-2xl bg-slate-50 px-4 py-4">
                                     <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
                                     <p class="mt-2 text-sm font-bold text-slate-900"
-                                       th:text="${view.project.workTypeLabel}">원격</p>
+                                       th:text="${project.workTypeLabel}">원격</p>
                                 </div>
                                 <div class="rounded-2xl bg-slate-50 px-4 py-4">
                                     <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
                                     <p class="mt-2 text-sm font-bold text-slate-900"
-                                       th:text="${view.project.budgetText}">3,000,000원 ~ 4,000,000원</p>
+                                       th:text="${project.budgetText}">3,000,000원 ~ 4,000,000원</p>
                                 </div>
                                 <div class="rounded-2xl bg-slate-50 px-4 py-4">
                                     <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예상 기간</p>
                                     <p class="mt-2 text-sm font-bold text-slate-900"
-                                       th:text="${view.project.expectedPeriodText}">8주</p>
+                                       th:text="${project.expectedPeriodText}">8주</p>
                                 </div>
                             </div>
 
-                            <div th:if="${!#lists.isEmpty(view.project.essentialSkills)}">
+                            <div th:if="${!#lists.isEmpty(project.essentialSkills)}">
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
                                 <div class="mt-3 flex flex-wrap gap-2">
-                                    <span th:each="skill : ${view.project.essentialSkills}"
+                                    <span th:each="skill : ${project.essentialSkills}"
                                           class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600"
                                           th:text="${skill}">React</span>
                                 </div>
                             </div>
 
-                            <div th:if="${!#lists.isEmpty(view.project.preferredSkills)}">
+                            <div th:if="${!#lists.isEmpty(project.preferredSkills)}">
                                 <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
                                 <div class="mt-3 flex flex-wrap gap-2">
-                                    <span th:each="skill : ${view.project.preferredSkills}"
+                                    <span th:each="skill : ${project.preferredSkills}"
                                           class="rounded-xl border border-blue-100 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700"
                                           th:text="${skill}">Tailwind</span>
                                 </div>

--- a/src/main/resources/templates/profile/shell.html
+++ b/src/main/resources/templates/profile/shell.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+  <title th:text="${view.title} + ' | IT-da'">상대 프로필 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <main class="min-h-screen bg-slate-50">
+
+    <th:block th:replace="~{fragments/profileFragments :: profileHeader(profile=${view})}"></th:block>
+    <th:block th:replace="~{fragments/profileFragments :: profileAlerts}"></th:block>
+
+    <div class="mx-auto max-w-7xl px-4 py-6 lg:px-6 lg:py-8">
+      <div class="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(320px,0.85fr)]">
+        <section class="space-y-6">
+          <th:block th:if="${view.freelancerSubject()}">
+            <th:block th:replace="~{fragments/profileFragments :: freelancerBody(profile=${view})}"></th:block>
+          </th:block>
+
+          <th:block th:if="${view.clientSubject()}">
+            <th:block th:replace="~{fragments/profileFragments :: clientBody(profile=${view})}"></th:block>
+          </th:block>
+
+          <th:block th:if="${view.hasProjectSummary()}">
+            <th:block th:replace="~{fragments/profileFragments :: projectSummarySection(project=${view.projectSummary})}"></th:block>
+          </th:block>
+        </section>
+
+        <div class="space-y-6">
+          <th:block th:if="${view.hasMatchingContext()}">
+            <th:block th:replace="~{fragments/profileFragments :: matchingContextPanel(profile=${view})}"></th:block>
+          </th:block>
+
+          <th:block th:if="${view.hasRecommendationContext()}">
+            <th:block th:replace="~{fragments/profileFragments :: recommendationContextPanel(profile=${view})}"></th:block>
+          </th:block>
+        </div>
+
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
@@ -49,7 +49,7 @@ class MatchingProfileControllerTest {
     @DisplayName("프리랜서 상대 프로필에서도 공통 프로젝트 요약이 렌더링된다")
     void renderCounterpartProfileWithSharedProjectSummary() throws Exception {
         given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
-                .willReturn(createFreelancerShellView());
+                .willReturn(createFreelancerShellView(false));
 
         mockMvc.perform(get("/matchings/401/counterpart-profile")
                         .param("backUrl", "/client/dashboard")
@@ -60,6 +60,22 @@ class MatchingProfileControllerTest {
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("요청 프로젝트 요약")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("AI 매칭 플랫폼")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("매칭 상태")));
+    }
+
+    @Test
+    @DisplayName("연락처가 공개된 매칭 프로필에서는 상대 연락처를 함께 렌더링한다")
+    void renderCounterpartProfileWithContactDetailsWhenVisible() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willReturn(createFreelancerShellView(true));
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("backUrl", "/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("profile/shell"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("공개된 연락처")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("freelancer@example.com")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("010-0000-0002")));
     }
 
     @Test
@@ -101,17 +117,17 @@ class MatchingProfileControllerTest {
         );
     }
 
-    private ProfileShellViewModel createFreelancerShellView() {
+    private ProfileShellViewModel createFreelancerShellView(boolean contactVisible) {
         return new ProfileShellViewModel(
                 ProfileSubjectType.FREELANCER,
                 ProfileContextType.MATCHING,
-                ProfileAccessLevel.PREVIEW,
-                "길*",
+                contactVisible ? ProfileAccessLevel.FULL : ProfileAccessLevel.PREVIEW,
+                contactVisible ? "길동" : "길*",
                 "AI 매칭 플랫폼 · 플랫폼 백엔드 개발자",
-                "제안됨",
+                contactVisible ? "수락됨" : "제안됨",
                 "/matchings/401",
                 new ProfileFreelancerBodyViewModel(
-                        "길*",
+                        contactVisible ? "길동" : "길*",
                         "프리랜서 프로필",
                         "커머스와 금융 도메인 백엔드 개발 경험이 있습니다.",
                         5,
@@ -147,14 +163,18 @@ class MatchingProfileControllerTest {
                 new ProfileMatchingContextViewModel(
                         401L,
                         "CLIENT",
-                        "PROPOSED",
-                        false,
-                        "제안됨",
-                        "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.",
+                        contactVisible ? "ACCEPTED" : "PROPOSED",
+                        contactVisible,
+                        contactVisible ? "수락됨" : "제안됨",
+                        contactVisible
+                                ? "연락처가 공개되었습니다. 제안서를 다시 확인하고 협의를 이어가세요."
+                                : "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.",
                         "/matchings/401",
                         "/proposals/200",
                         "/matchings/401/accept",
-                        "/matchings/401/reject"
+                        "/matchings/401/reject",
+                        contactVisible ? "freelancer@example.com" : null,
+                        contactVisible ? "010-0000-0002" : null
                 ),
                 null
         );

--- a/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
@@ -1,0 +1,162 @@
+package com.generic4.itda.controller;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.dto.profile.ProfileAccessLevel;
+import com.generic4.itda.dto.profile.ProfileCareerItemViewModel;
+import com.generic4.itda.dto.profile.ProfileContextType;
+import com.generic4.itda.dto.profile.ProfileFreelancerBodyViewModel;
+import com.generic4.itda.dto.profile.ProfileMatchingContextViewModel;
+import com.generic4.itda.dto.profile.ProfileProjectSummaryViewModel;
+import com.generic4.itda.dto.profile.ProfileShellViewModel;
+import com.generic4.itda.dto.profile.ProfileSkillItemViewModel;
+import com.generic4.itda.dto.profile.ProfileSubjectType;
+import com.generic4.itda.dto.security.ItDaPrincipal;
+import com.generic4.itda.repository.MemberRepository;
+import com.generic4.itda.service.MatchingProfileQueryService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ControllerTest(MatchingProfileController.class)
+class MatchingProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MatchingProfileQueryService matchingProfileQueryService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("프리랜서 상대 프로필에서도 공통 프로젝트 요약이 렌더링된다")
+    void renderCounterpartProfileWithSharedProjectSummary() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willReturn(createFreelancerShellView());
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("backUrl", "/client/dashboard")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("profile/shell"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("href=\"/client/dashboard\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("요청 프로젝트 요약")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("AI 매칭 플랫폼")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("매칭 상태")));
+    }
+
+    @Test
+    @DisplayName("없는 매칭 상대 프로필을 조회하면 이전 화면으로 돌아가며 오류 메시지를 남긴다")
+    void redirectToBackUrlWhenProfileNotFound() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willThrow(new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=401"));
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("backUrl", "/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/matchings/401"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 매칭입니다."));
+    }
+
+    @Test
+    @DisplayName("외부 backUrl로 상대 프로필 접근이 실패하면 안전한 매칭 경로로 되돌린다")
+    void redirectToSafeMatchingPathWhenBackUrlIsUnsafe() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willThrow(new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다."));
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("backUrl", "https://example.com/outside")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/matchings/401"))
+                .andExpect(flash().attribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다."));
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(String email, String name) {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember(email, "hashed-password", name, "010-1234-5678")
+        );
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private ProfileShellViewModel createFreelancerShellView() {
+        return new ProfileShellViewModel(
+                ProfileSubjectType.FREELANCER,
+                ProfileContextType.MATCHING,
+                ProfileAccessLevel.PREVIEW,
+                "길*",
+                "AI 매칭 플랫폼 · 플랫폼 백엔드 개발자",
+                "제안됨",
+                "/matchings/401",
+                new ProfileFreelancerBodyViewModel(
+                        "길*",
+                        "프리랜서 프로필",
+                        "커머스와 금융 도메인 백엔드 개발 경험이 있습니다.",
+                        5,
+                        "상주, 원격 모두 가능",
+                        "https://portfolio.example.com",
+                        List.of(
+                                new ProfileSkillItemViewModel("Java", "고급", "ADVANCED"),
+                                new ProfileSkillItemViewModel("Spring", "중급", "INTERMEDIATE")
+                        ),
+                        List.of(
+                                new ProfileCareerItemViewModel(
+                                        "네오핀",
+                                        "백엔드 개발자",
+                                        "정규직",
+                                        "2021-01 ~ 2023-06",
+                                        "결제 API와 정산 배치를 개발했습니다.",
+                                        List.of("Java", "Spring Boot", "MySQL")
+                                )
+                        )
+                ),
+                null,
+                new ProfileProjectSummaryViewModel(
+                        200L,
+                        "AI 매칭 플랫폼",
+                        "AI 추천 기반 외주 매칭 프로젝트",
+                        "플랫폼 백엔드 개발자",
+                        "원격",
+                        "3,000,000원 ~ 5,000,000원",
+                        "4주",
+                        List.of("Java"),
+                        List.of("Docker")
+                ),
+                new ProfileMatchingContextViewModel(
+                        401L,
+                        "CLIENT",
+                        "PROPOSED",
+                        false,
+                        "제안됨",
+                        "프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.",
+                        "/matchings/401",
+                        "/proposals/200",
+                        "/matchings/401/accept",
+                        "/matchings/401/reject"
+                ),
+                null
+        );
+    }
+}

--- a/src/test/java/com/generic4/itda/service/MatchingProfileQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/MatchingProfileQueryServiceTest.java
@@ -101,6 +101,8 @@ class MatchingProfileQueryServiceTest {
         assertThat(result.matchingContext().viewerRole()).isEqualTo("CLIENT");
         assertThat(result.matchingContext().matchingStatus()).isEqualTo("PROPOSED");
         assertThat(result.matchingContext().contactVisible()).isFalse();
+        assertThat(result.matchingContext().contactEmail()).isNull();
+        assertThat(result.matchingContext().contactPhone()).isNull();
         assertThat(result.matchingContext().statusLabel()).isEqualTo("제안됨");
         assertThat(result.matchingContext().helperMessage())
                 .isEqualTo("프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.");
@@ -142,6 +144,8 @@ class MatchingProfileQueryServiceTest {
         assertThat(result.client().project().preferredSkills()).containsExactly("Docker");
         assertThat(result.matchingContext().viewerRole()).isEqualTo("FREELANCER");
         assertThat(result.matchingContext().contactVisible()).isFalse();
+        assertThat(result.matchingContext().contactEmail()).isNull();
+        assertThat(result.matchingContext().contactPhone()).isNull();
         assertThat(result.matchingContext().helperMessage()).isEqualTo("요청 내용을 확인한 뒤 수락 또는 거절할 수 있습니다.");
         assertThat(result.matchingContext().canRespond()).isTrue();
 
@@ -164,6 +168,9 @@ class MatchingProfileQueryServiceTest {
         assertThat(result.client().userTypeLabel()).isEqualTo("기업");
         assertThat(result.matchingContext().matchingStatus()).isEqualTo("ACCEPTED");
         assertThat(result.matchingContext().contactVisible()).isTrue();
+        assertThat(result.matchingContext().contactEmail()).isEqualTo(CLIENT_EMAIL);
+        assertThat(result.matchingContext().contactPhone()).isEqualTo("010-0000-0001");
+        assertThat(result.matchingContext().hasContactDetails()).isTrue();
         assertThat(result.matchingContext().helperMessage())
                 .isEqualTo("연락처가 공개되었습니다. 제안서를 다시 확인하고 협의를 이어가세요.");
         assertThat(result.matchingContext().canRespond()).isFalse();
@@ -186,6 +193,9 @@ class MatchingProfileQueryServiceTest {
         assertThat(result.statusLabel()).isEqualTo("취소됨");
         assertThat(result.matchingContext().matchingStatus()).isEqualTo("CANCELED");
         assertThat(result.matchingContext().contactVisible()).isTrue();
+        assertThat(result.matchingContext().contactEmail()).isEqualTo(FREELANCER_EMAIL);
+        assertThat(result.matchingContext().contactPhone()).isEqualTo("010-0000-0002");
+        assertThat(result.matchingContext().hasContactDetails()).isTrue();
         assertThat(result.matchingContext().helperMessage())
                 .isEqualTo("취소된 계약입니다. 필요한 경우 진행 이력과 연락처 정보를 확인해보세요.");
 

--- a/src/test/java/com/generic4/itda/service/MatchingProfileQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/MatchingProfileQueryServiceTest.java
@@ -1,0 +1,334 @@
+package com.generic4.itda.service;
+
+import static com.generic4.itda.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.generic4.itda.domain.matching.Matching;
+import com.generic4.itda.domain.matching.constant.MatchingCancellationReason;
+import com.generic4.itda.domain.matching.constant.MatchingParticipantRole;
+import com.generic4.itda.domain.member.Member;
+import com.generic4.itda.domain.member.UserType;
+import com.generic4.itda.domain.position.Position;
+import com.generic4.itda.domain.proposal.Proposal;
+import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalWorkType;
+import com.generic4.itda.domain.resume.CareerEmploymentType;
+import com.generic4.itda.domain.resume.CareerItemPayload;
+import com.generic4.itda.domain.resume.CareerPayload;
+import com.generic4.itda.domain.resume.Proficiency;
+import com.generic4.itda.domain.resume.Resume;
+import com.generic4.itda.domain.resume.ResumeWritingStatus;
+import com.generic4.itda.domain.resume.WorkType;
+import com.generic4.itda.domain.skill.Skill;
+import com.generic4.itda.dto.profile.ProfileAccessLevel;
+import com.generic4.itda.dto.profile.ProfileContextType;
+import com.generic4.itda.dto.profile.ProfileShellViewModel;
+import com.generic4.itda.dto.profile.ProfileSubjectType;
+import com.generic4.itda.repository.MatchingRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingProfileQueryServiceTest {
+
+    private static final String CLIENT_EMAIL = "client@example.com";
+    private static final String FREELANCER_EMAIL = "freelancer@example.com";
+
+    @Mock
+    private MatchingRepository matchingRepository;
+
+    @InjectMocks
+    private MatchingProfileQueryService matchingProfileQueryService;
+
+    @Test
+    @DisplayName("클라이언트가 제안 단계 매칭을 조회하면 프리랜서 프로필을 마스킹된 미리보기로 반환한다")
+    void getCounterpartProfile_returnsMaskedFreelancerPreviewForClientOnProposed() {
+        Matching matching = createProposedMatching();
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        ProfileShellViewModel result = matchingProfileQueryService.getCounterpartProfile(401L, CLIENT_EMAIL);
+
+        assertThat(result.subjectType()).isEqualTo(ProfileSubjectType.FREELANCER);
+        assertThat(result.contextType()).isEqualTo(ProfileContextType.MATCHING);
+        assertThat(result.accessLevel()).isEqualTo(ProfileAccessLevel.PREVIEW);
+        assertThat(result.title()).isEqualTo("길*");
+        assertThat(result.subtitle()).isEqualTo("AI 매칭 플랫폼 · 플랫폼 백엔드 개발자");
+        assertThat(result.statusLabel()).isEqualTo("제안됨");
+        assertThat(result.backUrl()).isEqualTo("/matchings/401");
+        assertThat(result.projectSummary()).isNotNull();
+        assertThat(result.projectSummary().proposalTitle()).isEqualTo("AI 매칭 플랫폼");
+        assertThat(result.projectSummary().positionTitle()).isEqualTo("플랫폼 백엔드 개발자");
+        assertThat(result.projectSummary().essentialSkills()).containsExactly("Java");
+        assertThat(result.client()).isNull();
+        assertThat(result.freelancer()).isNotNull();
+        assertThat(result.freelancer().displayName()).isEqualTo("길*");
+        assertThat(result.freelancer().headline()).isEqualTo("프리랜서 프로필");
+        assertThat(result.freelancer().introduction()).isEqualTo("커머스와 금융 도메인 백엔드 개발 경험이 있습니다.");
+        assertThat(result.freelancer().careerYears()).isEqualTo(5);
+        assertThat(result.freelancer().preferredWorkTypeLabel()).isEqualTo("상주, 원격 모두 가능");
+        assertThat(result.freelancer().portfolioUrl()).isEqualTo("https://portfolio.example.com");
+        assertThat(result.freelancer().skills())
+                .extracting("name", "proficiencyLabel", "proficiencyCode")
+                .containsExactly(
+                        tuple("Java", "고급", "ADVANCED"),
+                        tuple("Spring", "중급", "INTERMEDIATE")
+                );
+        assertThat(result.freelancer().careerItems()).singleElement().satisfies(item -> {
+            assertThat(item.companyName()).isEqualTo("네오핀");
+            assertThat(item.position()).isEqualTo("백엔드 개발자");
+            assertThat(item.employmentTypeLabel()).isEqualTo("정규직");
+            assertThat(item.periodLabel()).isEqualTo("2021-01 ~ 2023-06");
+            assertThat(item.summary()).isEqualTo("결제 API와 정산 배치를 개발했습니다.");
+            assertThat(item.techStack()).containsExactly("Java", "Spring Boot", "MySQL");
+        });
+        assertThat(result.hasMatchingContext()).isTrue();
+        assertThat(result.hasRecommendationContext()).isFalse();
+        assertThat(result.matchingContext()).isNotNull();
+        assertThat(result.matchingContext().viewerRole()).isEqualTo("CLIENT");
+        assertThat(result.matchingContext().matchingStatus()).isEqualTo("PROPOSED");
+        assertThat(result.matchingContext().contactVisible()).isFalse();
+        assertThat(result.matchingContext().statusLabel()).isEqualTo("제안됨");
+        assertThat(result.matchingContext().helperMessage())
+                .isEqualTo("프리랜서가 요청을 확인하고 응답하면 다음 단계로 넘어갈 수 있습니다.");
+        assertThat(result.matchingContext().matchingDetailUrl()).isEqualTo("/matchings/401");
+        assertThat(result.matchingContext().proposalDetailUrl()).isEqualTo("/proposals/200");
+        assertThat(result.matchingContext().acceptActionUrl()).isEqualTo("/matchings/401/accept");
+        assertThat(result.matchingContext().rejectActionUrl()).isEqualTo("/matchings/401/reject");
+        assertThat(result.matchingContext().canRespond()).isFalse();
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    @Test
+    @DisplayName("프리랜서가 제안 단계 매칭을 조회하면 클라이언트 프로필과 응답 가능 상태를 반환한다")
+    void getCounterpartProfile_returnsMaskedClientPreviewAndResponseStateForFreelancerOnProposed() {
+        Matching matching = createProposedMatching();
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        ProfileShellViewModel result = matchingProfileQueryService.getCounterpartProfile(401L, FREELANCER_EMAIL);
+
+        assertThat(result.subjectType()).isEqualTo(ProfileSubjectType.CLIENT);
+        assertThat(result.accessLevel()).isEqualTo(ProfileAccessLevel.PREVIEW);
+        assertThat(result.title()).isEqualTo("에***A");
+        assertThat(result.projectSummary()).isNotNull();
+        assertThat(result.freelancer()).isNull();
+        assertThat(result.client()).isNotNull();
+        assertThat(result.client().displayName()).isEqualTo("에***A");
+        assertThat(result.client().userTypeLabel()).isEqualTo("기업");
+        assertThat(result.client().memo()).isEqualTo("금융/커머스 프로젝트 경험자를 선호합니다.");
+        assertThat(result.client().project().proposalId()).isEqualTo(200L);
+        assertThat(result.client().project().proposalTitle()).isEqualTo("AI 매칭 플랫폼");
+        assertThat(result.client().project().description()).isEqualTo("AI 추천 기반 외주 매칭 프로젝트");
+        assertThat(result.client().project().positionTitle()).isEqualTo("플랫폼 백엔드 개발자");
+        assertThat(result.client().project().workTypeLabel()).isEqualTo("원격");
+        assertThat(result.client().project().budgetText()).isEqualTo("3,000,000원 ~ 5,000,000원");
+        assertThat(result.client().project().expectedPeriodText()).isEqualTo("4주");
+        assertThat(result.client().project().essentialSkills()).containsExactly("Java");
+        assertThat(result.client().project().preferredSkills()).containsExactly("Docker");
+        assertThat(result.matchingContext().viewerRole()).isEqualTo("FREELANCER");
+        assertThat(result.matchingContext().contactVisible()).isFalse();
+        assertThat(result.matchingContext().helperMessage()).isEqualTo("요청 내용을 확인한 뒤 수락 또는 거절할 수 있습니다.");
+        assertThat(result.matchingContext().canRespond()).isTrue();
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    @Test
+    @DisplayName("프리랜서가 수락된 매칭을 조회하면 클라이언트 프로필은 실명 공개 상태로 반환된다")
+    void getCounterpartProfile_returnsFullClientProfileWhenContactIsVisible() {
+        Matching matching = createAcceptedMatching();
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        ProfileShellViewModel result = matchingProfileQueryService.getCounterpartProfile(401L, FREELANCER_EMAIL);
+
+        assertThat(result.subjectType()).isEqualTo(ProfileSubjectType.CLIENT);
+        assertThat(result.accessLevel()).isEqualTo(ProfileAccessLevel.FULL);
+        assertThat(result.title()).isEqualTo("에이전시A");
+        assertThat(result.client().displayName()).isEqualTo("에이전시A");
+        assertThat(result.client().userTypeLabel()).isEqualTo("기업");
+        assertThat(result.matchingContext().matchingStatus()).isEqualTo("ACCEPTED");
+        assertThat(result.matchingContext().contactVisible()).isTrue();
+        assertThat(result.matchingContext().helperMessage())
+                .isEqualTo("연락처가 공개되었습니다. 제안서를 다시 확인하고 협의를 이어가세요.");
+        assertThat(result.matchingContext().canRespond()).isFalse();
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    @Test
+    @DisplayName("계약 이후 취소된 매칭은 취소 상태여도 연락처 공개 레벨을 유지한다")
+    void getCounterpartProfile_keepsFullAccessForCanceledContract() {
+        Matching matching = createContractCanceledMatching();
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        ProfileShellViewModel result = matchingProfileQueryService.getCounterpartProfile(401L, CLIENT_EMAIL);
+
+        assertThat(result.subjectType()).isEqualTo(ProfileSubjectType.FREELANCER);
+        assertThat(result.accessLevel()).isEqualTo(ProfileAccessLevel.FULL);
+        assertThat(result.title()).isEqualTo("길동");
+        assertThat(result.statusLabel()).isEqualTo("취소됨");
+        assertThat(result.matchingContext().matchingStatus()).isEqualTo("CANCELED");
+        assertThat(result.matchingContext().contactVisible()).isTrue();
+        assertThat(result.matchingContext().helperMessage())
+                .isEqualTo("취소된 계약입니다. 필요한 경우 진행 이력과 연락처 정보를 확인해보세요.");
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    @Test
+    @DisplayName("매칭 당사자가 아니면 상대 프로필을 조회할 수 없다")
+    void getCounterpartProfile_throwsWhenViewerIsNotParticipant() {
+        Matching matching = createAcceptedMatching();
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.of(matching));
+
+        assertThatThrownBy(() -> matchingProfileQueryService.getCounterpartProfile(401L, "other@example.com"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("해당 매칭 정보에 접근할 수 없습니다.");
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    @Test
+    @DisplayName("매칭이 없으면 예외를 던진다")
+    void getCounterpartProfile_throwsWhenMatchingDoesNotExist() {
+        given(matchingRepository.findDetailById(401L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> matchingProfileQueryService.getCounterpartProfile(401L, CLIENT_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매칭 정보를 찾을 수 없습니다. id=401");
+
+        verify(matchingRepository).findDetailById(401L);
+        verifyNoMoreInteractions(matchingRepository);
+    }
+
+    private Matching createAcceptedMatching() {
+        Matching matching = createProposedMatching();
+        matching.accept();
+        return matching;
+    }
+
+    private Matching createContractCanceledMatching() {
+        Matching matching = createAcceptedMatching();
+        matching.acceptContractStart(MatchingParticipantRole.CLIENT);
+        matching.acceptContractStart(MatchingParticipantRole.FREELANCER);
+        matching.requestCancellation(
+                MatchingParticipantRole.CLIENT,
+                MatchingCancellationReason.CLIENT_AFTER_PROJECT_SUSPENDED,
+                null
+        );
+        matching.confirmCancellation(MatchingParticipantRole.FREELANCER);
+        return matching;
+    }
+
+    private Matching createProposedMatching() {
+        Member client = createMember(
+                CLIENT_EMAIL,
+                "hashed-password",
+                "주식회사 에이전시",
+                "에이전시A",
+                "금융/커머스 프로젝트 경험자를 선호합니다.",
+                "010-0000-0001"
+        );
+        ReflectionTestUtils.setField(client, "type", UserType.CORPORATE);
+
+        Member freelancer = createMember(
+                FREELANCER_EMAIL,
+                "hashed-password",
+                "홍길동",
+                "길동",
+                "010-0000-0002"
+        );
+
+        Position position = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(position, "id", 101L);
+
+        Skill java = Skill.create("Java", null);
+        ReflectionTestUtils.setField(java, "id", 1001L);
+
+        Skill spring = Skill.create("Spring", null);
+        ReflectionTestUtils.setField(spring, "id", 1002L);
+
+        Skill docker = Skill.create("Docker", null);
+        ReflectionTestUtils.setField(docker, "id", 1003L);
+
+        Proposal proposal = Proposal.create(
+                client,
+                "AI 매칭 플랫폼",
+                "원본 입력",
+                "AI 추천 기반 외주 매칭 프로젝트",
+                6_000_000L,
+                10_000_000L,
+                8L
+        );
+        proposal.startMatching();
+        ReflectionTestUtils.setField(proposal, "id", 200L);
+
+        ProposalPosition proposalPosition = proposal.addPosition(
+                position,
+                "플랫폼 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                3_000_000L,
+                5_000_000L,
+                4L,
+                3,
+                8,
+                null
+        );
+        proposalPosition.addSkill(java, ProposalPositionSkillImportance.ESSENTIAL);
+        proposalPosition.addSkill(docker, ProposalPositionSkillImportance.PREFERENCE);
+        ReflectionTestUtils.setField(proposalPosition, "id", 201L);
+
+        Resume resume = Resume.create(
+                freelancer,
+                "커머스와 금융 도메인 백엔드 개발 경험이 있습니다.",
+                (byte) 5,
+                createCareerPayload(),
+                WorkType.HYBRID,
+                ResumeWritingStatus.DONE,
+                "https://portfolio.example.com"
+        );
+        resume.addSkill(java, Proficiency.ADVANCED);
+        resume.addSkill(spring, Proficiency.INTERMEDIATE);
+        ReflectionTestUtils.setField(resume, "id", 301L);
+
+        Matching matching = Matching.create(resume, proposalPosition, client, freelancer);
+        ReflectionTestUtils.setField(matching, "id", 401L);
+        return matching;
+    }
+
+    private CareerPayload createCareerPayload() {
+        CareerItemPayload careerItem = new CareerItemPayload();
+        careerItem.setCompanyName("네오핀");
+        careerItem.setPosition("백엔드 개발자");
+        careerItem.setEmploymentType(CareerEmploymentType.FULL_TIME);
+        careerItem.setStartYearMonth("2021-01");
+        careerItem.setEndYearMonth("2023-06");
+        careerItem.setCurrentlyWorking(false);
+        careerItem.setSummary("결제 API와 정산 배치를 개발했습니다.");
+        careerItem.setTechStack(List.of("Java", "Spring Boot", "MySQL"));
+
+        CareerPayload payload = new CareerPayload();
+        payload.setItems(List.of(careerItem));
+        return payload;
+    }
+}


### PR DESCRIPTION
## 🔎 What

매칭 상대 프로필 조회 기능을 추가하고, 기존 추천 화면에서 도입한 **공통 프로필 셸(`ProfileShellViewModel`) 구조를 매칭 문맥에 확장 적용**했습니다.

* `/matchings/{matchingId}/counterpart-profile` 라우트 추가
* `MatchingProfileQueryService` 구현을 통해 매칭 도메인 기반 프로필 조회 로직 분리
* `viewerRole` 기준으로 `subjectType(FREELANCER / CLIENT)`를 결정하여 **프리랜서/클라이언트 본문 분기**
* `contactVisible` 정책을 반영하여 **프로필 표시명 마스킹 처리**
* 매칭 상태 및 액션을 `ProfileMatchingContextViewModel`로 매핑하여 **우측 문맥 패널 구성**
* 추천/매칭 공통으로 사용할 수 있도록 **ProfileShell 기반 렌더링 구조 재사용**
* 매칭 상세 화면에서 상대 프로필로 이동할 수 있는 링크 추가

이를 통해 프로필을 “개별 화면”이 아니라
**본문(Subject) + 문맥(Context) 조합으로 렌더링하는 구조를 추천/매칭 영역에 일관되게 적용**했습니다.

---

## 🔗 Issue

* Closes: #129 

---

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
