### PR TITLE
[Refactor] 추천 받기 플로우 개선("추천 받아 보기" 클릭시 이동되는 포지션 선택 페이지를 제안서 페이지의 모달로 변경) + 매칭/추천 진행중인 제안서 수정 옵션 제거

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -8,12 +8,14 @@ import com.generic4.itda.domain.proposal.ProposalWorkType;
 import com.generic4.itda.dto.proposal.AiInterviewMessageResponse;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.PositionResolver;
 import com.generic4.itda.service.ProposalService;
+import com.generic4.itda.service.recommend.RecommendationEntryService;
 import jakarta.validation.Valid;
 import java.util.HashSet;
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -38,6 +41,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 @RequestMapping("/proposals")
 @RequiredArgsConstructor
+@Slf4j
 public class ProposalController {
 
     private static final String SAVE_ACTION = "save";
@@ -47,6 +51,7 @@ public class ProposalController {
     private final ProposalAiInterviewService proposalAiInterviewService;
     private final PositionResolver positionResolver;
     private final MatchingRepository matchingRepository;
+    private final RecommendationEntryService recommendationEntryService;
 
     @GetMapping("/new")
     public String newForm(@AuthenticationPrincipal ItDaPrincipal principal, Model model) {
@@ -121,6 +126,16 @@ public class ProposalController {
                     .stream()
                     .map(m -> m.getProposalPosition().getId())
                     .collect(Collectors.toSet());
+
+            if (proposal.getStatus() == ProposalStatus.MATCHING) {
+                try {
+                    RecommendationEntryViewModel recommendEntry =
+                            recommendationEntryService.getEntry(proposalId, principal.getEmail());
+                    model.addAttribute("recommendEntry", recommendEntry);
+                } catch (Exception e) {
+                    log.warn("추천 진입 뷰 로딩 실패. proposalId={}, email={}", proposalId, principal.getEmail(), e);
+                }
+            }
 
             model.addAttribute("proposal", proposal);
             model.addAttribute("positionsWithMatchings", positionsWithMatchings);
@@ -352,7 +367,7 @@ public class ProposalController {
 
     private String redirectAfterSave(Proposal proposal, boolean registerAction, boolean aiBriefRequested) {
         if (registerAction) {
-            return "redirect:/proposals/" + proposal.getId() + "/recommendations";
+            return "redirect:/proposals/" + proposal.getId() + "?openRecommendModal=true";
         }
 
         if (aiBriefRequested) {

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -1,17 +1,18 @@
 package com.generic4.itda.controller;
 
-import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
-import com.generic4.itda.service.recommend.RecommendationEntryService;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -28,22 +30,44 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Slf4j
 public class RecommendationController {
 
-    private final RecommendationEntryService recommendationEntryService;
     private final RecommendationRunService recommendationRunService;
     private final RecommendationRunQueryService recommendationRunQueryService;
 
     @GetMapping("/proposals/{proposalId}/recommendations")
     public String entry(
             @PathVariable Long proposalId,
-            @AuthenticationPrincipal ItDaPrincipal principal,
-            Model model
+            @AuthenticationPrincipal ItDaPrincipal principal
     ) {
-        RecommendationEntryViewModel entry = recommendationEntryService.getEntry(proposalId, principal.getEmail());
+        return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
+    }
 
-        model.addAttribute("entry", entry);
-        model.addAttribute("requestForm", new RecommendationRequestForm(entry.selectedProposalPositionId()));
+    /** 모달에서 fetch로 호출 — 성공: redirect URL 반환, 실패: 에러 메시지 반환 */
+    @PostMapping(value = "/proposals/{proposalId}/recommendations", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<Map<String, String>> runAjax(
+            @PathVariable Long proposalId,
+            @Valid @ModelAttribute RecommendationRequestForm form,
+            BindingResult bindingResult,
+            @AuthenticationPrincipal ItDaPrincipal principal
+    ) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "포지션을 선택해주세요."));
+        }
 
-        return "recommendation/entry";
+        try {
+            Long runId = recommendationRunService.createOrReuse(
+                    proposalId,
+                    form.proposalPositionId(),
+                    principal.getEmail()
+            );
+            return ResponseEntity.ok(Map.of(
+                    "redirect", "/proposals/" + proposalId + "/runs/" + runId
+            ));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("추천 실행 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
+                    proposalId, form.proposalPositionId(), principal.getEmail(), e);
+            return ResponseEntity.badRequest().body(Map.of("error", toUserMessage(e)));
+        }
     }
 
     @PostMapping("/proposals/{proposalId}/recommendations")
@@ -52,13 +76,11 @@ public class RecommendationController {
             @Valid @ModelAttribute("requestForm") RecommendationRequestForm form,
             BindingResult bindingResult,
             @AuthenticationPrincipal ItDaPrincipal principal,
-            RedirectAttributes redirectAttributes,
-            Model model
+            RedirectAttributes redirectAttributes
     ) {
         if (bindingResult.hasErrors()) {
-            RecommendationEntryViewModel entry = recommendationEntryService.getEntry(proposalId, principal.getEmail());
-            model.addAttribute("entry", entry);
-            return "recommendation/entry";
+            redirectAttributes.addFlashAttribute("errorMessage", "포지션을 선택해주세요.");
+            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
         }
 
         try {
@@ -76,7 +98,7 @@ public class RecommendationController {
                     proposalId, form.proposalPositionId(), principal.getEmail(), e);
 
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
-            return "redirect:/proposals/{proposalId}/recommendations";
+            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
         }
     }
 
@@ -101,9 +123,8 @@ public class RecommendationController {
             log.warn("추가 추천 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, proposalPositionId, principal.getEmail(), e);
 
-            redirectAttributes.addAttribute("proposalId", proposalId);
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
-            return "redirect:/proposals/{proposalId}/recommendations";
+            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
         }
     }
 
@@ -126,7 +147,7 @@ public class RecommendationController {
 
             model.addAttribute("title", "추천 실행 정보를 확인할 수 없습니다.");
             model.addAttribute("message", toRunStatusUserMessage(e));
-            model.addAttribute("backUrl", "/proposals/" + proposalId + "/recommendations");
+            model.addAttribute("backUrl", "/proposals/" + proposalId + "?openRecommendModal=true");
 
             return "recommendation/error";
         }
@@ -175,7 +196,7 @@ public class RecommendationController {
 
             model.addAttribute("title", "추천 후보 이력서를 확인할 수 없습니다.");
             model.addAttribute("message", toResultsUserMessage(e));
-            model.addAttribute("backUrl", "/proposals/" + proposalId + "/recommendations");
+            model.addAttribute("backUrl", "/proposals/" + proposalId + "?openRecommendModal=true");
             return "recommendation/error";
         }
     }
@@ -185,7 +206,7 @@ public class RecommendationController {
             return "추천 요청을 처리할 수 없습니다. 선택한 포지션을 다시 확인해주세요.";
         }
         if (e instanceof IllegalStateException) {
-            return "현재 상태에는 추천을 실행할 수 없습니다.";
+            return "모집 중 상태의 포지션만 추천을 실행할 수 있습니다.";
         }
         return "추천 요청 처리 중 문제가 발생했습니다. 다시 시도해주세요.";
     }

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -102,6 +102,34 @@ public class RecommendationController {
         }
     }
 
+    /** 모달에서 fetch로 호출 — 성공: redirect URL 반환, 실패: 에러 메시지 반환 */
+    @PostMapping(
+            value = "/proposal-positions/{proposalPositionId}/recommendations/more",
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            headers = "Accept=application/json"
+    )
+    @ResponseBody
+    public ResponseEntity<Map<String, String>> moreAjax(
+            @PathVariable Long proposalPositionId,
+            @RequestParam Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal
+    ) {
+        try {
+            Long runId = recommendationRunService.createAdditional(
+                    proposalId,
+                    proposalPositionId,
+                    principal.getEmail()
+            );
+            return ResponseEntity.ok(Map.of(
+                    "redirect", "/proposals/" + proposalId + "/runs/" + runId
+            ));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("추가 추천 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
+                    proposalId, proposalPositionId, principal.getEmail(), e);
+            return ResponseEntity.badRequest().body(Map.of("error", toUserMessage(e)));
+        }
+    }
+
     @PostMapping("/proposal-positions/{proposalPositionId}/recommendations/more")
     public String more(
             @PathVariable Long proposalPositionId,

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationEntryPositionItem.java
@@ -9,7 +9,9 @@ public record RecommendationEntryPositionItem(
         Long headCount,
         String budgetText,
         Long expectedPeriod,
-        List<RecommendationEntrySkillItem> skills
+        List<RecommendationEntrySkillItem> skills,
+        String positionStatusName,
+        String positionStatusDescription
 ) {
 
 }

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -36,8 +36,7 @@ public class RecommendationEntryService {
         boolean hasOpenPosition = proposal.getPositions().stream()
                 .anyMatch(position -> position.getStatus() == ProposalPositionStatus.OPEN);
 
-        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING
-                && (proposal.getPositions().isEmpty() || hasOpenPosition);
+        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING && hasOpenPosition;
 
         List<RecommendationEntryPositionItem> positions = proposal.getPositions().stream()
                 .sorted(Comparator.comparing(ProposalPosition::getId))

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -36,7 +36,8 @@ public class RecommendationEntryService {
         boolean hasOpenPosition = proposal.getPositions().stream()
                 .anyMatch(position -> position.getStatus() == ProposalPositionStatus.OPEN);
 
-        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING && hasOpenPosition;
+        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING
+                && (proposal.getPositions().isEmpty() || hasOpenPosition);
 
         List<RecommendationEntryPositionItem> positions = proposal.getPositions().stream()
                 .sorted(Comparator.comparing(ProposalPosition::getId))

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -78,7 +78,9 @@ public class RecommendationEntryService {
                         .map(skill -> new RecommendationEntrySkillItem(
                                 skill.getSkill().getName(),
                                 skill.getImportance().getDescription()
-                        )).toList()
+                        )).toList(),
+                position.getStatus().name(),
+                position.getStatus().getDescription()
         );
     }
 

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationEntryService.java
@@ -3,6 +3,7 @@ package com.generic4.itda.service.recommend;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.dto.recommend.RecommendationEntryPositionItem;
 import com.generic4.itda.dto.recommend.RecommendationEntrySkillItem;
@@ -32,21 +33,28 @@ public class RecommendationEntryService {
 
         validateOwnership(proposal, member);
 
-        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING;
+        boolean hasOpenPosition = proposal.getPositions().stream()
+                .anyMatch(position -> position.getStatus() == ProposalPositionStatus.OPEN);
+
+        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING && hasOpenPosition;
 
         List<RecommendationEntryPositionItem> positions = proposal.getPositions().stream()
                 .sorted(Comparator.comparing(ProposalPosition::getId))
                 .map(this::toPositionItem)
                 .toList();
 
-        Long selectedProposalPositionId = positions.isEmpty() ? null : positions.get(0).proposalPositionId();
+        Long selectedProposalPositionId = positions.stream()
+                .filter(position -> ProposalPositionStatus.OPEN.name().equals(position.positionStatusName()))
+                .map(RecommendationEntryPositionItem::proposalPositionId)
+                .findFirst()
+                .orElseGet(() -> positions.isEmpty() ? null : positions.get(0).proposalPositionId());
 
         return new RecommendationEntryViewModel(
                 proposal.getId(),
                 proposal.getTitle(),
                 proposal.getStatus().getDescription(),
                 runnable,
-                buildHelperMessage(runnable),
+                buildHelperMessage(proposal, hasOpenPosition),
                 selectedProposalPositionId,
                 positions
         );
@@ -104,9 +112,13 @@ public class RecommendationEntryService {
         return String.format("%,d 이하", max);
     }
 
-    private String buildHelperMessage(boolean runnable) {
-        return runnable
-                ? "선택한 포지션 기준으로 추천을 시작할 수 있습니다."
-                : "제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.";
+    private String buildHelperMessage(Proposal proposal, boolean hasOpenPosition) {
+        if (proposal.getStatus() != ProposalStatus.MATCHING) {
+            return "제안서가 MATCHING 상태일 때만 추천을 실행할 수 있습니다.";
+        }
+        if (!hasOpenPosition) {
+            return "OPEN 상태의 모집 포지션이 없어 추천을 실행할 수 없습니다.";
+        }
+        return "선택한 포지션 기준으로 추천을 시작할 수 있습니다.";
     }
 }

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -202,10 +202,10 @@
         <div id="menuDeleteDivider" class="my-1 border-t border-slate-100"></div>
         <button id="menuDelete" type="button"
                 class="flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-red-500 hover:bg-red-50">
-            <i data-lucide="trash-2" class="h-4 w-4"></i>프로젝트 삭제
+            <i data-lucide="trash-2" class="h-4 w-4"></i>제안서 삭제
         </button>
     </div>
-
+    
     <!-- 삭제 확인 모달 -->
     <div id="deleteModal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
         <div id="deleteModalBackdrop" class="absolute inset-0 bg-black/40"></div>
@@ -350,7 +350,7 @@
             menuDelete.dataset.proposalTitle = proposalTitle;
 
             // 상태별 항목 표시/숨김
-            menuEdit.classList.toggle('hidden', statusKey === 'COMPLETE');
+            menuEdit.classList.toggle('hidden', statusKey === 'MATCHING' || statusKey === 'COMPLETE');
             menuRecommend.classList.toggle('hidden', statusKey === 'WRITING');
             menuMatching.classList.toggle('hidden', !(statusKey === 'MATCHING' || statusKey === 'COMPLETE'));
             var showDelete = statusKey === 'WRITING';

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -402,8 +402,10 @@
 
                     <!-- 추천 요청 폼 -->
                     <form id="recommendModalForm"
-                          th:action="@{/proposals/{id}/recommendations(id=${proposal.id})}"
+                          th:action="@{/proposal-positions/{proposalPositionId}/recommendations/more(
+                                    proposalPositionId=${recommendEntry != null ? recommendEntry.selectedProposalPositionId : 0})}"
                           method="post">
+                        <input type="hidden" name="proposalId" th:value="${proposal.id}">
                         <th:block th:if="${_csrf != null}">
                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
                         </th:block>
@@ -425,15 +427,21 @@
                                     <th:block th:if="${recommendEntry != null}">
                                         <option th:each="position : ${recommendEntry.positions}"
                                                 th:value="${position.proposalPositionId}"
+                                                th:disabled="${position.positionStatusName != 'OPEN'}"
                                                 th:selected="${position.proposalPositionId == recommendEntry.selectedProposalPositionId}"
-                                                th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
+                                                th:text="${position.positionTitle
+                                                    + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')
+                                                    + (position.positionStatusName != 'OPEN' ? ' · ' + position.positionStatusDescription : '')}">
                                             백엔드 개발자
                                         </option>
                                     </th:block>
                                     <th:block th:if="${recommendEntry == null}">
                                         <option th:each="pos : ${proposal.positions}"
                                                 th:value="${pos.id}"
