### PR TITLE
[Bug] 매칭 리스트 → 상세 이동 시 backUrl이 유지되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/generic4/itda/controller/MatchingController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingController.java
@@ -32,23 +32,26 @@ public class MatchingController {
     @GetMapping("/matchings/{matchingId}")
     public String detail(
             @PathVariable Long matchingId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model,
             RedirectAttributes redirectAttributes
     ) {
         try {
-            model.addAttribute("view", matchingQueryService.getDetail(matchingId, principal.getEmail()));
+            var view = matchingQueryService.getDetail(matchingId, principal.getEmail());
+            model.addAttribute("view", view);
+            model.addAttribute("backUrl", resolveBackUrl(backUrl, view));
             return "matching/detail";
         } catch (IllegalArgumentException e) {
             log.warn("매칭 상세 조회 실패. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 매칭입니다.");
-            return "redirect:/";
+            return redirectTo(backUrl, "/");
         } catch (AccessDeniedException e) {
             log.warn("매칭 상세 접근 거부. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다.");
-            return "redirect:/";
+            return redirectTo(backUrl, "/");
         }
     }
 
@@ -345,5 +348,17 @@ public class MatchingController {
             return "redirect:" + redirectTo;
         }
         return "redirect:" + fallback;
+    }
+
+    private String resolveBackUrl(String requestedBackUrl, com.generic4.itda.dto.matching.MatchingDetailViewModel view) {
+        if (StringUtils.hasText(requestedBackUrl)
+                && requestedBackUrl.startsWith("/")
+                && !requestedBackUrl.startsWith("//")) {
+            return requestedBackUrl;
+        }
+        if ("CLIENT".equals(view.viewerRole()) && view.project() != null && view.project().proposalId() != null) {
+            return "/proposals/" + view.project().proposalId() + "/matchings";
+        }
+        return "CLIENT".equals(view.viewerRole()) ? "/client/dashboard" : "/freelancers/dashboard";
     }
 }

