### PR TITLE
[refactor] 추천 진행 페이지 탈출 UX 개선

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -1,5 +1,6 @@
 package com.generic4.itda.controller;
 
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
@@ -30,8 +31,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Slf4j
 public class RecommendationController {
 
+    private static final String RUN_STATUS_FROM_PARAM = "recommendation";
+
     private final RecommendationRunService recommendationRunService;
     private final RecommendationRunQueryService recommendationRunQueryService;
+
+    private static String buildRunStatusRedirectUrl(Long proposalId, Long runId) {
+        return "/proposals/" + proposalId + "/runs/" + runId + "?from=" + RUN_STATUS_FROM_PARAM;
+    }
 
     @GetMapping("/proposals/{proposalId}/recommendations")
     public String entry(
@@ -61,7 +68,7 @@ public class RecommendationController {
                     principal.getEmail()
             );
             return ResponseEntity.ok(Map.of(
-                    "redirect", "/proposals/" + proposalId + "/runs/" + runId
+                    "redirect", buildRunStatusRedirectUrl(proposalId, runId)
             ));
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
@@ -92,6 +99,7 @@ public class RecommendationController {
 
             redirectAttributes.addAttribute("runId", runId);
             redirectAttributes.addAttribute("proposalId", proposalId);
+            redirectAttributes.addAttribute("from", RUN_STATUS_FROM_PARAM);
             return "redirect:/proposals/{proposalId}/runs/{runId}";
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패. proposalId={}, proposalPositionId={}, email={}",
@@ -121,7 +129,7 @@ public class RecommendationController {
                     principal.getEmail()
             );
             return ResponseEntity.ok(Map.of(
-                    "redirect", "/proposals/" + proposalId + "/runs/" + runId
+                    "redirect", buildRunStatusRedirectUrl(proposalId, runId)
             ));
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추가 추천 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
@@ -146,6 +154,7 @@ public class RecommendationController {
 
             redirectAttributes.addAttribute("runId", runId);
             redirectAttributes.addAttribute("proposalId", proposalId);
+            redirectAttributes.addAttribute("from", RUN_STATUS_FROM_PARAM);
             return "redirect:/proposals/{proposalId}/runs/{runId}";
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추가 추천 요청 실패. proposalId={}, proposalPositionId={}, email={}",
@@ -160,14 +169,22 @@ public class RecommendationController {
     public String runStatus(
             @PathVariable Long proposalId,
             @PathVariable Long runId,
+            @RequestParam(name = "from", required = false) String from,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
+        String normalizedFrom = (from != null && !from.isBlank()) ? from : null;
+
         try {
             RecommendationRunStatusViewModel view = recommendationRunQueryService
                     .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
 
+            if (view.status() == RecommendationRunStatus.COMPUTED && normalizedFrom == null) {
+                return "redirect:" + view.nextActionUrl();
+            }
+
             model.addAttribute("view", view);
+            model.addAttribute("from", normalizedFrom);
             return "recommendation/status";
         } catch (IllegalArgumentException e) {
             log.warn("추천 실행 상태 조회 실패. proposalId={}, runId={}, email={}",

--- a/src/main/resources/templates/recommendation/status.html
+++ b/src/main/resources/templates/recommendation/status.html
@@ -68,7 +68,7 @@
 
                     <!-- 수동 새로고침 -->
                     <div class="mt-6">
-                        <a th:href="@{/proposals/{proposalId}/runs/{runId}(proposalId=${view.proposalId}, runId=${view.runId})}"
+                        <a th:href="@{/proposals/{proposalId}/runs/{runId}(proposalId=${view.proposalId}, runId=${view.runId}, from=${from})}"
                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">
                             <i data-lucide="refresh-cw" class="h-4 w-4"></i>
                             지금 새로고침
@@ -134,5 +134,20 @@
         </div>
     </main>
 </div>
+
+<th:block layout:fragment="scripts">
+    <th:block th:if="${view.status.name() == 'COMPUTED' and view.nextActionUrl != null}">
+        <script th:inline="javascript">
+            (function () {
+                var nextUrl = /*[[${view.nextActionUrl}]]*/ null;
+                if (!nextUrl) return;
+
+                setTimeout(function () {
+                    window.location.replace(nextUrl);
+                }, 500);
+            })();
+        </script>
+    </th:block>
+</th:block>
 </body>
 </html>

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -284,6 +284,78 @@ class RecommendationControllerTest {
     }
 
     @Test
+    @DisplayName("COMPUTED 상태로 진행 페이지 접근 시 결과 페이지로 리다이렉트한다")
+    void redirectToResultsWhenRunAlreadyComputed() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationRunStatusViewModel computedView = new RecommendationRunStatusViewModel(
+                PROPOSAL_ID, RUN_ID, "추천 테스트 제안서",
+                RecommendationRunStatus.COMPUTED,
+                "추천 결과가 준비되었습니다.",
+                "추천 결과 목록으로 이동할 수 있습니다.",
+                "결과 보기",
+                "/proposals/" + PROPOSAL_ID + "/recommendations/results?runId=" + RUN_ID,
+                false
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(computedView);
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/" + PROPOSAL_ID + "/recommendations/results?runId=" + RUN_ID));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태라도 from 파라미터가 있으면 status 화면을 렌더링한다")
+    void renderRunStatusWhenComputedAndFromParamPresent() throws Exception {
+        // given
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationRunStatusViewModel computedView = new RecommendationRunStatusViewModel(
+                PROPOSAL_ID, RUN_ID, "추천 테스트 제안서",
+                RecommendationRunStatus.COMPUTED,
+                "추천 결과가 준비되었습니다.",
+                "추천 결과 목록으로 이동할 수 있습니다.",
+                "결과 보기",
+                "/proposals/" + PROPOSAL_ID + "/recommendations/results?runId=" + RUN_ID,
+                false
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(computedView);
+
+        // when / then
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .param("from", "recommendation")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/status"))
+                .andExpect(model().attributeExists("view"))
+                .andExpect(model().attribute("from", "recommendation"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+    @Test
     @DisplayName("추천 실행 정보를 찾을 수 없으면 error 화면을 렌더링한다")
     void renderErrorWhenRunNotFound() throws Exception {
         // given
@@ -355,7 +427,7 @@ class RecommendationControllerTest {
                                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID));
+                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID + "?from=recommendation"));
 
         then(recommendationRunService).should()
                 .createOrReuse(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com"));
@@ -431,7 +503,7 @@ class RecommendationControllerTest {
                                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID));
+                .andExpect(jsonPath("$.redirect").value("/proposals/" + PROPOSAL_ID + "/runs/" + RUN_ID + "?from=recommendation"));
 
         then(recommendationRunService).should()
                 .createAdditional(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com"));


### PR DESCRIPTION
## 🔎 What


- [ ] 추천 진행 페이지에서 완료 여부를 판단하는 기준/응답값(상태 API 또는 모델 값) 확인
- [ ] 추천 “완료” 상태 감지 시 추천 결과 페이지로 자동 이동(프론트 폴링/이벤트에서 location.href 처리)
- [ ] 이미 완료된 추천을 진행 페이지로 접근한 경우 서버/컨트롤러에서 결과 페이지로 즉시 리다이렉트(재진입 UX)
- [ ] 실패/취소/타임아웃 등 예외 상태는 기존 메시지 유지 + 자동 이동하지 않기
- [ ] “결과보기” 버튼은 fallback으로 유지(자동 이동이 막힌 환경 대비) + 관련 컨트롤러 테스트 추가

## 🔗 Issue

- Closes: #134 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?