-                                                th:text="${pos.title}">
+                                                th:disabled="${pos.status == null or pos.status.name() != 'OPEN'}"
+                                                th:text="${pos.title
+                                                    + (pos.status != null and pos.status.name() != 'OPEN' ? ' · ' + pos.status.description : '')
+                                                    + (pos.status == null ? ' · 상태 미정' : '')}">
                                             백엔드 개발자
                                         </option>
                                     </th:block>
@@ -448,9 +456,10 @@
                         <div class="mt-5 space-y-3"
                              th:if="${recommendEntry != null and !#lists.isEmpty(recommendEntry.positions)}">
                             <article th:each="position : ${recommendEntry.positions}"
-                                     th:attr="data-position-id=${position.proposalPositionId}"
-                                     class="rounded-[24px] border border-slate-200 bg-slate-50 p-5 transition cursor-pointer hover:border-blue-200"
-                                     onclick="selectPositionCard(this)">
+                                     th:attr="data-position-id=${position.proposalPositionId}, data-position-status=${position.positionStatusName}"
+                                     class="rounded-[24px] border border-slate-200 bg-slate-50 p-5 transition"
+                                     th:classappend="${position.positionStatusName == 'OPEN'} ? ' cursor-pointer hover:border-blue-200' : ' opacity-50 cursor-not-allowed'"
+                                     th:onclick="${position.positionStatusName == 'OPEN'} ? 'selectPositionCard(this)' : null">
 
                                 <div class="flex flex-wrap items-start justify-between gap-3">
                                     <div>