--- a/src/main/java/com/generic4/itda/controller/MatchingEntryController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingEntryController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -45,6 +46,7 @@ public class MatchingEntryController {
             @PathVariable Long proposalId,
             @RequestParam(name = "positionId", required = false) Long positionId,
             @RequestParam(name = "status", required = false) String status,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model,
             RedirectAttributes redirectAttributes
@@ -55,6 +57,7 @@ public class MatchingEntryController {
                     .findWithPositionAndFreelancerByProposalIdAndClientEmail(proposalId, principal.getEmail());
 
             MatchingStatus filterStatus = parseStatus(status).orElse(null);
+            String resolvedBackUrl = resolveBackUrl(proposalId, backUrl);
 
             List<ClientMatchingListItemViewModel> items = applyFiltersAndSort(
                     matchings, positionId, filterStatus);
@@ -68,6 +71,9 @@ public class MatchingEntryController {
                     items
             ));
             model.addAttribute("items", items);
+            model.addAttribute("backUrl", resolvedBackUrl);
+            model.addAttribute("detailBackUrl",
+                    buildListUrl(proposalId, positionId, filterStatus, resolvedBackUrl));
             return "matching/list";
         } catch (ProposalNotFoundException e) {
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
@@ -86,6 +92,7 @@ public class MatchingEntryController {
             @PathVariable Long proposalId,
             @RequestParam(name = "positionId", required = false) Long positionId,
             @RequestParam(name = "status", required = false) String status,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
@@ -97,6 +104,8 @@ public class MatchingEntryController {
         MatchingStatus filterStatus = parseStatus(status).orElse(null);
 
         model.addAttribute("items", applyFiltersAndSort(matchings, positionId, filterStatus));
+        model.addAttribute("detailBackUrl",
+                buildListUrl(proposalId, positionId, filterStatus, resolveBackUrl(proposalId, backUrl)));
         return "matching/fragments :: itemList";
     }
 
@@ -168,6 +177,35 @@ public class MatchingEntryController {
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }
+    }
+
+    private static String resolveBackUrl(Long proposalId, String backUrl) {
+        if (StringUtils.hasText(backUrl)) {
+            String trimmed = backUrl.trim();
+            if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+                return trimmed;
+            }
+        }
+        return "/proposals/" + proposalId;
+    }
+
+    private static String buildListUrl(
+            Long proposalId,
+            Long positionId,
+            MatchingStatus filterStatus,
+            String backUrl
+    ) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/proposals/{proposalId}/matchings");
+        if (positionId != null) {
+            builder.queryParam("positionId", positionId);
+        }
+        if (filterStatus != null) {
+            builder.queryParam("status", filterStatus.name());
+        }
+        if (StringUtils.hasText(backUrl)) {
+            builder.queryParam("backUrl", backUrl);
+        }
+        return builder.buildAndExpand(proposalId).toUriString();
     }
 
     private static Comparator<Matching> matchingSortComparator() {

--- a/src/main/java/com/generic4/itda/controller/MatchingProfileController.java
+++ b/src/main/java/com/generic4/itda/controller/MatchingProfileController.java
@@ -25,39 +25,62 @@ public class MatchingProfileController {
     @GetMapping("/matchings/{matchingId}/counterpart-profile")
     public String counterpartProfile(
             @PathVariable Long matchingId,
+            @RequestParam(name = "returnTo", required = false) String returnTo,
             @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model,
             RedirectAttributes redirectAttributes
     ) {
+        String requestedBackUrl = resolveRequestedBackUrl(returnTo, backUrl);
+
         try {
             ProfileShellViewModel view = matchingProfileQueryService
                     .getCounterpartProfile(matchingId, principal.getEmail());
 
-            model.addAttribute("view", view.withBackUrl(resolveBackUrl(backUrl, view.backUrl())));
+            model.addAttribute("view", view.withBackUrl(resolveBackUrl(requestedBackUrl, view.backUrl())));
 
             return "profile/shell";
         } catch (IllegalArgumentException e) {
             log.warn("상대 프로필 조회 실패. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 매칭입니다.");
-            return redirectTo(backUrl, "/matchings/" + matchingId);
+            return redirectTo(requestedBackUrl, "/matchings/" + matchingId);
         } catch (AccessDeniedException e) {
             log.warn("상대 프로필 접근 거부. matchingId={}, email={}",
                     matchingId, principal.getEmail(), e);
             redirectAttributes.addFlashAttribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다.");
-            return redirectTo(backUrl, "/matchings/" + matchingId);
+            return redirectTo(requestedBackUrl, "/matchings/" + matchingId);
         }
     }
 
-    private String redirectTo(String backUrl, String fallback) {
-        return "redirect:" + resolveBackUrl(backUrl, fallback);
+    private String redirectTo(String requestedBackUrl, String fallback) {
+        return "redirect:" + resolveBackUrl(requestedBackUrl, fallback);
     }
 
-    private String resolveBackUrl(String backUrl, String fallback) {
-        if (StringUtils.hasText(backUrl) && backUrl.startsWith("/") && !backUrl.startsWith("//")) {
-            return backUrl;
+    private String resolveBackUrl(String requestedBackUrl, String fallback) {
+        if (requestedBackUrl != null) {
+            return requestedBackUrl;
         }
         return fallback;
+    }
+
+    private String resolveRequestedBackUrl(String returnTo, String backUrl) {
+        String resolvedReturnTo = normalizeLocalPath(returnTo);
+        if (resolvedReturnTo != null) {
+            return resolvedReturnTo;
+        }
+        return normalizeLocalPath(backUrl);
+    }
+
+    private String normalizeLocalPath(String candidate) {
+        if (!StringUtils.hasText(candidate)) {
+            return null;
+        }
+
+        String trimmed = candidate.trim();
+        if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+            return trimmed;
+        }
+        return null;
     }
 }

--- a/src/main/resources/templates/client/dashboard.html
+++ b/src/main/resources/templates/client/dashboard.html
@@ -345,7 +345,7 @@
             menuDetail.href    = '/proposals/' + proposalId;
             menuEdit.href      = '/proposals/' + proposalId + '/edit';
             menuRecommend.href = '/proposals/' + proposalId + '/recommendations';
-            menuMatching.href  = '/proposals/' + proposalId + '/matchings';
+            menuMatching.href  = '/proposals/' + proposalId + '/matchings?backUrl=' + encodeURIComponent('/client/dashboard');
             menuDelete.dataset.proposalId    = proposalId;
             menuDelete.dataset.proposalTitle = proposalTitle;
 

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -67,7 +67,7 @@
                                 완료된 프로젝트
                             </span>
                             <a th:if="${proposal.status.name() == 'COMPLETE'}"
-                               th:href="@{/proposals/{id}/matchings(id=${proposal.id})}"
+                               th:href="@{/proposals/{id}/matchings(id=${proposal.id}, backUrl=${'/proposals/' + proposal.id})}"
                                class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
                                 <i data-lucide="activity" class="h-4 w-4"></i>
                                 매칭 결과 보기
@@ -517,4 +517,3 @@
 </div>
 </body>
 </html>
-

--- a/src/main/resources/templates/fragments/proposalDetailFragments.html
+++ b/src/main/resources/templates/fragments/proposalDetailFragments.html
@@ -28,7 +28,7 @@
 
                 <!-- 클라이언트: 해당 포지션 매칭 결과 바로가기 (매칭이 존재하는 포지션에만 표시) -->
                 <a th:if="${viewerRole != 'FREELANCER' and positionsWithMatchings != null and positionsWithMatchings.contains(pos.id)}"
-                   th:href="@{/proposals/{id}/matchings(id=${pos.proposal.id}, positionId=${pos.id})}"
+                   th:href="@{/proposals/{id}/matchings(id=${pos.proposal.id}, positionId=${pos.id}, backUrl=${'/proposals/' + pos.proposal.id})}"
                    class="inline-flex items-center gap-2 rounded-2xl border border-blue-600 bg-white px-5 py-3 text-sm font-bold text-blue-600 transition hover:bg-blue-600 hover:text-white">
                     <i data-lucide="users" class="h-4 w-4"></i>
                     매칭 결과 보기

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -9,6 +9,8 @@
 <div layout:fragment="content">
     <main class="min-h-screen bg-slate-50"
           th:with="statusName=${view.status.name()},
+                   profileReturnTo=@{/matchings/{id}(id=${view.matchingId}, backUrl=${backUrl})},
+                   profileReturnToEncoded=${#uris.escapeQueryParam(profileReturnTo)},
                    proposed=${statusName == 'PROPOSED'},
                    accepted=${statusName == 'ACCEPTED'},
                    rejected=${statusName == 'REJECTED'},
@@ -50,7 +52,7 @@
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <a th:href="@{/matchings/{id}/counterpart-profile(id=${view.matchingId}, backUrl=${'/matchings/' + view.matchingId})}"
+                    <a th:href="@{'/matchings/' + ${view.matchingId} + '/counterpart-profile?returnTo=' + ${profileReturnToEncoded}}"
                        class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
                         <i data-lucide="user" class="h-4 w-4"></i>
                         상대 프로필 보기

--- a/src/main/resources/templates/matching/fragments.html
+++ b/src/main/resources/templates/matching/fragments.html
@@ -13,13 +13,13 @@
 
     <section th:if="${items != null and !items.isEmpty()}"
              class="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm shadow-slate-200/70">
-        <div class="hidden md:grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1fr_1fr_80px] gap-4 px-6 py-3 border-b border-slate-100 text-xs font-bold text-slate-400 uppercase tracking-wide">
+        <div class="hidden md:grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1fr_1fr_180px] gap-4 px-6 py-3 border-b border-slate-100 text-xs font-bold text-slate-400 uppercase tracking-wide">
             <span>프리랜서</span><span>포지션</span><span>상태</span><span>요청일</span><span></span>
         </div>
         <div class="divide-y divide-slate-100">
-            <a th:each="item : ${items}"
-               th:href="@{/matchings/{id}(id=${item.matchingId})}"
-               class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1fr_1fr_80px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors">
+            <div th:each="item : ${items}"
+                 th:with="detailBackUrlEncoded=${#uris.escapeQueryParam(detailBackUrl)}"
+                 class="grid grid-cols-1 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_1fr_1fr_180px] gap-4 items-center px-6 py-5 hover:bg-slate-50 transition-colors">
                 <div>
                     <p class="text-sm font-bold text-slate-900" th:text="${item.freelancerName}">프리랜서</p>
                 </div>
@@ -39,12 +39,17 @@
                     <i data-lucide="calendar" class="h-4 w-4 text-slate-400 hidden md:block"></i>
                     <span th:text="${item.requestedAt != null ? #temporals.format(item.requestedAt, 'yyyy.MM.dd') : '-'}">날짜</span>
                 </div>
-                <div class="flex justify-end">
-                    <span class="flex items-center gap-1 text-sm font-semibold text-blue-600 whitespace-nowrap">
-                        보기<i data-lucide="chevron-right" class="h-4 w-4"></i>
-                    </span>
+                <div class="flex justify-end gap-2">
+                    <a th:href="@{'/matchings/' + ${item.matchingId} + '/counterpart-profile?returnTo=' + ${detailBackUrlEncoded}}"
+                       class="inline-flex items-center rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-bold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
+                        프로필
+                    </a>
+                    <a th:href="@{'/matchings/' + ${item.matchingId} + '?backUrl=' + ${detailBackUrlEncoded}}"
+                       class="inline-flex items-center gap-1 rounded-xl border border-blue-100 bg-blue-50 px-3 py-2 text-xs font-bold text-blue-600 transition hover:border-blue-200 hover:bg-blue-100">
+                        상세<i data-lucide="chevron-right" class="h-4 w-4"></i>
+                    </a>
                 </div>
-            </a>
+            </div>
         </div>
     </section>
 

--- a/src/main/resources/templates/matching/list.html
+++ b/src/main/resources/templates/matching/list.html
@@ -14,7 +14,7 @@
             <div class="sticky top-0 z-10 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
                 <div class="flex flex-wrap items-center justify-between gap-4">
                     <div class="flex items-center gap-4">
-                        <a id="btnBack" href="#"
+                        <a id="btnBack" th:href="${backUrl}"
                            class="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white p-3 text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
                             <i data-lucide="arrow-left" class="h-4 w-4"></i>
                         </a>
@@ -95,7 +95,7 @@
 
             <!-- 목록 영역 (AJAX로 교체되는 영역) -->
             <div id="itemListWrapper"
-                 th:attr="data-proposal-id=${view.proposalId}, data-position-id=${view.selectedPositionId}, data-status=${view.selectedStatus}">
+                 th:attr="data-proposal-id=${view.proposalId}, data-position-id=${view.selectedPositionId}, data-status=${view.selectedStatus}, data-back-url=${backUrl}">
                 <div th:replace="~{matching/fragments :: itemList}"></div>
             </div>
 
@@ -104,16 +104,11 @@
 
     <script th:inline="javascript">
         (function () {
-            const backUrl = document.referrer || '/client/dashboard';
-            const btnBack = document.getElementById('btnBack');
-            if (btnBack) btnBack.href = backUrl;
-        })();
-
-        (function () {
             const wrapper = document.getElementById('itemListWrapper');
             if (!wrapper) return;
 
             const proposalId = wrapper.dataset.proposalId;
+            const backUrl = wrapper.dataset.backUrl || '';
             let currentPositionId = wrapper.dataset.positionId || '';
             let currentStatus = wrapper.dataset.status || '';
 
@@ -121,6 +116,7 @@
                 const params = new URLSearchParams();
                 if (positionId) params.set('positionId', positionId);
                 if (status) params.set('status', status);
+                if (backUrl) params.set('backUrl', backUrl);
 
                 const url = `/proposals/${proposalId}/matchings/items?${params.toString()}`;
 

--- a/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,9 +74,53 @@ class MatchingControllerTest {
                         .with(authentication(authToken("client@example.com", "클라이언트"))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("matching/detail"))
+                .andExpect(model().attribute("backUrl", "/proposals/200/matchings"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "counterpart-profile?returnTo=/matchings/401?backUrl%3D/proposals/200/matchings")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("매칭 프로세스 현황")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("연락처 정보")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("프로젝트 요약")));
+    }
+
+    @Test
+    @DisplayName("매칭 상세 페이지는 전달된 로컬 backUrl을 우선 사용한다")
+    void renderMatchingDetailPageWithExplicitBackUrl() throws Exception {
+        given(matchingQueryService.getDetail(401L, "client@example.com"))
+                .willReturn(createMatchingDetailView());
+
+        mockMvc.perform(get("/matchings/401")
+                        .param("backUrl", "/client/dashboard?tab=matchings")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("backUrl", "/client/dashboard?tab=matchings"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "counterpart-profile?returnTo=/matchings/401?backUrl%3D/client/dashboard?tab%253Dmatchings")));
+    }
+
+    @Test
+    @DisplayName("매칭 상세 페이지는 외부 backUrl을 무시하고 기본 복귀 경로를 사용한다")
+    void renderMatchingDetailPageWithUnsafeBackUrl() throws Exception {
+        given(matchingQueryService.getDetail(401L, "client@example.com"))
+                .willReturn(createMatchingDetailView());
+
+        mockMvc.perform(get("/matchings/401")
+                        .param("backUrl", "https://example.com/outside")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("backUrl", "/proposals/200/matchings"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 정보가 비어 있어도 매칭 상세 페이지는 fallback 문구로 렌더링된다")
+    void renderMatchingDetailPageWhenProjectSummaryIsMissing() throws Exception {
+        given(matchingQueryService.getDetail(401L, "client@example.com"))
+                .willReturn(createMatchingDetailViewWithoutProject());
+
+        mockMvc.perform(get("/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/detail"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("연결된 제안서 요약을 불러오지 못했습니다.")));
     }
 
     @Test
@@ -92,12 +137,27 @@ class MatchingControllerTest {
     }
 
     @Test
-    @DisplayName("권한 없는 매칭 상세를 조회하면 홈으로 이동하며 오류 메시지를 남긴다")
+    @DisplayName("없는 매칭 상세를 조회하면 전달된 backUrl로 복귀하며 오류 메시지를 남긴다")
+    void redirectToBackUrlWhenMatchingDetailNotFound() throws Exception {
+        given(matchingQueryService.getDetail(999L, "client@example.com"))
+                .willThrow(new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=999"));
+
+        mockMvc.perform(get("/matchings/999")
+                        .param("backUrl", "/proposals/200/matchings?status=PROPOSED")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/200/matchings?status=PROPOSED"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 매칭입니다."));
+    }
+
+    @Test
+    @DisplayName("권한 없는 매칭 상세를 조회하면 외부 backUrl을 무시하고 홈으로 이동한다")
     void redirectHomeWhenMatchingDetailAccessDenied() throws Exception {
         given(matchingQueryService.getDetail(401L, "client@example.com"))
                 .willThrow(new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다."));
 
         mockMvc.perform(get("/matchings/401")
+                        .param("backUrl", "https://example.com/outside")
                         .with(authentication(authToken("client@example.com", "클라이언트"))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"))
@@ -488,6 +548,22 @@ class MatchingControllerTest {
                         false,
                         false
                 )
+        );
+    }
+
+    private MatchingDetailViewModel createMatchingDetailViewWithoutProject() {
+        MatchingDetailViewModel view = createMatchingDetailView();
+        return new MatchingDetailViewModel(
+                view.matchingId(),
+                view.viewerRole(),
+                view.status(),
+                view.contactVisible(),
+                view.header(),
+                view.summary(),
+                view.contacts(),
+                null,
+                view.timeline(),
+                view.lifecycle()
         );
     }
 }

--- a/src/test/java/com/generic4/itda/controller/MatchingEntryControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingEntryControllerTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -83,6 +84,57 @@ class MatchingEntryControllerTest {
         assertThat(view.items()).hasSize(3);
         assertThat(view.selectedPositionId()).isNull();
         assertThat(view.selectedStatus()).isNull();
+        assertThat(result.getModelAndView().getModel().get("backUrl")).isEqualTo("/proposals/10");
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?backUrl=/proposals/10");
+        assertThat(result.getResponse().getContentAsString()).contains("href=\"/proposals/10\"");
+        assertThat(result.getResponse().getContentAsString())
+                .contains("counterpart-profile?returnTo=/proposals/10/matchings?backUrl%3D/proposals/10");
+    }
+
+    @Test
+    @DisplayName("매칭 목록 페이지는 전달된 backUrl을 사용하고 상세 복귀 경로에도 유지한다")
+    void list_preservesProvidedBackUrl() throws Exception {
+        Proposal proposal = createProposalWithTwoPositions();
+        List<Matching> matchings = createMatchingsForBothPositions(proposal);
+
+        given(proposalService.findOwnedProposal(PROPOSAL_ID, CLIENT_EMAIL)).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(PROPOSAL_ID, CLIENT_EMAIL))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/{id}/matchings", PROPOSAL_ID)
+                        .param("backUrl", "/client/dashboard")
+                        .with(authentication(authToken(CLIENT_EMAIL, "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("matching/list"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "counterpart-profile?returnTo=/proposals/10/matchings?backUrl%3D/client/dashboard")))
+                .andReturn();
+
+        assertThat(result.getModelAndView().getModel().get("backUrl")).isEqualTo("/client/dashboard");
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?backUrl=/client/dashboard");
+    }
+
+    @Test
+    @DisplayName("외부 backUrl은 무시하고 제안서 상세로 복귀시킨다")
+    void list_ignoresExternalBackUrl() throws Exception {
+        Proposal proposal = createProposalWithTwoPositions();
+        List<Matching> matchings = createMatchingsForBothPositions(proposal);
+
+        given(proposalService.findOwnedProposal(PROPOSAL_ID, CLIENT_EMAIL)).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(PROPOSAL_ID, CLIENT_EMAIL))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/{id}/matchings", PROPOSAL_ID)
+                        .param("backUrl", "https://example.com/outside")
+                        .with(authentication(authToken(CLIENT_EMAIL, "클라이언트"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getModelAndView().getModel().get("backUrl")).isEqualTo("/proposals/10");
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?backUrl=/proposals/10");
     }
 
     @Test
@@ -328,6 +380,8 @@ class MatchingEntryControllerTest {
 
         assertThat(items).hasSize(1);
         assertThat(items.get(0).proposalPositionId()).isEqualTo(2L);
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?positionId=2&backUrl=/proposals/10");
     }
 
     @Test
@@ -354,6 +408,30 @@ class MatchingEntryControllerTest {
         assertThat(items).hasSize(1);
         assertThat(items.get(0).proposalPositionId()).isEqualTo(1L);
         assertThat(items.get(0).status()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?positionId=1&status=REJECTED&backUrl=/proposals/10");
+    }
+
+    @Test
+    @DisplayName("AJAX 아이템 요청은 전달된 부모 backUrl까지 포함한 상세 복귀 경로를 만든다")
+    void listItems_preservesParentBackUrlInDetailLink() throws Exception {
+        Proposal proposal = createProposalWithTwoPositions();
+        List<Matching> matchings = createMatchingsForBothPositions(proposal);
+
+        given(proposalService.findOwnedProposal(PROPOSAL_ID, CLIENT_EMAIL)).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(PROPOSAL_ID, CLIENT_EMAIL))
+                .willReturn(matchings);
+
+        MvcResult result = mockMvc.perform(get("/proposals/{id}/matchings/items", PROPOSAL_ID)
+                        .param("positionId", "1")
+                        .param("status", "PROPOSED")
+                        .param("backUrl", "/client/dashboard")
+                        .with(authentication(authToken(CLIENT_EMAIL, "클라이언트"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getModelAndView().getModel().get("detailBackUrl"))
+                .isEqualTo("/proposals/10/matchings?positionId=1&status=PROPOSED&backUrl=/client/dashboard");
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/MatchingProfileControllerTest.java
@@ -46,13 +46,13 @@ class MatchingProfileControllerTest {
     private MemberRepository memberRepository;
 
     @Test
-    @DisplayName("프리랜서 상대 프로필에서도 공통 프로젝트 요약이 렌더링된다")
+    @DisplayName("프리랜서 상대 프로필에서도 returnTo 기반 back 링크와 공통 프로젝트 요약이 렌더링된다")
     void renderCounterpartProfileWithSharedProjectSummary() throws Exception {
         given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
                 .willReturn(createFreelancerShellView(false));
 
         mockMvc.perform(get("/matchings/401/counterpart-profile")
-                        .param("backUrl", "/client/dashboard")
+                        .param("returnTo", "/client/dashboard")
                         .with(authentication(authToken("client@example.com", "클라이언트"))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("profile/shell"))
@@ -60,6 +60,21 @@ class MatchingProfileControllerTest {
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("요청 프로젝트 요약")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("AI 매칭 플랫폼")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("매칭 상태")));
+    }
+
+    @Test
+    @DisplayName("returnTo가 있으면 기존 backUrl보다 우선 적용한다")
+    void renderCounterpartProfilePrefersReturnToOverBackUrl() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willReturn(createFreelancerShellView(false));
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("returnTo", "/proposals/10/matchings")
+                        .param("backUrl", "/matchings/401")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("profile/shell"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("href=\"/proposals/10/matchings\"")));
     }
 
     @Test
@@ -85,10 +100,10 @@ class MatchingProfileControllerTest {
                 .willThrow(new IllegalArgumentException("매칭 정보를 찾을 수 없습니다. id=401"));
 
         mockMvc.perform(get("/matchings/401/counterpart-profile")
-                        .param("backUrl", "/matchings/401")
+                        .param("returnTo", "/proposals/10/matchings?status=PROPOSED")
                         .with(authentication(authToken("client@example.com", "클라이언트"))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/matchings/401"))
+                .andExpect(redirectedUrl("/proposals/10/matchings?status=PROPOSED"))
                 .andExpect(flash().attribute("errorMessage", "존재하지 않는 매칭입니다."));
     }
 
@@ -100,6 +115,21 @@ class MatchingProfileControllerTest {
 
         mockMvc.perform(get("/matchings/401/counterpart-profile")
                         .param("backUrl", "https://example.com/outside")
+                        .with(authentication(authToken("client@example.com", "클라이언트"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/matchings/401"))
+                .andExpect(flash().attribute("errorMessage", "해당 매칭 정보에 접근할 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("외부 returnTo는 무시하고 기존 내부 backUrl을 사용한다")
+    void redirectToLegacyBackUrlWhenReturnToIsUnsafe() throws Exception {
+        given(matchingProfileQueryService.getCounterpartProfile(401L, "client@example.com"))
+                .willThrow(new AccessDeniedException("해당 매칭 정보에 접근할 수 없습니다."));
+
+        mockMvc.perform(get("/matchings/401/counterpart-profile")
+                        .param("returnTo", "https://example.com/outside")
+                        .param("backUrl", "/matchings/401")
                         .with(authentication(authToken("client@example.com", "클라이언트"))))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/matchings/401"))


### PR DESCRIPTION
## 🔎 What

  - 매칭/프로필 화면의 뒤로가기 흐름을 진입 경로 기반으로 정리했습니다.
  - 매칭 리스트, 매칭 상세, 상대 프로필 진입 시 `backUrl`/`returnTo`를 전달하도록 수정했습니다.
  - 매칭 상세 조회 실패, 상대 프로필 조회 실패 시에도 안전한 내부 경로로 복귀하도록 redirect fallback을 보강했습니다.
  - 매칭 리스트에서 `프로필` CTA를 추가하고, 필터링 이후에도 현재 리스트 문맥이 상세/프로필 링크에 유지되도록 반영했습니다.
  - 외부 URL은 무시하고 내부 경로만 허용하도록 처리해 오픈 리다이렉트 가능성을 막았습니다.

  ## 🔗 Issue

  - Closes: #136

  ## ✅ 체크리스트

  - [x] 브랜치 base가 적절한가요?
  - [x] 제목이 이슈 제목과 동일한가요?
  - [x] 최소 1명의 리뷰를 받았나요?