@@ -512,7 +521,8 @@
 
                         <!-- 액션 버튼 -->
                         <div class="mt-6 flex items-center justify-end gap-3"
-                             th:with="canRun=${recommendEntry != null ? recommendEntry.runnable : !#lists.isEmpty(proposal.positions)}">
+                             th:with="openPositions=${recommendEntry != null ? recommendEntry.positions.?[positionStatusName == 'OPEN'] : proposal.positions.?[status != null and status.name() == 'OPEN']},
+                                      canRun=${recommendEntry != null ? recommendEntry.runnable : !#lists.isEmpty(openPositions)}">
                             <button type="button"
                                     id="btnCancelRecommendModal"
                                     onclick="closeRecommendModal()"
@@ -593,6 +603,21 @@
             form.addEventListener('submit', function (e) {
                 e.preventDefault();
                 hideError();
+
+                var select = document.getElementById('modalProposalPositionId');
+                var proposalPositionId = select ? select.value : '';
+                if (!proposalPositionId) {
+                    showError('포지션을 선택해주세요.');
+                    return;
+                }
+
+                var selectedOption = select ? select.options[select.selectedIndex] : null;
+                if (selectedOption && selectedOption.disabled) {
+                    showError('모집 중(OPEN)인 포지션만 추천을 실행할 수 있습니다.');
+                    return;
+                }
+
+                form.action = '/proposal-positions/' + encodeURIComponent(proposalPositionId) + '/recommendations/more';
 
                 var csrfInput  = form.querySelector('input[name="_csrf"]');
                 var csrfHeader = document.querySelector('meta[name="_csrf_header"]');

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -400,12 +400,13 @@
                         <p id="recommendModalErrorMsg" class="text-sm font-semibold text-rose-700"></p>
                     </div>
 
-                    <!-- 추천 요청 폼 -->
+                    <!-- 추천 요청 폼 — POST /proposal-positions/{posId}/recommendations/more?proposalId={id} -->
                     <form id="recommendModalForm"
-                          th:action="@{/proposal-positions/{proposalPositionId}/recommendations/more(
-                                    proposalPositionId=${recommendEntry != null ? recommendEntry.selectedProposalPositionId : 0})}"
-                          method="post">
-                        <input type="hidden" name="proposalId" th:value="${proposal.id}">
+                          th:action="@{/proposal-positions/{posId}/recommendations/more(
+                                    posId=${recommendEntry != null ? recommendEntry.selectedProposalPositionId : 0},
+                                    proposalId=${proposal.id})}"
+                          method="post"
+                          th:data-proposal-id="${proposal.id}">
                         <th:block th:if="${_csrf != null}">
                             <input type="hidden" name="_csrf" th:value="${_csrf.token}">
                         </th:block>
@@ -617,17 +618,17 @@
                     return;
                 }
 
-                form.action = '/proposal-positions/' + encodeURIComponent(proposalPositionId) + '/recommendations/more';
+                // POST /proposal-positions/{posId}/recommendations/more?proposalId={id}
+                var proposalId = form.dataset.proposalId;
+                form.action = '/proposal-positions/' + encodeURIComponent(proposalPositionId)
+                            + '/recommendations/more'
+                            + '?proposalId=' + encodeURIComponent(proposalId);
 
-                var csrfInput  = form.querySelector('input[name="_csrf"]');
-                var csrfHeader = document.querySelector('meta[name="_csrf_header"]');
+                var csrfInput = form.querySelector('input[name="_csrf"]');
                 var headers = {
                     'Content-Type': 'application/x-www-form-urlencoded',
                     'Accept':       'application/json'
                 };
-                if (csrfInput && csrfHeader) {
-                    headers[csrfHeader.content] = csrfInput.value;
-                }
 
                 fetch(form.action, {
                     method:  'POST',

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -54,12 +54,14 @@
                                 제안서 수정
                             </a>
                             
-                            <a th:if="${proposal.status.name() == 'MATCHING'}"
-                               th:href="@{/proposals/{id}/recommendations(id=${proposal.id})}"
-                               class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                            <button th:if="${viewerRole == 'CLIENT' and proposal.status.name() == 'MATCHING'}"
+                                    type="button"
+                                    id="btnOpenRecommendModal"
+                                    onclick="openRecommendModal()"
+                                    class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
                                 <i data-lucide="sparkles" class="h-4 w-4"></i>
                                 추천 받아 보기
-                            </a>
+                            </button>
                             
                             <span th:if="${proposal.status.name() == 'COMPLETE'}"
                                   class="inline-flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-sm font-bold text-emerald-600">
@@ -334,187 +336,338 @@
                     </th:block>
                 </div>
 
-                
-                <th:block th:if="${false}">
-
-                        <div class="flex flex-wrap items-start justify-between gap-4">
-                            <div class="space-y-1">
-                                <h4 class="text-2xl font-black tracking-tight text-slate-950"
-                                    th:text="${pos.title}">Node.js 백엔드 개발자/h4>
-                                <p class="text-base font-medium text-slate-400"
-                                   th:text="${pos.position.name}">백엔드 개발자</p>
-                            </div>
-
-                            <div class="flex flex-wrap items-center gap-2">
-                                
-                                <span th:classappend="${
-                                          pos.status.name() == 'OPEN'   ? 'border-blue-200 bg-blue-50 text-blue-600' :
-                                          (pos.status.name() == 'FULL'  ? 'border-amber-200 bg-amber-50 text-amber-600' :
-                                                                           'border-slate-200 bg-slate-100 text-slate-500')
-                                      }"
-                                      class="inline-flex rounded-full border px-4 py-1.5 text-xs font-bold"
-                                      th:text="${pos.status.name() == 'OPEN' ? '모집 중 :
-                                                 (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">
-                                    모집 중                                </span>
-
-                                
-                                <th:block th:if="${viewerRole == 'FREELANCER' and matchingByPositionId != null and matchingByPositionId[pos.id] != null}">
-                                    <th:block th:with="myMatching=${matchingByPositionId[pos.id]}">
-                                        
-                                        <span th:classappend="${
-                                                  myMatching.status.name() == 'PROPOSED'    ? 'border-yellow-200 bg-yellow-50 text-yellow-700' :
-                                                  (myMatching.status.name() == 'ACCEPTED'   ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
-                                                  (myMatching.status.name() == 'REJECTED'   ? 'border-red-200 bg-red-50 text-red-600' :
-                                                  (myMatching.status.name() == 'IN_PROGRESS'? 'border-blue-200 bg-blue-50 text-blue-600' :
-                                                  (myMatching.status.name() == 'COMPLETED'  ? 'border-slate-200 bg-slate-100 text-slate-600' :
-                                                                                               'border-slate-200 bg-slate-100 text-slate-500'))))
-                                              }"
-                                              class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold"
-                                              th:text="${myMatching.status.description}">
-                                            제안됨                                        </span>
-
-                                        
-                                        <th:block th:if="${myMatching.status.name() == 'PROPOSED'}">
-                                            <form th:action="@{/matchings/{id}/accept(id=${myMatching.id})}" method="post" class="inline">
-                                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
-                                                <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
-                                                <button type="submit"
-                                                        class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-4 py-2 text-xs font-bold text-white shadow-sm transition hover:bg-blue-700">
-                                                    <i data-lucide="check" class="h-3.5 w-3.5"></i>
-                                                    수락
-                                                </button>
-                                            </form>
-                                            <form th:action="@{/matchings/{id}/reject(id=${myMatching.id})}" method="post" class="inline">
-                                                <input type="hidden" name="_csrf" th:value="${_csrf.token}">
-                                                <input type="hidden" name="redirectTo" th:value="@{/matchings/{id}(id=${myMatching.id})}">
-                                                <input type="hidden" name="errorRedirectTo" th:value="@{/proposals/{id}(id=${proposal.id})}">
-                                                <button type="submit"
-                                                        class="inline-flex items-center gap-1.5 rounded-2xl border border-red-200 bg-white px-4 py-2 text-xs font-bold text-red-500 transition hover:bg-red-50">
-                                                    <i data-lucide="x" class="h-3.5 w-3.5"></i>
-                                                    거절
-                                                </button>
-                                            </form>
-                                        </th:block>
-                                    </th:block>
-                                </th:block>
-                            </div>
-                        </div>
-
-                        
-                        <div class="mt-6 grid gap-6 sm:grid-cols-3">
-                            <div>
-                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">모집 인원</p>
-                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900"
-                                   th:text="${pos.headCount != null ? pos.headCount + '명 : '미정'}">2명</p>
-                            </div>
-                            <div>
-                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">예산 (월)</p>
-                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900">
-                                    <span th:if="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}"
-                                          th:text="${#numbers.formatInteger(pos.unitBudgetMin, 3, 'COMMA') + '년~ ' + #numbers.formatInteger(pos.unitBudgetMax, 3, 'COMMA') + '??}">
-                                        3,000,000원~ 4,000,000원                                    </span>
-                                    <span th:unless="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}">미정</span>
-                                </p>
-                            </div>
-                            <div>
-                                <p class="text-xs font-black uppercase tracking-widest text-slate-400">湲곌컙</p>
-                                <p class="mt-2 text-2xl font-black tracking-tight text-slate-900"
-                                   th:text="${pos.expectedPeriod != null ? pos.expectedPeriod + '주 : '미정'}">4二?</p>
-                            </div>
-                        </div>
-
-                        
-                        <div class="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
-
-                            
-                            <div class="space-y-4">
-                                
-                                <div>
-                                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">필수 기술</p>
-                                    <div class="mt-3 flex flex-wrap gap-2">
-                                        <th:block th:each="skill : ${pos.skills}">
-                                            <span th:if="${skill.importance.name() == 'ESSENTIAL'}"
-                                                  class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700"
-                                                  th:text="${skill.skill.name}">React</span>
-                                        </th:block>
-                                        
-                                        <span th:if="${!#lists.isEmpty(pos.skills) and
-                                                       #lists.isEmpty(pos.skills.?[importance.name() == 'ESSENTIAL'])}"
-                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
-                                            없음
-                                        </span>
-                                        <span th:if="${#lists.isEmpty(pos.skills)}"
-                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
-                                            없음
-                                        </span>
-                                    </div>
-                                </div>
-
-                                
-                                <div>
-                                    <p class="text-xs font-black uppercase tracking-widest text-slate-400">우대 기술</p>
-                                    <div class="mt-3 flex flex-wrap gap-2">
-                                        <th:block th:each="skill : ${pos.skills}">
-                                            <span th:if="${skill.importance.name() == 'PREFERENCE'}"
-                                                  class="rounded-full border border-blue-100 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-600"
-                                                  th:text="${skill.skill.name}">TypeScript</span>
-                                        </th:block>
-                                        
-                                        <span th:if="${!#lists.isEmpty(pos.skills) and
-                                                       #lists.isEmpty(pos.skills.?[importance.name() == 'PREFERENCE'])}"
-                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
-                                            없음
-                                        </span>
-                                        <span th:if="${#lists.isEmpty(pos.skills)}"
-                                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">
-                                            없음
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            
-                            <div class="rounded-[24px] border border-white bg-white px-5 py-5">
-                                <div class="grid gap-4 sm:grid-cols-2">
-                                    <div>
-                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">근무 형태</p>
-                                        <p class="mt-2 text-base font-bold text-slate-900"
-                                           th:text="${pos.workType != null ? pos.workType.description : '미정'}">?먭꺽</p>
-                                    </div>
-                                    <div>
-                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">근무지</p>
-                                        <p class="mt-2 text-base font-bold text-slate-900"
-                                           th:text="${!#strings.isEmpty(pos.workPlace) ? pos.workPlace : '미정'}">서울 강남구</p>
-                                    </div>
-                                    <div>
-                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">경력 범위</p>
-                                        <p class="mt-2 text-base font-bold text-slate-900">
-                                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears != null}"
-                                                  th:text="${pos.careerMinYears + '년~ ' + pos.careerMaxYears + '??}">3??~ 5??</span>
-                                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears == null}"
-                                                  th:text="${pos.careerMinYears + '년 이상'}">3???댁긽</span>
-                                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears != null}"
-                                                  th:text="${pos.careerMaxYears + '년 이하'}">5???댄븯</span>
-                                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears == null}">미정</span>
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <p class="text-xs font-black uppercase tracking-widest text-slate-400">모집 상태</p>
-                                        <p class="mt-2 text-base font-bold text-slate-900"
-                                           th:text="${pos.status.name() == 'OPEN' ? '모집 중 :
-                                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">모집 중</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                </div>
-                </th:block>
             </section>
 
         </div>
     </main>
+
+    <!-- ── 추천 포지션 선택 모달 (MATCHING 상태 CLIENT에게만 렌더) ── -->
+
+        <!-- 백드롭 -->
+        <div id="recommendModalBackdrop"
+             th:if="${viewerRole == 'CLIENT' and proposal.status.name() == 'MATCHING'}"
+             class="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm hidden"
+             onclick="closeRecommendModal()"
+        >
+        </div>
+
+        <!-- 모달 패널 -->
+        <div id="recommendModal"
+              th:if="${viewerRole == 'CLIENT' and proposal.status.name() == 'MATCHING'}"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="recommendModalTitle"
+              class="fixed inset-0 z-50 flex items-center justify-center px-4 hidden">
+            <div class="flex flex-col w-full max-w-xl max-h-[90vh] rounded-[32px] border border-slate-200 bg-white shadow-2xl shadow-slate-300/40">
+
+                <!-- 헤더 -->
+                <div class="flex-shrink-0 flex items-start justify-between px-7 pt-7 pb-5 border-b border-slate-100">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation</p>
+                        <h2 id="recommendModalTitle"
+                            class="mt-1 text-lg font-bold tracking-tight text-slate-900"
+                            th:text="${recommendEntry != null ? recommendEntry.proposalTitle : proposal.title}">제안서명</h2>
+                    </div>
+                    <button type="button"
+                            id="btnCloseRecommendModal"
+                            onclick="closeRecommendModal()"
+                            class="ml-4 rounded-xl p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600">
+                        <i data-lucide="x" class="h-5 w-5"></i>
+                    </button>
+                </div>
+
+                <!-- 본문 -->
+                <div class="flex-1 overflow-y-auto px-7 py-6 space-y-5">
+
+                    <!-- 에러 배너 -->
+                    <div th:if="${errorMessage}"
+                         class="flex items-center gap-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3">
+                        <i data-lucide="triangle-alert" class="h-4 w-4 shrink-0 text-rose-500"></i>
+                        <p class="text-sm font-semibold text-rose-700" th:text="${errorMessage}">오류 메시지</p>
+                    </div>
+
+                    <!-- 안내 문구 -->
+                    <div class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                        <i data-lucide="info" class="mt-0.5 h-4 w-4 shrink-0 text-slate-400"></i>
+                        <p class="text-sm leading-relaxed text-slate-600"
+                           th:text="${recommendEntry != null ? recommendEntry.helperMessage : '추천을 받을 포지션을 선택하고 추천을 시작해주세요.'}">안내 문구</p>
+                    </div>
+
+                    <!-- JS 에러 배너 (fetch 응답용 — 초기 hidden) -->
+                    <div id="recommendModalErrorBanner"
+                         class="hidden flex items-center gap-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3">
+                        <i data-lucide="triangle-alert" class="h-4 w-4 shrink-0 text-rose-500"></i>
+                        <p id="recommendModalErrorMsg" class="text-sm font-semibold text-rose-700"></p>
+                    </div>
+
+                    <!-- 추천 요청 폼 -->
+                    <form id="recommendModalForm"
+                          th:action="@{/proposals/{id}/recommendations(id=${proposal.id})}"
+                          method="post">
+                        <th:block th:if="${_csrf != null}">
+                            <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+                        </th:block>
+
+                        <!-- 포지션 select -->
+                        <div>
+                            <div class="flex items-center gap-1.5 mb-3">
+                                <i data-lucide="layers" class="h-4 w-4 text-slate-400"></i>
+                                <label for="modalProposalPositionId"
+                                       class="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                                    추천 대상 포지션
+                                </label>
+                            </div>
+                            <div class="relative">
+                                <select id="modalProposalPositionId"
+                                        name="proposalPositionId"
+                                        class="w-full appearance-none rounded-2xl border border-slate-200 bg-slate-50 py-3 pl-4 pr-10 text-sm font-semibold text-slate-900 outline-none transition focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100">
+                                    <option value="">포지션을 선택해주세요</option>
+                                    <th:block th:if="${recommendEntry != null}">
+                                        <option th:each="position : ${recommendEntry.positions}"
+                                                th:value="${position.proposalPositionId}"
+                                                th:selected="${position.proposalPositionId == recommendEntry.selectedProposalPositionId}"
+                                                th:text="${position.positionTitle + (position.positionCategoryName != null and position.positionCategoryName != position.positionTitle ? ' · ' + position.positionCategoryName : '')}">
+                                            백엔드 개발자
+                                        </option>
+                                    </th:block>
+                                    <th:block th:if="${recommendEntry == null}">
+                                        <option th:each="pos : ${proposal.positions}"
+                                                th:value="${pos.id}"
+                                                th:text="${pos.title}">
+                                            백엔드 개발자
+                                        </option>
+                                    </th:block>
+                                </select>
+                                <div class="pointer-events-none absolute inset-y-0 right-4 flex items-center">
+                                    <i data-lucide="chevron-down" class="h-4 w-4 text-slate-400"></i>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 포지션 카드 목록 -->
+                        <div class="mt-5 space-y-3"
+                             th:if="${recommendEntry != null and !#lists.isEmpty(recommendEntry.positions)}">
+                            <article th:each="position : ${recommendEntry.positions}"
+                                     th:attr="data-position-id=${position.proposalPositionId}"
+                                     class="rounded-[24px] border border-slate-200 bg-slate-50 p-5 transition cursor-pointer hover:border-blue-200"
+                                     onclick="selectPositionCard(this)">
+
+                                <div class="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                        <div class="flex items-center gap-2">
+                                            <h3 class="text-base font-bold tracking-tight text-slate-900"
+                                                th:text="${position.positionTitle}">백엔드 개발자</h3>
+                                            <span th:classappend="${position.positionStatusName == 'OPEN'}
+                                                      ? 'border-blue-200 bg-blue-50 text-blue-600'
+                                                      : (${position.positionStatusName == 'FULL'}
+                                                          ? 'border-amber-200 bg-amber-50 text-amber-600'
+                                                          : 'border-slate-200 bg-slate-100 text-slate-500')"
+                                                  class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-bold"
+                                                  th:text="${position.positionStatusDescription}">모집 중</span>
+                                        </div>
+                                        <p th:if="${position.positionCategoryName != null and position.positionCategoryName != position.positionTitle}"
+                                           class="mt-1 text-sm font-medium text-slate-500"
+                                           th:text="${position.positionCategoryName}">백엔드</p>
+                                    </div>
+                                    <!-- JS가 토글 -->
+                                    <span class="selected-badge hidden rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700">
+                                        선택됨
+                                    </span>
+                                </div>
+
+                                <!-- 수치 -->
+                                <div class="mt-3 flex flex-wrap gap-4">
+                                    <div>
+                                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">인원</p>
+                                        <p class="mt-1 text-sm font-bold text-slate-900"
+                                           th:text="${position.headCount != null ? position.headCount + '명' : '미정'}">2명</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산</p>
+                                        <p class="mt-1 text-sm font-bold text-slate-900"
+                                           th:text="${position.budgetText != null ? position.budgetText : '미정'}">3,000,000 ~ 5,000,000</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">기간</p>
+                                        <p class="mt-1 text-sm font-bold text-slate-900"
+                                           th:text="${position.expectedPeriod != null ? position.expectedPeriod + '주' : '미정'}">8주</p>
+                                    </div>
+                                </div>
+
+                                <!-- 스킬 -->
+                                <div class="mt-4" th:if="${!#lists.isEmpty(position.skills)}">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">요구 스킬</p>
+                                    <div class="mt-2 flex flex-wrap gap-2">
+                                        <span th:each="skill : ${position.skills}"
+                                              th:classappend="${skill.importanceLabel == '필수'} ? 'border-slate-200 bg-white text-slate-700' : 'border-blue-100 bg-blue-50 text-blue-700'"
+                                              class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold">
+                                            <span th:text="${skill.skillName}">Java</span>
+                                            <span class="text-slate-300">·</span>
+                                            <span th:text="${skill.importanceLabel}">필수</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+
+                        <!-- 액션 버튼 -->
+                        <div class="mt-6 flex items-center justify-end gap-3"
+                             th:with="canRun=${recommendEntry != null ? recommendEntry.runnable : !#lists.isEmpty(proposal.positions)}">
+                            <button type="button"
+                                    id="btnCancelRecommendModal"
+                                    onclick="closeRecommendModal()"
+                                    class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-5 py-3 text-sm font-bold text-slate-600 transition hover:bg-slate-50">
+                                취소
+                            </button>
+                            <button type="submit"
+                                    th:disabled="${!canRun}"
+                                    th:classappend="${canRun}
+                                        ? 'bg-blue-600 text-white shadow-lg shadow-blue-100 hover:bg-blue-700'
+                                        : 'cursor-not-allowed bg-slate-100 text-slate-400'"
+                                    class="inline-flex items-center gap-2 rounded-2xl px-6 py-3 text-sm font-bold transition">
+                                <i data-lucide="sparkles" class="h-4 w-4"></i>
+                                추천 시작
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+
 </div>
+
+<th:block layout:fragment="scripts">
+    <script>
+        function openRecommendModal() {
+            var modal = document.getElementById('recommendModal');
+            var backdrop = document.getElementById('recommendModalBackdrop');
+            if (!modal || !backdrop) return;
+            modal.classList.remove('hidden');
+            backdrop.classList.remove('hidden');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeRecommendModal() {
+            var modal = document.getElementById('recommendModal');
+            var backdrop = document.getElementById('recommendModalBackdrop');
+            if (!modal || !backdrop) return;
+            modal.classList.add('hidden');
+            backdrop.classList.add('hidden');
+            document.body.style.overflow = '';
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeRecommendModal();
+        });
+
+        (function () {
+            var params = new URLSearchParams(location.search);
+            if (params.get('openRecommendModal') === 'true') {
+                openRecommendModal();
+
+                params.delete('openRecommendModal');
+                var nextUrl = location.pathname + (params.toString() ? ('?' + params.toString()) : '');
+                history.replaceState(null, '', nextUrl);
+            }
+        })();
+
+        // ── 모달 폼 — fetch 제출 (에러 시 리다이렉트 없이 배너 표시) ──
+        (function () {
+            var form = document.getElementById('recommendModalForm');
+            if (!form) return;
+
+            var errorBanner = document.getElementById('recommendModalErrorBanner');
+            var errorMsg    = document.getElementById('recommendModalErrorMsg');
+
+            function showError(msg) {
+                if (!errorBanner || !errorMsg) return;
+                errorMsg.textContent = msg;
+                errorBanner.classList.remove('hidden');
+            }
+
+            function hideError() {
+                if (errorBanner) errorBanner.classList.add('hidden');
+            }
+
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                hideError();
+
+                var csrfInput  = form.querySelector('input[name="_csrf"]');
+                var csrfHeader = document.querySelector('meta[name="_csrf_header"]');
+                var headers = {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Accept':       'application/json'
+                };
+                if (csrfInput && csrfHeader) {
+                    headers[csrfHeader.content] = csrfInput.value;
+                }
+
+                fetch(form.action, {
+                    method:  'POST',
+                    headers: headers,
+                    body:    new URLSearchParams(new FormData(form)).toString()
+                })
+                .then(function (res) { return res.json(); })
+                .then(function (data) {
+                    if (data.redirect) {
+                        location.href = data.redirect;
+                    } else if (data.error) {
+                        showError(data.error);
+                    }
+                })
+                .catch(function () {
+                    // 네트워크 오류 — 폼 직접 제출로 fallback
+                    form.submit();
+                });
+            });
+
+            // 모달 닫을 때 에러 배너 초기화
+            var origClose = window.closeRecommendModal;
+            window.closeRecommendModal = function () {
+                hideError();
+                if (origClose) origClose();
+            };
+        })();
+
+        // ── 포지션 카드 ↔ 드롭다운 연동 ──────────────────────────
+        (function () {
+            var select = document.getElementById('modalProposalPositionId');
+
+            function highlightCard(posId) {
+                document.querySelectorAll('[data-position-id]').forEach(function (card) {
+                    var badge = card.querySelector('.selected-badge');
+                    var isSelected = posId && card.dataset.positionId === String(posId);
+                    // 테두리 / 배경
+                    card.classList.toggle('border-blue-200', isSelected);
+                    card.classList.toggle('bg-blue-50', isSelected);
+                    card.classList.toggle('border-slate-200', !isSelected);
+                    card.classList.toggle('bg-slate-50', !isSelected);
+                    // 뱃지
+                    if (badge) badge.classList.toggle('hidden', !isSelected);
+                });
+            }
+
+            // 카드 클릭 → 드롭다운 갱신 + 하이라이트
+            window.selectPositionCard = function (cardEl) {
+                var posId = cardEl.dataset.positionId;
+                if (select) select.value = posId;
+                highlightCard(posId);
+            };
+
+            // 드롭다운 변경 → 카드 하이라이트
+            if (select) {
+                select.addEventListener('change', function () {
+                    highlightCard(this.value);
+                });
+                // 초기화 — 드롭다운 기본값에 맞춰 카드 선택 상태 적용
+                if (select.value) highlightCard(select.value);
+            }
+        })();
+    </script>
+</th:block>
+
 </body>
 </html>
 

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -665,8 +665,8 @@ class ProposalControllerTest {
     }
 
     @Test
-    @DisplayName("없는 제안서 상세 조회 시 대시보드로 리다이렉트한다")
-    void redirectDashboardWhenDetailNotFound() throws Exception {
+    @DisplayName("없는 제안서 상세 조회 시 홈으로 리다이렉트하고 오류 메시지를 남긴다")
+    void redirectHomeWhenDetailNotFound() throws Exception {
         given(proposalService.findOwnedProposal(999L, "client@example.com"))
                 .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"));
 
@@ -680,11 +680,12 @@ class ProposalControllerTest {
                                 principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/"));
+                .andExpect(redirectedUrl("/"))
+                .andExpect(flash().attributeExists("errorMessage"));
     }
 
     @Test
-    @DisplayName("존재하지 않는 제안서 조회 시 홈으로 리다이렉트된다")
+    @DisplayName("외부 referer에서 없는 제안서 조회 시 홈으로 리다이렉트하고 오류 메시지를 남긴다")
     void redirectHomeWhenDetailNotFoundWithExternalReferer() throws Exception {
         given(proposalService.findOwnedProposal(999L, "client@example.com"))
                 .willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=999"));
@@ -699,7 +700,8 @@ class ProposalControllerTest {
                                 principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/"));
+                .andExpect(redirectedUrl("/"))
+                .andExpect(flash().attributeExists("errorMessage"));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.dto.recommend.RecommendationEntryPositionItem;
 import com.generic4.itda.domain.matching.Matching;
 import com.generic4.itda.domain.position.Position;
 import com.generic4.itda.domain.proposal.Proposal;
@@ -33,11 +35,13 @@ import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.exception.ProposalNotFoundException;
 import java.time.LocalDateTime;
 import org.springframework.security.access.AccessDeniedException;
+import com.generic4.itda.dto.recommend.RecommendationEntryViewModel;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.PositionResolver;
 import com.generic4.itda.service.ProposalAiInterviewService;
 import com.generic4.itda.service.ProposalService;
+import com.generic4.itda.service.recommend.RecommendationEntryService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -67,6 +71,9 @@ class ProposalControllerTest {
 
     @MockitoBean
     private MatchingRepository matchingRepository;
+
+    @MockitoBean
+    private RecommendationEntryService recommendationEntryService;
 
     @Test
     @DisplayName("인증된 사용자가 새 제안서 작성 화면을 조회하면 편집기를 렌더링한다")
@@ -148,7 +155,7 @@ class ProposalControllerTest {
     }
 
     @Test
-    @DisplayName("제안서 등록 요청이 유효하면 추천 진입 화면으로 이동한다")
+    @DisplayName("제안서 등록 요청이 유효하면 제안서 상세 추천 모달로 이동한다")
     void registerAndRedirectToRecommendationEntry() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(3L);
@@ -183,7 +190,7 @@ class ProposalControllerTest {
                         .param("positions[0].expectedPeriod", "4")
                         .param("positions[0].essentialSkillNames[0]", "Node.js"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/proposals/3/recommendations"));
+                .andExpect(redirectedUrl("/proposals/3?openRecommendModal=true"));
 
         then(proposalService).should().register(anyString(), any(ProposalForm.class));
     }
@@ -359,7 +366,7 @@ class ProposalControllerTest {
     }
 
     @Test
-    @DisplayName("수정 요청에서 register 액션이 유효하면 추천 진입 화면으로 이동한다")
+    @DisplayName("수정 요청에서 register 액션이 유효하면 제안서 상세 추천 모달로 이동한다")
     void registerAfterUpdateAndRedirectToRecommendationEntry() throws Exception {
         Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
         given(proposal.getId()).willReturn(1L);
@@ -393,7 +400,7 @@ class ProposalControllerTest {
                         .param("positions[0].expectedPeriod", "4")
                         .param("positions[0].essentialSkillNames[0]", "Node.js"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/proposals/1/recommendations"));
+                .andExpect(redirectedUrl("/proposals/1?openRecommendModal=true"));
 
         then(proposalService).should().register(any(Long.class), anyString(), any(ProposalForm.class));
     }
@@ -881,5 +888,81 @@ class ProposalControllerTest {
                 .andExpect(redirectedUrl("/client/dashboard"));
 
         then(proposalService).should().delete(1L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("MATCHING 상태 제안서 상세 조회 시 recommendEntry 모델에 포함되고 모달 DOM이 렌더된다")
+    void detailForMatchingProposalIncludesRecommendEntry() throws Exception {
+        var client = createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678");
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(proposal.getTitle()).willReturn("핀테크 앱 프로젝트");
+        given(proposal.getDescription()).willReturn("설명");
+        given(proposal.getStatus()).willReturn(ProposalStatus.MATCHING);
+        given(proposal.getExpectedPeriod()).willReturn(8L);
+        given(proposal.getTotalBudgetMin()).willReturn(3_000_000L);
+        given(proposal.getTotalBudgetMax()).willReturn(4_000_000L);
+        given(proposal.getModifiedAt()).willReturn(java.time.LocalDateTime.of(2026, 4, 23, 12, 0));
+        given(proposal.getPositions()).willReturn(List.of());
+
+        RecommendationEntryPositionItem positionItem = new RecommendationEntryPositionItem(
+                10L, "백엔드 개발자", "백엔드", 2L, "3,000,000 ~ 5,000,000", 8L, List.of(),
+                "OPEN", "모집 중"
+        );
+        RecommendationEntryViewModel recommendEntry = new RecommendationEntryViewModel(
+                1L, "핀테크 앱 프로젝트", "MATCHING", true,
+                "추천을 실행할 수 있습니다.", 10L, List.of(positionItem)
+        );
+
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(1L, "client@example.com"))
+                .willReturn(List.of());
+        given(recommendationEntryService.getEntry(1L, "client@example.com")).willReturn(recommendEntry);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(client);
+
+        mockMvc.perform(get("/proposals/1")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalDetail"))
+                .andExpect(model().attribute("viewerRole", "CLIENT"))
+                .andExpect(model().attributeExists("recommendEntry"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("id=\"recommendModal\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("id=\"recommendModalBackdrop\"")));
+    }
+
+    @Test
+    @DisplayName("MATCHING 제안서에서 getEntry 예외 발생 시에도 페이지는 200으로 렌더되고 모달은 표시되지 않는다")
+    void detailPageRendersEvenWhenGetEntryFails() throws Exception {
+        var client = createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678");
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getId()).willReturn(1L);
+        given(proposal.getTitle()).willReturn("핀테크 앱 프로젝트");
+        given(proposal.getDescription()).willReturn("설명");
+        given(proposal.getStatus()).willReturn(ProposalStatus.MATCHING);
+        given(proposal.getExpectedPeriod()).willReturn(8L);
+        given(proposal.getTotalBudgetMin()).willReturn(3_000_000L);
+        given(proposal.getTotalBudgetMax()).willReturn(4_000_000L);
+        given(proposal.getModifiedAt()).willReturn(java.time.LocalDateTime.of(2026, 4, 23, 12, 0));
+        given(proposal.getPositions()).willReturn(List.of());
+
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(1L, "client@example.com"))
+                .willReturn(List.of());
+        given(recommendationEntryService.getEntry(1L, "client@example.com"))
+                .willThrow(new IllegalArgumentException("존재하지 않는 제안서입니다."));
+
+        ItDaPrincipal principal = ItDaPrincipal.from(client);
+
+        mockMvc.perform(get("/proposals/1")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalDetail"))
+                .andExpect(model().attribute("viewerRole", "CLIENT"))
+                .andExpect(model().attributeDoesNotExist("recommendEntry"));
     }
 }

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -20,7 +21,6 @@ import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
-import com.generic4.itda.service.recommend.RecommendationEntryService;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
 import java.util.List;
@@ -44,9 +44,6 @@ class RecommendationControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private RecommendationEntryService recommendationEntryService;
-
-    @MockitoBean
     private RecommendationRunService recommendationRunService;
 
     @MockitoBean
@@ -54,6 +51,25 @@ class RecommendationControllerTest {
 
     @MockitoBean
     private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("GET /recommendations — 제안서 상세 모달로 redirect한다")
+    void entryRedirectsToProposalDetail() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations", PROPOSAL_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/" + PROPOSAL_ID + "?openRecommendModal=true"));
+    }
 
     @Test
     @DisplayName("추천 결과 조회가 성공하면 results 화면을 렌더링한다")

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -6,19 +6,24 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.generic4.itda.annotation.ControllerTest;
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
+import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
@@ -27,6 +32,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -215,5 +221,244 @@ class RecommendationControllerTest {
 
         then(recommendationRunQueryService).should()
                 .getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 후보 이력서 조회 실패 시 error 화면을 렌더링한다")
+    void renderErrorWhenCandidateResumeFails() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunQueryService.getRecommendationCandidateResume(eq(PROPOSAL_ID), eq(RESULT_ID), eq("client@example.com")))
+                .willThrow(new IllegalArgumentException("추천 결과를 찾을 수 없습니다."));
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results/{resultId}", PROPOSAL_ID, RESULT_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/error"))
+                .andExpect(model().attribute("title", "추천 후보 이력서를 확인할 수 없습니다."))
+                .andExpect(model().attribute("backUrl", "/proposals/" + PROPOSAL_ID + "?openRecommendModal=true"));
+    }
+
+    // ── GET /proposals/{proposalId}/runs/{runId} ─────────────────────────────
+
+    @Test
+    @DisplayName("추천 실행 상태 조회가 성공하면 status 화면을 렌더링한다")
+    void renderRunStatus() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationRunStatusViewModel statusView = new RecommendationRunStatusViewModel(
+                PROPOSAL_ID, RUN_ID, "추천 테스트 제안서",
+                RecommendationRunStatus.PENDING,
+                "추천 결과를 생성하고 있습니다.",
+                "잠시 후 자동으로 결과를 확인할 수 있습니다.",
+                "새로고침", null, true
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(statusView);
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/status"))
+                .andExpect(model().attributeExists("view"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 실행 정보를 찾을 수 없으면 error 화면을 렌더링한다")
+    void renderErrorWhenRunNotFound() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willThrow(new IllegalArgumentException("추천 실행 정보를 찾을 수 없습니다."));
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/error"))
+                .andExpect(model().attribute("title", "추천 실행 정보를 확인할 수 없습니다."))
+                .andExpect(model().attribute("message", "존재하지 않거나 만료된 추천 실행입니다."))
+                .andExpect(model().attribute("backUrl", "/proposals/" + PROPOSAL_ID + "?openRecommendModal=true"));
+    }
+
+    @Test
+    @DisplayName("추천 실행 접근 권한이 없으면 error 화면에 권한 없음 메시지를 렌더링한다")
+    void renderErrorWhenRunAccessDenied() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willThrow(new IllegalArgumentException("접근 권한이 없습니다."));
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/error"))
+                .andExpect(model().attribute("message", "해당 추천 실행 정보에 접근할 수 없습니다."));
+    }
+
+    // ── POST /proposals/{proposalId}/recommendations (AJAX — Accept: application/json) ──
+
+    @Test
+    @DisplayName("추천 시작 AJAX 요청이 성공하면 JSON으로 redirect URL을 반환한다")
+    void runAjaxReturnsRedirectUrl() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createOrReuse(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willReturn(RUN_ID);
+
+        // when / then
+        mockMvc.perform(post("/proposals/{proposalId}/recommendations", PROPOSAL_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .param("proposalPositionId", String.valueOf(PROPOSAL_POSITION_ID))
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID));
+
+        then(recommendationRunService).should()
+                .createOrReuse(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 시작 AJAX 요청에서 포지션이 없으면 400과 JSON 에러를 반환한다")
+    void runAjaxReturnsBadRequestWhenPositionMissing() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        // when / then — proposalPositionId 미전송
+        mockMvc.perform(post("/proposals/{proposalId}/recommendations", PROPOSAL_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("추천 시작 AJAX 요청 처리 중 예외가 발생하면 400과 JSON 에러를 반환한다")
+    void runAjaxReturnsBadRequestOnException() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createOrReuse(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willThrow(new IllegalStateException("모집 중인 포지션만 추천을 실행할 수 있습니다."));
+
+        // when / then
+        mockMvc.perform(post("/proposals/{proposalId}/recommendations", PROPOSAL_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .param("proposalPositionId", String.valueOf(PROPOSAL_POSITION_ID))
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    // ── POST /proposal-positions/{proposalPositionId}/recommendations/more (AJAX) ──
+
+    @Test
+    @DisplayName("추가 추천 AJAX 요청이 성공하면 JSON으로 redirect URL을 반환한다")
+    void moreAjaxReturnsRedirectUrl() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createAdditional(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willReturn(RUN_ID);
+
+        // when / then
+        mockMvc.perform(post("/proposal-positions/{proposalPositionId}/recommendations/more", PROPOSAL_POSITION_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .param("proposalId", String.valueOf(PROPOSAL_ID))
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID));
+
+        then(recommendationRunService).should()
+                .createAdditional(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추가 추천 AJAX 요청 처리 중 예외가 발생하면 400과 JSON 에러를 반환한다")
+    void moreAjaxReturnsBadRequestOnException() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createAdditional(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willThrow(new IllegalStateException("모집 중인 포지션만 추천을 실행할 수 있습니다."));
+
+        // when / then
+        mockMvc.perform(post("/proposal-positions/{proposalPositionId}/recommendations/more", PROPOSAL_POSITION_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .param("proposalId", String.valueOf(PROPOSAL_ID))
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
     }
 }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceIntegrationTest.java
@@ -134,7 +134,7 @@ class RecommendationEntryServiceIntegrationTest {
                 owner.getEmail().getValue()
         );
 
-        assertThat(result.runnable()).isTrue();
+        assertThat(result.runnable()).isFalse();
         assertThat(result.positions()).isEmpty();
         assertThat(result.selectedProposalPositionId()).isNull();
     }

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationEntryServiceTest.java
@@ -132,7 +132,7 @@ class RecommendationEntryServiceTest {
 
         assertThat(result.positions()).isEmpty();
         assertThat(result.selectedProposalPositionId()).isNull();
-        assertThat(result.runnable()).isTrue();
+        assertThat(result.runnable()).isFalse();
 
         verifyNoMoreInteractions(proposalRepository, memberRepository);
     }


### PR DESCRIPTION
## 🔎 What

- proposalDetail의 “추천 받아 보기” 링크/버튼 동작 위치 찾기
- GET /proposals/{id}/recommendations 화면/데이터/제출(추천 실행) 로직 파악
- proposalDetail에 추천 포지션 선택 모달 뼈대 추가(열기/닫기)
- 모달 오픈 시 포지션 목록 로딩(fetch: HTML fragment or JSON) 구현
- 선택 → 확인 시 기존 추천 실행 로직 호출 + 결과 처리(성공/실패/로딩)
- 노출 조건: “매칭/추천 진행중” 상태에서만 활성화
- /proposals/{id}/recommendations 직접 접속 시 /proposals/{id}로 리다이렉트하고 추천 모달 자동 오픈 처리
- 컨트롤러/템플릿 중복 정리(fragment 분리)
- 테스트(컨트롤러/상태/요청 파라미터) 추가
- 제안서 수정 버튼 표시/숨김 조건 수성 작업

## 🔗 Issue

- Closes: #133

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?