### PR TITLE
[Feat] 모집단위별 추천 실행 이력 조회 및 진입 흐름 추가

### DIFF
--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -208,7 +208,7 @@ public class RecommendationController {
             Model model
     ) {
         String requestedBackUrl = normalizeLocalPath(backUrl);
-        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true");
+        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId);
         String normalizedFrom = (from != null && !from.isBlank()) ? from : null;
 
         try {
@@ -216,7 +216,7 @@ public class RecommendationController {
                     .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
 
             if (view.status() == RecommendationRunStatus.COMPUTED && normalizedFrom == null) {
-                return "redirect:" + resolveRunStatusNextActionUrl(view, requestedBackUrl);
+                return "redirect:" + resolveRunStatusNextActionUrl(view, resolvedBackUrl);
             }
 
             model.addAttribute("view", view);
@@ -246,7 +246,7 @@ public class RecommendationController {
             Model model
     ) {
         String requestedBackUrl = normalizeLocalPath(backUrl);
-        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, buildRunStatusUrl(proposalId, runId, null));
+        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId);
 
         try {
             RecommendationResultsViewModel view = recommendationRunQueryService

--- a/src/main/java/com/generic4/itda/controller/RecommendationController.java
+++ b/src/main/java/com/generic4/itda/controller/RecommendationController.java
@@ -4,11 +4,14 @@ import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
 import com.generic4.itda.dto.recommend.RecommendationRequestForm;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
+import com.generic4.itda.dto.recommend.RecommendationRunHistoryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
 import jakarta.validation.Valid;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -36,8 +40,11 @@ public class RecommendationController {
     private final RecommendationRunService recommendationRunService;
     private final RecommendationRunQueryService recommendationRunQueryService;
 
-    private static String buildRunStatusRedirectUrl(Long proposalId, Long runId) {
-        return "/proposals/" + proposalId + "/runs/" + runId + "?from=" + RUN_STATUS_FROM_PARAM;
+    private static String buildRunStatusEntryUrl(Long proposalId, Long runId, String backUrl) {
+        if (StringUtils.hasText(backUrl)) {
+            return buildRunStatusUrl(proposalId, runId, backUrl);
+        }
+        return buildRunStatusUrl(proposalId, runId, null, RUN_STATUS_FROM_PARAM);
     }
 
     @GetMapping("/proposals/{proposalId}/recommendations")
@@ -48,6 +55,34 @@ public class RecommendationController {
         return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
     }
 
+    @GetMapping("/proposal-positions/{proposalPositionId}/recommendations/runs")
+    public String runHistory(
+            @PathVariable Long proposalPositionId,
+            @RequestParam Long proposalId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            Model model,
+            RedirectAttributes redirectAttributes
+    ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
+        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId);
+
+        try {
+            RecommendationRunHistoryViewModel view = recommendationRunQueryService
+                    .getRecommendationRunHistory(proposalId, proposalPositionId, principal.getEmail());
+
+            model.addAttribute("view", view);
+            model.addAttribute("backUrl", resolvedBackUrl);
+            model.addAttribute("currentUrl", buildRunHistoryUrl(proposalId, proposalPositionId, resolvedBackUrl));
+            return "recommendation/runs";
+        } catch (IllegalArgumentException e) {
+            log.warn("추천 실행 이력 조회 실패. proposalId={}, proposalPositionId={}, email={}",
+                    proposalId, proposalPositionId, principal.getEmail(), e);
+            redirectAttributes.addFlashAttribute("errorMessage", toRunHistoryUserMessage(e));
+            return redirectTo(requestedBackUrl, "/proposals/" + proposalId);
+        }
+    }
+
     /** 모달에서 fetch로 호출 — 성공: redirect URL 반환, 실패: 에러 메시지 반환 */
     @PostMapping(value = "/proposals/{proposalId}/recommendations", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
@@ -55,6 +90,7 @@ public class RecommendationController {
             @PathVariable Long proposalId,
             @Valid @ModelAttribute RecommendationRequestForm form,
             BindingResult bindingResult,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal
     ) {
         if (bindingResult.hasErrors()) {
@@ -68,7 +104,7 @@ public class RecommendationController {
                     principal.getEmail()
             );
             return ResponseEntity.ok(Map.of(
-                    "redirect", buildRunStatusRedirectUrl(proposalId, runId)
+                    "redirect", buildRunStatusEntryUrl(proposalId, runId, normalizeLocalPath(backUrl))
             ));
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
@@ -82,12 +118,14 @@ public class RecommendationController {
             @PathVariable Long proposalId,
             @Valid @ModelAttribute("requestForm") RecommendationRequestForm form,
             BindingResult bindingResult,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
         if (bindingResult.hasErrors()) {
             redirectAttributes.addFlashAttribute("errorMessage", "포지션을 선택해주세요.");
-            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
+            return redirectTo(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true");
         }
 
         try {
@@ -96,17 +134,13 @@ public class RecommendationController {
                     form.proposalPositionId(),
                     principal.getEmail()
             );
-
-            redirectAttributes.addAttribute("runId", runId);
-            redirectAttributes.addAttribute("proposalId", proposalId);
-            redirectAttributes.addAttribute("from", RUN_STATUS_FROM_PARAM);
-            return "redirect:/proposals/{proposalId}/runs/{runId}";
+            return "redirect:" + buildRunStatusEntryUrl(proposalId, runId, requestedBackUrl);
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 실행 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, form.proposalPositionId(), principal.getEmail(), e);
 
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
-            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
+            return redirectTo(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true");
         }
     }
 
@@ -120,6 +154,7 @@ public class RecommendationController {
     public ResponseEntity<Map<String, String>> moreAjax(
             @PathVariable Long proposalPositionId,
             @RequestParam Long proposalId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal
     ) {
         try {
@@ -129,7 +164,7 @@ public class RecommendationController {
                     principal.getEmail()
             );
             return ResponseEntity.ok(Map.of(
-                    "redirect", buildRunStatusRedirectUrl(proposalId, runId)
+                    "redirect", buildRunStatusEntryUrl(proposalId, runId, normalizeLocalPath(backUrl))
             ));
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추가 추천 요청 실패(AJAX). proposalId={}, proposalPositionId={}, email={}",
@@ -142,26 +177,24 @@ public class RecommendationController {
     public String more(
             @PathVariable Long proposalPositionId,
             @RequestParam Long proposalId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
         try {
             Long runId = recommendationRunService.createAdditional(
                     proposalId,
                     proposalPositionId,
                     principal.getEmail()
             );
-
-            redirectAttributes.addAttribute("runId", runId);
-            redirectAttributes.addAttribute("proposalId", proposalId);
-            redirectAttributes.addAttribute("from", RUN_STATUS_FROM_PARAM);
-            return "redirect:/proposals/{proposalId}/runs/{runId}";
+            return "redirect:" + buildRunStatusEntryUrl(proposalId, runId, requestedBackUrl);
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추가 추천 요청 실패. proposalId={}, proposalPositionId={}, email={}",
                     proposalId, proposalPositionId, principal.getEmail(), e);
 
             redirectAttributes.addFlashAttribute("errorMessage", toUserMessage(e));
-            return "redirect:/proposals/" + proposalId + "?openRecommendModal=true";
+            return redirectTo(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true");
         }
     }
 
@@ -169,10 +202,13 @@ public class RecommendationController {
     public String runStatus(
             @PathVariable Long proposalId,
             @PathVariable Long runId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @RequestParam(name = "from", required = false) String from,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
+        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true");
         String normalizedFrom = (from != null && !from.isBlank()) ? from : null;
 
         try {
@@ -180,11 +216,14 @@ public class RecommendationController {
                     .getRecommendationRunStatus(proposalId, runId, principal.getEmail());
 
             if (view.status() == RecommendationRunStatus.COMPUTED && normalizedFrom == null) {
-                return "redirect:" + view.nextActionUrl();
+                return "redirect:" + resolveRunStatusNextActionUrl(view, requestedBackUrl);
             }
 
             model.addAttribute("view", view);
             model.addAttribute("from", normalizedFrom);
+            model.addAttribute("backUrl", resolvedBackUrl);
+            model.addAttribute("refreshUrl", buildRunStatusUrl(proposalId, runId, requestedBackUrl, normalizedFrom));
+            model.addAttribute("nextActionUrl", resolveRunStatusNextActionUrl(view, resolvedBackUrl));
             return "recommendation/status";
         } catch (IllegalArgumentException e) {
             log.warn("추천 실행 상태 조회 실패. proposalId={}, runId={}, email={}",
@@ -192,7 +231,7 @@ public class RecommendationController {
 
             model.addAttribute("title", "추천 실행 정보를 확인할 수 없습니다.");
             model.addAttribute("message", toRunStatusUserMessage(e));
-            model.addAttribute("backUrl", "/proposals/" + proposalId + "?openRecommendModal=true");
+            model.addAttribute("backUrl", resolvedBackUrl);
 
             return "recommendation/error";
         }
@@ -202,14 +241,20 @@ public class RecommendationController {
     public String results(
             @PathVariable Long proposalId,
             @RequestParam Long runId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
+        String resolvedBackUrl = resolveBackUrl(requestedBackUrl, buildRunStatusUrl(proposalId, runId, null));
+
         try {
             RecommendationResultsViewModel view = recommendationRunQueryService
                     .getRecommendationResults(proposalId, runId, principal.getEmail());
 
             model.addAttribute("view", view);
+            model.addAttribute("backUrl", resolvedBackUrl);
+            model.addAttribute("currentUrl", buildResultsUrl(proposalId, runId, resolvedBackUrl));
             return "recommendation/results";
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 결과 조회 실패. proposalId={}, runId={}, email={}",
@@ -217,7 +262,7 @@ public class RecommendationController {
 
             model.addAttribute("title", "추천 결과를 확인할 수 없습니다.");
             model.addAttribute("message", toResultsUserMessage(e));
-            model.addAttribute("backUrl", "/proposals/" + proposalId + "/runs/" + runId);
+            model.addAttribute("backUrl", resolvedBackUrl);
             return "recommendation/error";
         }
     }
@@ -226,14 +271,18 @@ public class RecommendationController {
     public String candidateResume(
             @PathVariable Long proposalId,
             @PathVariable Long resultId,
+            @RequestParam(name = "backUrl", required = false) String backUrl,
             @AuthenticationPrincipal ItDaPrincipal principal,
             Model model
     ) {
+        String requestedBackUrl = normalizeLocalPath(backUrl);
+
         try {
             RecommendationResumeDetailViewModel view = recommendationRunQueryService
                     .getRecommendationCandidateResume(proposalId, resultId, principal.getEmail());
 
             model.addAttribute("view", view);
+            model.addAttribute("backUrl", buildResultsUrl(proposalId, view.runId(), requestedBackUrl));
             return "recommendation/resume";
         } catch (IllegalArgumentException | IllegalStateException e) {
             log.warn("추천 후보 이력서 조회 실패. proposalId={}, resultId={}, email={}",
@@ -241,7 +290,7 @@ public class RecommendationController {
 
             model.addAttribute("title", "추천 후보 이력서를 확인할 수 없습니다.");
             model.addAttribute("message", toResultsUserMessage(e));
-            model.addAttribute("backUrl", "/proposals/" + proposalId + "?openRecommendModal=true");
+            model.addAttribute("backUrl", resolveBackUrl(requestedBackUrl, "/proposals/" + proposalId + "?openRecommendModal=true"));
             return "recommendation/error";
         }
     }
@@ -270,5 +319,90 @@ public class RecommendationController {
             case "접근 권한이 없습니다." -> "해당 추천 실행 정보에 접근할 수 없습니다.";
             default -> "추천 실행 정보를 불러오는 중 문제가 발생했습니다.";
         };
+    }
+
+    private static String toRunHistoryUserMessage(IllegalArgumentException e) {
+        return switch (e.getMessage()) {
+            case "존재하지 않는 제안서입니다." -> "존재하지 않는 제안서입니다.";
+            case "해당 제안서에 속한 모집 포지션이 아닙니다." -> "해당 제안서의 모집단위를 다시 확인해주세요.";
+            case "접근 권한이 없습니다." -> "본인 제안서의 추천 실행 이력만 조회할 수 있습니다.";
+            default -> "추천 실행 이력을 불러오는 중 문제가 발생했습니다.";
+        };
+    }
+
+    private static String resolveRunStatusNextActionUrl(RecommendationRunStatusViewModel view, String backUrl) {
+        return switch (view.status()) {
+            case PENDING, RUNNING -> buildRunStatusUrl(view.proposalId(), view.runId(), backUrl);
+            case COMPUTED -> buildResultsUrl(view.proposalId(), view.runId(), backUrl);
+            case FAILED -> view.nextActionUrl();
+        };
+    }
+
+    private static String buildRunHistoryUrl(Long proposalId, Long proposalPositionId, String backUrl) {
+        String url = "/proposal-positions/%d/recommendations/runs?proposalId=%d"
+                .formatted(proposalPositionId, proposalId);
+        if (!StringUtils.hasText(backUrl)) {
+            return url;
+        }
+        return url + "&backUrl=" + encodeParam(backUrl);
+    }
+
+    private static String buildRunStatusUrl(Long proposalId, Long runId, String backUrl) {
+        return buildRunStatusUrl(proposalId, runId, backUrl, null);
+    }
+
+    private static String buildRunStatusUrl(Long proposalId, Long runId, String backUrl, String from) {
+        StringBuilder url = new StringBuilder("/proposals/%d/runs/%d".formatted(proposalId, runId));
+        boolean hasQuery = false;
+
+        if (StringUtils.hasText(backUrl)) {
+            url.append("?backUrl=").append(encodeParam(backUrl));
+            hasQuery = true;
+        }
+
+        if (StringUtils.hasText(from)) {
+            url.append(hasQuery ? "&" : "?")
+                    .append("from=")
+                    .append(encodeParam(from));
+        }
+
+        return url.toString();
+    }
+
+    private static String buildResultsUrl(Long proposalId, Long runId, String backUrl) {
+        String url = "/proposals/%d/recommendations/results?runId=%d".formatted(proposalId, runId);
+        if (!StringUtils.hasText(backUrl)) {
+            return url;
+        }
+        return url + "&backUrl=" + encodeParam(backUrl);
+    }
+
+    private static String resolveBackUrl(String requestedBackUrl, String fallback) {
+        return requestedBackUrl != null ? requestedBackUrl : fallback;
+    }
+
+    private static String normalizeLocalPath(String candidate) {
+        if (!StringUtils.hasText(candidate)) {
+            return null;
+        }
+
+        String trimmed = candidate.trim();
+        int duplicateValueSeparator = trimmed.indexOf(",/");
+        if (duplicateValueSeparator > 0) {
+            trimmed = trimmed.substring(0, duplicateValueSeparator);
+        }
+
+        if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+            return trimmed;
+        }
+        return null;
+    }
+
+    private static String redirectTo(String requestedBackUrl, String fallback) {
+        return "redirect:" + resolveBackUrl(requestedBackUrl, fallback);
+    }
+
+    private static String encodeParam(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunHistoryItemViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunHistoryItemViewModel.java
@@ -1,0 +1,22 @@
+package com.generic4.itda.dto.recommend;
+
+import com.generic4.itda.domain.recommendation.constant.RecommendationRunStatus;
+import java.time.LocalDateTime;
+
+public record RecommendationRunHistoryItemViewModel(
+        Long runId,
+        RecommendationRunStatus status,
+        String statusLabel,
+        Integer candidateCount,
+        int topK,
+        LocalDateTime requestedAt,
+        LocalDateTime updatedAt
+) {
+    public boolean completed() {
+        return status == RecommendationRunStatus.COMPUTED;
+    }
+
+    public boolean processing() {
+        return status == RecommendationRunStatus.PENDING || status == RecommendationRunStatus.RUNNING;
+    }
+}

--- a/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunHistoryViewModel.java
+++ b/src/main/java/com/generic4/itda/dto/recommend/RecommendationRunHistoryViewModel.java
@@ -1,0 +1,19 @@
+package com.generic4.itda.dto.recommend;
+
+import java.util.List;
+
+public record RecommendationRunHistoryViewModel(
+        Long proposalId,
+        Long proposalPositionId,
+        String proposalTitle,
+        String positionTitle,
+        String positionStatusName,
+        String positionStatusLabel,
+        boolean runnable,
+        String helperMessage,
+        List<RecommendationRunHistoryItemViewModel> runs
+) {
+    public boolean hasRuns() {
+        return runs != null && !runs.isEmpty();
+    }
+}

--- a/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
+++ b/src/main/java/com/generic4/itda/repository/RecommendationRunRepository.java
@@ -22,6 +22,8 @@ public interface RecommendationRunRepository extends JpaRepository<Recommendatio
             RecommendationAlgorithm algorithm
     );
 
+    List<RecommendationRun> findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(Long proposalPositionId);
+
     @Query("""
             select rr
             from RecommendationRun rr

--- a/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
+++ b/src/main/java/com/generic4/itda/service/recommend/RecommendationRunQueryService.java
@@ -4,6 +4,8 @@ import com.generic4.itda.domain.matching.constant.MatchingStatus;
 import com.generic4.itda.domain.member.Member;
 import com.generic4.itda.domain.proposal.Proposal;
 import com.generic4.itda.domain.proposal.ProposalPosition;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
+import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.recommendation.RecommendationResult;
 import com.generic4.itda.domain.recommendation.RecommendationRun;
 import com.generic4.itda.domain.recommendation.constant.LlmStatus;
@@ -15,9 +17,12 @@ import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
+import com.generic4.itda.dto.recommend.RecommendationRunHistoryItemViewModel;
+import com.generic4.itda.dto.recommend.RecommendationRunHistoryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.matching.LatestMatchingSummary;
 import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
@@ -34,9 +39,43 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RecommendationRunQueryService {
 
+    private final ProposalRepository proposalRepository;
     private final RecommendationRunRepository recommendationRunRepository;
     private final RecommendationResultRepository recommendationResultRepository;
     private final MatchingRepository matchingRepository;
+
+    public RecommendationRunHistoryViewModel getRecommendationRunHistory(Long proposalId, Long proposalPositionId, String email) {
+        Proposal proposal = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 제안서입니다."));
+
+        validateOwnership(proposal, email);
+
+        ProposalPosition proposalPosition = proposal.getPositions().stream()
+                .filter(position -> position.getId().equals(proposalPositionId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 제안서에 속한 모집 포지션이 아닙니다."));
+
+        List<RecommendationRunHistoryItemViewModel> runs = recommendationRunRepository
+                .findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(proposalPositionId)
+                .stream()
+                .map(this::toRunHistoryItem)
+                .toList();
+
+        boolean runnable = proposal.getStatus() == ProposalStatus.MATCHING
+                && proposalPosition.getStatus() == ProposalPositionStatus.OPEN;
+
+        return new RecommendationRunHistoryViewModel(
+                proposal.getId(),
+                proposalPosition.getId(),
+                proposal.getTitle(),
+                resolvePositionTitle(proposalPosition),
+                proposalPosition.getStatus().name(),
+                proposalPosition.getStatus().getDescription(),
+                runnable,
+                buildRunHistoryHelperMessage(proposal, proposalPosition, runs.isEmpty()),
+                runs
+        );
+    }
 
     public RecommendationRunStatusViewModel getRecommendationRunStatus(Long proposalId, Long runId, String email) {
         RecommendationRun run = recommendationRunRepository.findDetailById(runId)
@@ -187,6 +226,18 @@ public class RecommendationRunQueryService {
         );
     }
 
+    private RecommendationRunHistoryItemViewModel toRunHistoryItem(RecommendationRun run) {
+        return new RecommendationRunHistoryItemViewModel(
+                run.getId(),
+                run.getStatus(),
+                run.getStatus().getDescription(),
+                run.getCandidateCount(),
+                run.getTopK(),
+                run.getCreatedAt(),
+                run.getModifiedAt()
+        );
+    }
+
     private static String maskName(String name) {
         if (name == null || name.length() <= 1) return name;
         if (name.length() == 2) return name.charAt(0) + "*";
@@ -251,6 +302,19 @@ public class RecommendationRunQueryService {
         if (!proposal.getMember().getEmail().getValue().equals(email)) {
             throw new IllegalArgumentException("접근 권한이 없습니다.");
         }
+    }
+
+    private String buildRunHistoryHelperMessage(Proposal proposal, ProposalPosition proposalPosition, boolean empty) {
+        if (proposal.getStatus() != ProposalStatus.MATCHING) {
+            return "제안서가 MATCHING 상태일 때만 새로운 추천을 실행할 수 있습니다.";
+        }
+        if (proposalPosition.getStatus() != ProposalPositionStatus.OPEN) {
+            return "OPEN 상태의 모집 포지션만 새로운 추천을 실행할 수 있습니다.";
+        }
+        if (empty) {
+            return "아직 추천 실행 이력이 없습니다. 첫 추천을 실행해보세요.";
+        }
+        return "이전 추천 실행을 확인하거나 새 추천을 실행할 수 있습니다.";
     }
 
     private RecommendationRunStatusViewModel toViewModel(

--- a/src/main/resources/templates/fragments/proposalDetailFragments.html
+++ b/src/main/resources/templates/fragments/proposalDetailFragments.html
@@ -1,44 +1,52 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
-    <th:block th:fragment="positionCard(pos, viewerRole, matchingByPositionId)">
+<th:block th:fragment="positionCard(pos, viewerRole, matchingByPositionId)">
 
-        <div class="flex flex-wrap items-start justify-between gap-4">
-            <div class="space-y-1">
-                <h4 class="text-lg font-bold tracking-tight text-slate-900"
-                    th:text="${pos.title}">Node.js 백엔드 개발자</h4>
-                <div class="flex items-center gap-2">
-                    <p class="text-base font-medium text-slate-500"
-                       th:text="${pos.position.name}">백엔드 개발자</p>
-                    <!-- 포지션 모집 상태 배지 -->
-                    <span th:classappend="${
+  <div class="flex flex-wrap items-start justify-between gap-4">
+    <div class="space-y-1">
+      <h4 class="text-lg font-bold tracking-tight text-slate-900"
+          th:text="${pos.title}">Node.js 백엔드 개발자</h4>
+      <div class="flex items-center gap-2">
+        <p class="text-base font-medium text-slate-500"
+           th:text="${pos.position.name}">백엔드 개발자</p>
+        <!-- 포지션 모집 상태 배지 -->
+        <span th:classappend="${
                               pos.status.name() == 'OPEN'   ? 'border-blue-200 bg-blue-50 text-blue-600' :
                               (pos.status.name() == 'FULL'  ? 'border-amber-200 bg-amber-50 text-amber-600' :
                                                                'border-slate-200 bg-slate-100 text-slate-500')
                           }"
-                          class="inline-flex rounded-full border px-3 py-1 text-xs font-semibold"
-                          th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
+              class="inline-flex rounded-full border px-3 py-1 text-xs font-semibold"
+              th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">
                         모집 중
                     </span>
-                </div>
-            </div>
+      </div>
+    </div>
 
-            <div class="flex flex-wrap items-center gap-2">
+    <div class="flex flex-wrap items-center gap-2">
 
-                <!-- 클라이언트: 해당 포지션 매칭 결과 바로가기 (매칭이 존재하는 포지션에만 표시) -->
-                <a th:if="${viewerRole != 'FREELANCER' and positionsWithMatchings != null and positionsWithMatchings.contains(pos.id)}"
-                   th:href="@{/proposals/{id}/matchings(id=${pos.proposal.id}, positionId=${pos.id}, backUrl=${'/proposals/' + pos.proposal.id})}"
-                   class="inline-flex items-center gap-2 rounded-2xl border border-blue-600 bg-white px-5 py-3 text-sm font-bold text-blue-600 transition hover:bg-blue-600 hover:text-white">
-                    <i data-lucide="users" class="h-4 w-4"></i>
-                    매칭 결과 보기
-                </a>
+      <a th:if="${viewerRole != 'FREELANCER' and pos.proposal.status.name() == 'MATCHING'}"
+         th:href="@{/proposal-positions/{proposalPositionId}/recommendations/runs(proposalPositionId=${pos.id}, proposalId=${pos.proposal.id}, backUrl=${'/proposals/' + pos.proposal.id})}"
+         class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+        <i data-lucide="sparkles" class="h-4 w-4"></i>
+        추천 결과 보기
+      </a>
 
-                <!-- 프리랜서: 이 포지션에 매칭 요청이 온 경우 상태 배지 (수락/거절은 상단 액션바에서 처리) -->
-                <th:block th:if="${viewerRole == 'FREELANCER' and matchingByPositionId != null and matchingByPositionId[pos.id] != null}">
-                    <th:block th:with="myMatching=${matchingByPositionId[pos.id]}">
-                        <!-- 매칭 상태 배지 -->
-                        <span th:classappend="${
+      <!-- 클라이언트: 해당 포지션 매칭 결과 바로가기 (매칭이 존재하는 포지션에만 표시) -->
+      <a th:if="${viewerRole != 'FREELANCER' and positionsWithMatchings != null and positionsWithMatchings.contains(pos.id)}"
+         th:href="@{/proposals/{id}/matchings(id=${pos.proposal.id}, positionId=${pos.id}, backUrl=${'/proposals/' + pos.proposal.id})}"
+         class="inline-flex items-center gap-2 rounded-2xl border border-blue-600 bg-white px-5 py-3 text-sm font-bold text-blue-600 transition hover:bg-blue-600 hover:text-white">
+        <i data-lucide="users" class="h-4 w-4"></i>
+        매칭 결과 보기
+      </a>
+
+      <!-- 프리랜서: 이 포지션에 매칭 요청이 온 경우 상태 배지 (수락/거절은 상단 액션바에서 처리) -->
+      <th:block
+          th:if="${viewerRole == 'FREELANCER' and matchingByPositionId != null and matchingByPositionId[pos.id] != null}">
+        <th:block th:with="myMatching=${matchingByPositionId[pos.id]}">
+          <!-- 매칭 상태 배지 -->
+          <span th:classappend="${
                                   myMatching.status.name() == 'PROPOSED'    ? 'border-yellow-200 bg-yellow-50 text-yellow-700' :
                                   (myMatching.status.name() == 'ACCEPTED'   ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
                                   (myMatching.status.name() == 'REJECTED'   ? 'border-red-200 bg-red-50 text-red-600' :
@@ -46,113 +54,115 @@
                                   (myMatching.status.name() == 'COMPLETED'  ? 'border-slate-200 bg-slate-100 text-slate-600' :
                                                                                'border-slate-200 bg-slate-100 text-slate-500'))))
                               }"
-                              class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold"
-                              th:text="${myMatching.status.description}">
+                class="inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-xs font-bold"
+                th:text="${myMatching.status.description}">
                             제안됨
                         </span>
-                    </th:block>
-                </th:block>
-            </div>
-        </div>
+        </th:block>
+      </th:block>
+    </div>
+  </div>
 
-        <!-- 수치 정보 -->
-        <div class="mt-5 grid gap-4 sm:grid-cols-3">
-            <div>
-                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">인원</p>
-                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
-                    <span th:text="${pos.headCount != null ? pos.headCount + '명' : '미정'}">1명</span>
-                </p>
-            </div>
-            <div>
-                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산 (인당)</p>
-                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
+  <!-- 수치 정보 -->
+  <div class="mt-5 grid gap-4 sm:grid-cols-3">
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">인원</p>
+      <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
+        <span th:text="${pos.headCount != null ? pos.headCount + '명' : '미정'}">1명</span>
+      </p>
+    </div>
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">예산 (인당)</p>
+      <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900">
                     <span th:if="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}"
                           th:text="${#numbers.formatInteger(pos.unitBudgetMin, 3, 'COMMA') + ' ~ ' + #numbers.formatInteger(pos.unitBudgetMax, 3, 'COMMA') + '원'}">
                         3,000,000 ~ 4,000,000원
                     </span>
-                    <span th:unless="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}">미정</span>
-                </p>
-            </div>
-            <div>
-                <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">기간</p>
-                <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900"
-                   th:text="${pos.expectedPeriod != null ? pos.expectedPeriod + '주' : '미정'}">4주</p>
-            </div>
-        </div>
+        <span th:unless="${pos.unitBudgetMin != null and pos.unitBudgetMax != null}">미정</span>
+      </p>
+    </div>
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">기간</p>
+      <p class="mt-1.5 text-lg font-bold tracking-tight text-slate-900"
+         th:text="${pos.expectedPeriod != null ? pos.expectedPeriod + '주' : '미정'}">4주</p>
+    </div>
+  </div>
 
-        <!-- 상세 정보 -->
-        <div class="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+  <!-- 상세 정보 -->
+  <div class="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
 
-            <!-- 스킬 영역 -->
-            <div class="space-y-4">
-                <!-- 필수 스킬 -->
-                <div>
-                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                        <th:block th:each="skill : ${pos.skills}">
+    <!-- 스킬 영역 -->
+    <div class="space-y-4">
+      <!-- 필수 스킬 -->
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">필수 기술</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <th:block th:each="skill : ${pos.skills}">
                             <span th:if="${skill.importance.name() == 'ESSENTIAL'}"
                                   class="rounded-full border border-blue-100 bg-blue-50 px-3 py-1.5 text-sm font-semibold text-blue-600"
                                   th:text="${skill.skill.name}">React</span>
-                        </th:block>
-                        <span th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'ESSENTIAL'])}"
-                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
-                        <span th:if="${#lists.isEmpty(pos.skills)}"
-                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
-                    </div>
-                </div>
+          </th:block>
+          <span
+              th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'ESSENTIAL'])}"
+              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+          <span th:if="${#lists.isEmpty(pos.skills)}"
+                class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+        </div>
+      </div>
 
-                <!-- 우대 스킬 -->
-                <div>
-                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                        <th:block th:each="skill : ${pos.skills}">
+      <!-- 우대 스킬 -->
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">우대 기술</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <th:block th:each="skill : ${pos.skills}">
                             <span th:if="${skill.importance.name() == 'PREFERENCE'}"
                                   class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700"
                                   th:text="${skill.skill.name}">TypeScript</span>
-                        </th:block>
-                        <span th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'PREFERENCE'])}"
-                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
-                        <span th:if="${#lists.isEmpty(pos.skills)}"
-                              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
-                    </div>
-                </div>
-            </div>
+          </th:block>
+          <span
+              th:if="${!#lists.isEmpty(pos.skills) and #lists.isEmpty(pos.skills.?[importance.name() == 'PREFERENCE'])}"
+              class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+          <span th:if="${#lists.isEmpty(pos.skills)}"
+                class="rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-sm text-slate-400">없음</span>
+        </div>
+      </div>
+    </div>
 
-            <!-- 근무 조건 카드 -->
-            <div class="rounded-[24px] border border-white bg-white px-5 py-5">
-                <div class="grid gap-4 sm:grid-cols-2">
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
-                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
-                           th:text="${pos.workType != null ? pos.workType.description : '미정'}">원격</p>
-                    </div>
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무지</p>
-                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
-                           th:text="${#strings.isEmpty(pos.workPlace) ? '미정' : pos.workPlace}">서울 강남구</p>
-                    </div>
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">경력 범위</p>
-                        <p class="mt-1.5 text-sm font-semibold text-slate-800">
+    <!-- 근무 조건 카드 -->
+    <div class="rounded-[24px] border border-white bg-white px-5 py-5">
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무 형태</p>
+          <p class="mt-1.5 text-sm font-semibold text-slate-800"
+             th:text="${pos.workType != null ? pos.workType.description : '미정'}">원격</p>
+        </div>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">근무지</p>
+          <p class="mt-1.5 text-sm font-semibold text-slate-800"
+             th:text="${#strings.isEmpty(pos.workPlace) ? '미정' : pos.workPlace}">서울 강남구</p>
+        </div>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">경력 범위</p>
+          <p class="mt-1.5 text-sm font-semibold text-slate-800">
                             <span th:if="${pos.careerMinYears != null and pos.careerMaxYears != null}"
                                   th:text="${pos.careerMinYears + '년 ~ ' + pos.careerMaxYears + '년'}">3년 ~ 5년</span>
-                            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears == null}"
-                                  th:text="${pos.careerMinYears + '년 이상'}">3년 이상</span>
-                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears != null}"
-                                  th:text="${pos.careerMaxYears + '년 이하'}">5년 이하</span>
-                            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears == null}">미정</span>
-                        </p>
-                    </div>
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">모집 상태</p>
-                        <p class="mt-1.5 text-sm font-semibold text-slate-800"
-                           th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
-                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">모집 중</p>
-                    </div>
-                </div>
-            </div>
+            <span th:if="${pos.careerMinYears != null and pos.careerMaxYears == null}"
+                  th:text="${pos.careerMinYears + '년 이상'}">3년 이상</span>
+            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears != null}"
+                  th:text="${pos.careerMaxYears + '년 이하'}">5년 이하</span>
+            <span th:if="${pos.careerMinYears == null and pos.careerMaxYears == null}">미정</span>
+          </p>
         </div>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">모집 상태</p>
+          <p class="mt-1.5 text-sm font-semibold text-slate-800"
+             th:text="${pos.status.name() == 'OPEN' ? '모집 중' :
+                                      (pos.status.name() == 'FULL' ? '정원 충족' : '모집 종료')}">모집 중</p>
+        </div>
+      </div>
+    </div>
+  </div>
 
-    </th:block>
+</th:block>
 </body>
 </html>

--- a/src/main/resources/templates/recommendation/results.html
+++ b/src/main/resources/templates/recommendation/results.html
@@ -16,7 +16,7 @@
       <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
 
         <div class="flex items-center gap-4">
-          <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+          <a th:href="${backUrl}"
              class="flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700">
             <i data-lucide="arrow-left" class="h-4 w-4"></i>
           </a>
@@ -38,6 +38,7 @@
           <form th:action="@{/proposal-positions/{id}/recommendations/more(id=${view.proposalPositionId()})}"
                 th:method="post">
             <input type="hidden" name="proposalId" th:value="${view.proposalId()}"/>
+            <input type="hidden" name="backUrl" th:value="${currentUrl}"/>
             <button
                 class="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50">
               <i data-lucide="refresh-cw" class="h-3.5 w-3.5"></i>
@@ -102,7 +103,7 @@
             <article th:each="candidate : ${view.candidates}"
                      th:classappend="${candidate.matchingStatus == 'REJECTED' or candidate.matchingStatus == 'COMPLETED' or candidate.matchingStatus == 'CANCELED'} ? 'opacity-60' : ''"
                      class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-200/50 transition-all hover:border-slate-300 hover:shadow-md">
-              <a th:href="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${candidate.resultId})}"
+              <a th:href="@{/proposals/{proposalId}/recommendations/results/{resultId}(proposalId=${view.proposalId}, resultId=${candidate.resultId}, backUrl=${backUrl})}"
                  class="block focus:outline-none">
 
                 <!-- ── 카드 상단: 이름 + 스킬 + 점수 ── -->
@@ -174,9 +175,9 @@
                                           method="post">
                                         <input type="hidden" name="_csrf" th:value="${_csrf.token}">
                                         <input type="hidden" name="redirectTo"
-                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                               th:value="${currentUrl}">
                                         <input type="hidden" name="errorRedirectTo"
-                                               th:value="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${view.runId})}">
+                                               th:value="${currentUrl}">
                                         <button type="submit"
                                                 class="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-blue-700">
                                             <i data-lucide="send" class="h-4 w-4"></i>

--- a/src/main/resources/templates/recommendation/resume.html
+++ b/src/main/resources/templates/recommendation/resume.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-  <main class="min-h-screen bg-slate-50" th:with="profile=${view.profile()}">
+  <main class="min-h-screen bg-slate-50" th:with="profile=${view.profile().withBackUrl(backUrl)}">
 
     <th:block th:replace="~{fragments/profileFragments :: profileHeader(profile=${profile})}"></th:block>
     <th:block th:replace="~{fragments/profileFragments :: profileAlerts}"></th:block>

--- a/src/main/resources/templates/recommendation/runs.html
+++ b/src/main/resources/templates/recommendation/runs.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+  <title th:text="${view.proposalTitle} + ' | 추천 실행 이력'">추천 실행 이력 | IT-da</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <main class="min-h-screen bg-slate-50 px-4 py-6 lg:px-8 lg:py-8">
+    <div class="mx-auto max-w-6xl">
+
+      <section th:if="${errorMessage != null}"
+               class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+        <p th:text="${errorMessage}">오류 메시지</p>
+      </section>
+      <section th:if="${noticeMessage != null}"
+               class="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+        <p th:text="${noticeMessage}">안내 메시지</p>
+      </section>
+
+      <div
+          class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <div class="flex items-center gap-4">
+            <a th:href="${backUrl}"
+               class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+              <i data-lucide="arrow-left" class="h-4 w-4"></i>
+              제안서로
+            </a>
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation History</p>
+              <h1 class="mt-1 text-2xl font-black tracking-tight text-slate-950 sm:text-3xl"
+                  th:text="${view.positionTitle}">백엔드 개발자</h1>
+              <p class="mt-1 text-sm text-slate-500"
+                 th:text="${view.proposalTitle} + ' · 추천 실행 이력'">제안서 제목 · 추천 실행 이력</p>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-3">
+                        <span th:classappend="${view.positionStatusName == 'OPEN'} ? 'border-blue-200 bg-blue-50 text-blue-600' :
+                                              (${view.positionStatusName == 'FULL'} ? 'border-amber-200 bg-amber-50 text-amber-600' :
+                                                                                      'border-slate-200 bg-slate-100 text-slate-500')"
+                              class="inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-bold"
+                              th:text="${view.positionStatusLabel}">모집 중</span>
+
+            <form th:if="${view.runnable}"
+                  th:action="@{/proposal-positions/{proposalPositionId}/recommendations/more(proposalPositionId=${view.proposalPositionId})}"
+                  method="post">
+              <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+              <input type="hidden" name="proposalPositionId" th:value="${view.proposalPositionId}">
+              <input type="hidden" name="backUrl" th:value="${currentUrl}">
+              <input type="hidden" name="proposalId" th:value="${view.proposalId}">
+              <button type="submit"
+                      class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                <i data-lucide="sparkles" class="h-4 w-4"></i>
+                추가추천받기
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <section class="mb-6 rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-sm shadow-slate-200/60">
+        <p class="text-sm leading-relaxed text-slate-600" th:text="${view.helperMessage}">
+          이전 추천 실행을 확인하거나 새 추천을 실행할 수 있습니다.
+        </p>
+      </section>
+
+      <section th:if="${!view.hasRuns()}"
+               class="rounded-[32px] border border-dashed border-slate-200 bg-white px-6 py-16 text-center shadow-sm shadow-slate-200/40">
+        <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl bg-slate-100 text-slate-400">
+          <i data-lucide="sparkles" class="h-7 w-7"></i>
+        </div>
+        <h2 class="mt-5 text-xl font-bold text-slate-900">아직 추천 실행 이력이 없습니다</h2>
+        <p class="mt-2 text-sm leading-relaxed text-slate-500">
+          이 모집단위에 대해 추천을 실행하면 상태와 결과 이력이 이 화면에 쌓입니다.
+        </p>
+        <form th:if="${view.runnable}"
+              th:action="@{/proposals/{proposalId}/recommendations(proposalId=${view.proposalId})}" method="post"
+              class="mt-8">
+          <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+          <input type="hidden" name="proposalPositionId" th:value="${view.proposalPositionId}">
+          <input type="hidden" name="backUrl" th:value="${currentUrl}">
+          <button type="submit"
+                  class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+            <i data-lucide="sparkles" class="h-4 w-4"></i>
+            첫 추천 실행하기
+          </button>
+        </form>
+      </section>
+
+      <section th:if="${view.hasRuns()}" class="space-y-4">
+        <article th:each="run : ${view.runs}"
+                 class="rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-sm shadow-slate-200/50">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="space-y-3">
+              <div class="flex flex-wrap items-center gap-2">
+                                <span
+                                    class="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-600"
+                                    th:text="${'RUN #' + run.runId}">RUN #301</span>
+                <span th:classappend="${run.status.name() == 'COMPUTED'} ? 'border-emerald-200 bg-emerald-50 text-emerald-700' :
+                                                      (${run.status.name() == 'FAILED'} ? 'border-rose-200 bg-rose-50 text-rose-600' :
+                                                                                          'border-blue-200 bg-blue-50 text-blue-700')"
+                      class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-bold"
+                      th:text="${run.statusLabel}">계산 완료</span>
+              </div>
+              <div class="grid gap-3 text-sm text-slate-600 sm:grid-cols-3">
+                <p>
+                  <span class="block text-xs font-semibold uppercase tracking-widest text-slate-400">요청 시각</span>
+                  <span
+                      th:text="${run.requestedAt != null ? #temporals.format(run.requestedAt, 'yyyy.MM.dd HH:mm') : '-'}">2026.04.25 11:30</span>
+                </p>
+                <p>
+                  <span class="block text-xs font-semibold uppercase tracking-widest text-slate-400">최근 갱신</span>
+                  <span th:text="${run.updatedAt != null ? #temporals.format(run.updatedAt, 'yyyy.MM.dd HH:mm') : '-'}">2026.04.25 11:35</span>
+                </p>
+                <p>
+                  <span class="block text-xs font-semibold uppercase tracking-widest text-slate-400">후보 수</span>
+                  <span th:text="${run.candidateCount != null ? run.candidateCount + '명' : '-'}">3명</span>
+                </p>
+              </div>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-2">
+              <a th:if="${run.completed()}"
+                 th:href="@{/proposals/{proposalId}/recommendations/results(proposalId=${view.proposalId}, runId=${run.runId}, backUrl=${currentUrl})}"
+                 class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
+                <i data-lucide="users" class="h-4 w-4"></i>
+                결과 보기
+              </a>
+              <a th:unless="${run.completed()}"
+                 th:href="@{/proposals/{proposalId}/runs/{runId}(proposalId=${view.proposalId}, runId=${run.runId}, backUrl=${currentUrl})}"
+                 class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
+                <i th:if="${run.processing()}" data-lucide="loader" class="h-4 w-4"></i>
+                <i th:if="${!run.processing()}" data-lucide="file-search" class="h-4 w-4"></i>
+                상태 보기
+              </a>
+            </div>
+          </div>
+        </article>
+      </section>
+
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/recommendation/status.html
+++ b/src/main/resources/templates/recommendation/status.html
@@ -139,7 +139,7 @@
     <th:block th:if="${view.status.name() == 'COMPUTED' and view.nextActionUrl != null}">
         <script th:inline="javascript">
             (function () {
-                var nextUrl = /*[[${view.nextActionUrl}]]*/ null;
+                var nextUrl = /*[[${nextActionUrl}]]*/ null;
                 if (!nextUrl) return;
 
                 setTimeout(function () {

--- a/src/main/resources/templates/recommendation/status.html
+++ b/src/main/resources/templates/recommendation/status.html
@@ -16,10 +16,10 @@
             <div class="sticky top-0 z-10 mb-6 rounded-[28px] border border-slate-200 bg-white/95 px-6 py-5 shadow-sm shadow-slate-200/60 backdrop-blur">
                 <div class="flex flex-wrap items-center justify-between gap-4">
                     <div class="flex items-center gap-4">
-                        <a th:href="@{/proposals/{id}/recommendations(id=${view.proposalId})}"
+                        <a th:href="${backUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-700 transition hover:border-blue-300 hover:text-blue-600">
                             <i data-lucide="arrow-left" class="h-4 w-4"></i>
-                            추천 진입으로
+                            이전으로
                         </a>
                         <div>
                             <p class="text-xs font-semibold uppercase tracking-widest text-slate-400">Recommendation</p>
@@ -68,7 +68,7 @@
 
                     <!-- 수동 새로고침 -->
                     <div class="mt-6">
-                        <a th:href="@{/proposals/{proposalId}/runs/{runId}(proposalId=${view.proposalId}, runId=${view.runId}, from=${from})}"
+                        <a th:href="${refreshUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">
                             <i data-lucide="refresh-cw" class="h-4 w-4"></i>
                             지금 새로고침
@@ -90,15 +90,15 @@
                        th:text="${view.message}">추천 결과를 확인해보세요.</p>
 
                     <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-                        <a th:if="${view.nextActionUrl != null}"
-                           th:href="${view.nextActionUrl}"
+                        <a th:if="${nextActionUrl != null}"
+                           th:href="${nextActionUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-blue-100 transition hover:bg-blue-700">
                             <i data-lucide="users" class="h-4 w-4"></i>
                             <span th:text="${view.nextActionLabel}">추천 결과 보기</span>
                         </a>
-                        <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                        <a th:href="${backUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
-                            제안서로 돌아가기
+                            이전 화면으로
                         </a>
                     </div>
                 </section>
@@ -117,15 +117,15 @@
                        th:text="${view.message}">오류가 발생했습니다. 다시 시도해주세요.</p>
 
                     <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
-                        <a th:if="${view.nextActionUrl != null}"
-                           th:href="${view.nextActionUrl}"
+                        <a th:if="${nextActionUrl != null}"
+                           th:href="${nextActionUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 px-6 py-3 text-sm font-bold text-white transition hover:bg-slate-700">
                             <i data-lucide="refresh-cw" class="h-4 w-4"></i>
                             <span th:text="${view.nextActionLabel}">다시 시도</span>
                         </a>
-                        <a th:href="@{/proposals/{id}(id=${view.proposalId})}"
+                        <a th:href="${backUrl}"
                            class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 transition hover:bg-slate-50">
-                            제안서로 돌아가기
+                            이전 화면으로
                         </a>
                     </div>
                 </section>

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -936,6 +936,80 @@ class ProposalControllerTest {
     }
 
     @Test
+    @DisplayName("MATCHING 상태의 클라이언트 제안서 상세에서는 모집단위별 추천 결과 보기 CTA가 노출된다")
+    void detailForMatchingProposalShowsRecommendationRunHistoryCta() throws Exception {
+        var client = createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678");
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        ProposalPosition proposalPosition = org.mockito.Mockito.mock(ProposalPosition.class);
+        Position position = org.mockito.Mockito.mock(Position.class);
+
+        given(proposal.getId()).willReturn(1L);
+        given(proposal.getTitle()).willReturn("핀테크 앱 프로젝트");
+        given(proposal.getDescription()).willReturn("설명");
+        given(proposal.getStatus()).willReturn(ProposalStatus.MATCHING);
+        given(proposal.getExpectedPeriod()).willReturn(8L);
+        given(proposal.getTotalBudgetMin()).willReturn(3_000_000L);
+        given(proposal.getTotalBudgetMax()).willReturn(4_000_000L);
+        given(proposal.getModifiedAt()).willReturn(LocalDateTime.of(2026, 4, 25, 9, 0));
+        given(proposal.getPositions()).willReturn(List.of(proposalPosition));
+
+        given(position.getName()).willReturn("백엔드 개발자");
+
+        given(proposalPosition.getId()).willReturn(10L);
+        given(proposalPosition.getProposal()).willReturn(proposal);
+        given(proposalPosition.getPosition()).willReturn(position);
+        given(proposalPosition.getTitle()).willReturn("Node.js 백엔드 개발자");
+        given(proposalPosition.getStatus()).willReturn(ProposalPositionStatus.OPEN);
+        given(proposalPosition.getHeadCount()).willReturn(1L);
+        given(proposalPosition.getUnitBudgetMin()).willReturn(3_000_000L);
+        given(proposalPosition.getUnitBudgetMax()).willReturn(4_000_000L);
+        given(proposalPosition.getExpectedPeriod()).willReturn(4L);
+        given(proposalPosition.getSkills()).willReturn(List.of());
+        given(proposalPosition.getWorkType()).willReturn(ProposalWorkType.REMOTE);
+        given(proposalPosition.getWorkPlace()).willReturn(null);
+        given(proposalPosition.getCareerMinYears()).willReturn(null);
+        given(proposalPosition.getCareerMaxYears()).willReturn(null);
+
+        RecommendationEntryViewModel recommendEntry = new RecommendationEntryViewModel(
+                1L,
+                "핀테크 앱 프로젝트",
+                "MATCHING",
+                true,
+                "추천을 실행할 수 있습니다.",
+                10L,
+                List.of(new RecommendationEntryPositionItem(
+                        10L,
+                        "Node.js 백엔드 개발자",
+                        "백엔드 개발자",
+                        1L,
+                        "3,000,000 ~ 4,000,000",
+                        4L,
+                        List.of(),
+                        "OPEN",
+                        "모집 중"
+                ))
+        );
+
+        given(proposalService.findOwnedProposal(1L, "client@example.com")).willReturn(proposal);
+        given(matchingRepository.findWithPositionAndFreelancerByProposalIdAndClientEmail(1L, "client@example.com"))
+                .willReturn(List.of());
+        given(recommendationEntryService.getEntry(1L, "client@example.com")).willReturn(recommendEntry);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(client);
+
+        mockMvc.perform(get("/proposals/1")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("client/proposalDetail"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("추천 결과 보기")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "/proposal-positions/10/recommendations/runs?proposalId=1")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("backUrl=/proposals/1")));
+    }
+
+    @Test
     @DisplayName("MATCHING 제안서에서 getEntry 예외 발생 시에도 페이지는 200으로 렌더되고 모달은 표시되지 않는다")
     void detailPageRendersEvenWhenGetEntryFails() throws Exception {
         var client = createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678");

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -22,12 +23,15 @@ import com.generic4.itda.dto.recommend.RecommendationCandidateItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeCareerItem;
 import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResumeSkillItem;
+import com.generic4.itda.dto.recommend.RecommendationRunHistoryItemViewModel;
+import com.generic4.itda.dto.recommend.RecommendationRunHistoryViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.dto.security.ItDaPrincipal;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.service.recommend.RecommendationRunQueryService;
 import com.generic4.itda.service.recommend.RecommendationRunService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,6 +82,71 @@ class RecommendationControllerTest {
     }
 
     @Test
+    @DisplayName("모집단위별 추천 실행 이력 조회가 성공하면 runs 화면을 렌더링한다")
+    void renderRunHistory() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationRunHistoryViewModel viewModel = new RecommendationRunHistoryViewModel(
+                PROPOSAL_ID,
+                PROPOSAL_POSITION_ID,
+                "추천 테스트 제안서",
+                "백엔드 개발자",
+                "OPEN",
+                "모집 중",
+                true,
+                "이전 추천 실행을 확인하거나 새 추천을 실행할 수 있습니다.",
+                List.of(new RecommendationRunHistoryItemViewModel(
+                        RUN_ID,
+                        RecommendationRunStatus.COMPUTED,
+                        "계산 완료",
+                        3,
+                        3,
+                        LocalDateTime.of(2026, 4, 25, 11, 0),
+                        LocalDateTime.of(2026, 4, 25, 11, 2)
+                ))
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunHistory(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willReturn(viewModel);
+
+        mockMvc.perform(get("/proposal-positions/{proposalPositionId}/recommendations/runs", PROPOSAL_POSITION_ID)
+                        .param("proposalId", String.valueOf(PROPOSAL_ID))
+                        .param("backUrl", "/proposals/10")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("recommendation/runs"))
+                .andExpect(model().attributeExists("view"))
+                .andExpect(model().attribute("backUrl", "/proposals/10"))
+                .andExpect(model().attribute("currentUrl",
+                        "/proposal-positions/20/recommendations/runs?proposalId=10&backUrl=%2Fproposals%2F10"));
+    }
+
+    @Test
+    @DisplayName("모집단위별 추천 실행 이력 조회 실패 시 이전 화면으로 redirect하고 flash를 남긴다")
+    void redirectWhenRunHistoryFails() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunHistory(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willThrow(new IllegalArgumentException("해당 제안서에 속한 모집 포지션이 아닙니다."));
+
+        mockMvc.perform(get("/proposal-positions/{proposalPositionId}/recommendations/runs", PROPOSAL_POSITION_ID)
+                        .param("proposalId", String.valueOf(PROPOSAL_ID))
+                        .param("backUrl", "/proposals/10")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/10"))
+                .andExpect(flash().attribute("errorMessage", "해당 제안서의 모집단위를 다시 확인해주세요."));
+    }
+
+    @Test
     @DisplayName("추천 결과 조회가 성공하면 results 화면을 렌더링한다")
     void renderResults() throws Exception {
         // given
@@ -118,6 +187,7 @@ class RecommendationControllerTest {
         // when / then
         mockMvc.perform(get("/proposals/{proposalId}/recommendations/results", PROPOSAL_ID)
                         .param("runId", String.valueOf(RUN_ID))
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10")
                         .with(authentication(new UsernamePasswordAuthenticationToken(
                                 principal,
                                 null,
@@ -125,7 +195,48 @@ class RecommendationControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("recommendation/results"))
-                .andExpect(model().attributeExists("view"));
+                .andExpect(model().attributeExists("view"))
+                .andExpect(model().attribute("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10"))
+                .andExpect(model().attribute("currentUrl",
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10"))
+                .andExpect(content().string(containsString(
+                        "/proposals/10/recommendations/results/100?backUrl=/proposal-positions/20/recommendations/runs?proposalId%3D10")));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("추천 결과 조회 시 깨진 comma backUrl은 첫 번째 내부 경로로 복구한다")
+    void renderResultsRepairsCommaJoinedBackUrl() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationResultsViewModel viewModel = new RecommendationResultsViewModel(
+                PROPOSAL_ID,
+                PROPOSAL_POSITION_ID,
+                RUN_ID,
+                "추천 테스트 제안서",
+                "백엔드 개발자",
+                3,
+                3,
+                List.of()
+        );
+
+        given(recommendationRunQueryService.getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(viewModel);
+
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results", PROPOSAL_ID)
+                        .param("runId", String.valueOf(RUN_ID))
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10,/proposals/10")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10"));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -209,6 +320,7 @@ class RecommendationControllerTest {
 
         // when / then
         mockMvc.perform(get("/proposals/{proposalId}/recommendations/results/{resultId}", PROPOSAL_ID, RESULT_ID)
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10")
                         .with(authentication(new UsernamePasswordAuthenticationToken(
                                 principal,
                                 null,
@@ -217,6 +329,8 @@ class RecommendationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("recommendation/resume"))
                 .andExpect(model().attributeExists("view"))
+                .andExpect(model().attribute("backUrl",
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10"))
                 .andExpect(content().string(containsString("text-amber-600")));
 
         then(recommendationRunQueryService).should()
@@ -270,6 +384,7 @@ class RecommendationControllerTest {
 
         // when / then
         mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10")
                         .with(authentication(new UsernamePasswordAuthenticationToken(
                                 principal,
                                 null,
@@ -277,7 +392,12 @@ class RecommendationControllerTest {
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(view().name("recommendation/status"))
-                .andExpect(model().attributeExists("view"));
+                .andExpect(model().attributeExists("view"))
+                .andExpect(model().attribute("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10"))
+                .andExpect(model().attribute("refreshUrl",
+                        "/proposals/10/runs/301?backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10"))
+                .andExpect(content().string(containsString(
+                        "/proposals/10/runs/301?backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10")));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -350,7 +470,44 @@ class RecommendationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("recommendation/status"))
                 .andExpect(model().attributeExists("view"))
-                .andExpect(model().attribute("from", "recommendation"));
+                .andExpect(model().attribute("from", "recommendation"))
+                .andExpect(model().attribute("refreshUrl",
+                        "/proposals/10/runs/301?from=recommendation"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
+    @DisplayName("COMPUTED 상태 직접 진입 시 backUrl을 유지한 채 결과 페이지로 리다이렉트한다")
+    void redirectToResultsWhenRunAlreadyComputedKeepsBackUrl() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationRunStatusViewModel computedView = new RecommendationRunStatusViewModel(
+                PROPOSAL_ID, RUN_ID, "추천 테스트 제안서",
+                RecommendationRunStatus.COMPUTED,
+                "추천 결과가 준비되었습니다.",
+                "추천 결과 목록으로 이동할 수 있습니다.",
+                "결과 보기",
+                "/proposals/" + PROPOSAL_ID + "/recommendations/results?runId=" + RUN_ID,
+                false
+        );
+
+        given(recommendationRunQueryService.getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(computedView);
+
+        mockMvc.perform(get("/proposals/{proposalId}/runs/{runId}", PROPOSAL_ID, RUN_ID)
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10"));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -532,5 +689,49 @@ class RecommendationControllerTest {
                         ))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @DisplayName("추천 시작 POST 요청은 backUrl을 유지한 채 상태 페이지로 redirect한다")
+    void runRedirectsToRunStatusWithBackUrl() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createOrReuse(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willReturn(RUN_ID);
+
+        mockMvc.perform(post("/proposals/{proposalId}/recommendations", PROPOSAL_ID)
+                        .param("proposalPositionId", String.valueOf(PROPOSAL_POSITION_ID))
+                        .param("backUrl", "/proposal-positions/20/recommendations/runs?proposalId=10")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(
+                        "/proposals/10/runs/301?backUrl=%2Fproposal-positions%2F20%2Frecommendations%2Fruns%3FproposalId%3D10"));
+    }
+
+    @Test
+    @DisplayName("추가 추천 POST 요청은 backUrl을 유지한 채 상태 페이지로 redirect한다")
+    void moreRedirectsToRunStatusWithBackUrl() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        given(recommendationRunService.createAdditional(eq(PROPOSAL_ID), eq(PROPOSAL_POSITION_ID), eq("client@example.com")))
+                .willReturn(RUN_ID);
+
+        mockMvc.perform(post("/proposal-positions/{proposalPositionId}/recommendations/more", PROPOSAL_POSITION_ID)
+                        .param("proposalId", String.valueOf(PROPOSAL_ID))
+                        .param("backUrl", "/proposals/10/recommendations/results?runId=301")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(
+                        "/proposals/10/runs/301?backUrl=%2Fproposals%2F10%2Frecommendations%2Fresults%3FrunId%3D301"));
     }
 }

--- a/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/RecommendationControllerTest.java
@@ -243,6 +243,43 @@ class RecommendationControllerTest {
     }
 
     @Test
+    @DisplayName("추천 결과 조회 시 backUrl이 없으면 제안서 상세로 복귀시킨다")
+    void renderResultsFallsBackToProposalDetail() throws Exception {
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        RecommendationResultsViewModel viewModel = new RecommendationResultsViewModel(
+                PROPOSAL_ID,
+                PROPOSAL_POSITION_ID,
+                RUN_ID,
+                "추천 테스트 제안서",
+                "백엔드 개발자",
+                3,
+                3,
+                List.of()
+        );
+
+        given(recommendationRunQueryService.getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com")))
+                .willReturn(viewModel);
+
+        mockMvc.perform(get("/proposals/{proposalId}/recommendations/results", PROPOSAL_ID)
+                        .param("runId", String.valueOf(RUN_ID))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("backUrl", "/proposals/10"))
+                .andExpect(model().attribute("currentUrl",
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposals%2F10"));
+
+        then(recommendationRunQueryService).should()
+                .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
+    }
+
+    @Test
     @DisplayName("추천 결과가 아직 준비되지 않으면 error 화면을 렌더링한다")
     void renderErrorWhenNotReady() throws Exception {
         // given
@@ -265,7 +302,7 @@ class RecommendationControllerTest {
                 .andExpect(view().name("recommendation/error"))
                 .andExpect(model().attribute("title", "추천 결과를 확인할 수 없습니다."))
                 .andExpect(model().attribute("message", "추천이 아직 완료되지 않았습니다. 잠시 후 다시 시도해주세요."))
-                .andExpect(model().attribute("backUrl", "/proposals/10/runs/301"));
+                .andExpect(model().attribute("backUrl", "/proposals/10"));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationResults(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -432,7 +469,8 @@ class RecommendationControllerTest {
                                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
                         ))))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/proposals/" + PROPOSAL_ID + "/recommendations/results?runId=" + RUN_ID));
+                .andExpect(redirectedUrl(
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposals%2F10"));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -471,8 +509,12 @@ class RecommendationControllerTest {
                 .andExpect(view().name("recommendation/status"))
                 .andExpect(model().attributeExists("view"))
                 .andExpect(model().attribute("from", "recommendation"))
+                .andExpect(model().attribute("backUrl", "/proposals/10"))
+                .andExpect(model().attribute("nextActionUrl",
+                        "/proposals/10/recommendations/results?runId=301&backUrl=%2Fproposals%2F10"))
                 .andExpect(model().attribute("refreshUrl",
-                        "/proposals/10/runs/301?from=recommendation"));
+                        "/proposals/10/runs/301?from=recommendation"))
+                .andExpect(content().string(containsString("backUrl=%2Fproposals%2F10")));
 
         then(recommendationRunQueryService).should()
                 .getRecommendationRunStatus(eq(PROPOSAL_ID), eq(RUN_ID), eq("client@example.com"));
@@ -534,7 +576,7 @@ class RecommendationControllerTest {
                 .andExpect(view().name("recommendation/error"))
                 .andExpect(model().attribute("title", "추천 실행 정보를 확인할 수 없습니다."))
                 .andExpect(model().attribute("message", "존재하지 않거나 만료된 추천 실행입니다."))
-                .andExpect(model().attribute("backUrl", "/proposals/" + PROPOSAL_ID + "?openRecommendModal=true"));
+                .andExpect(model().attribute("backUrl", "/proposals/" + PROPOSAL_ID));
     }
 
     @Test

--- a/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
+++ b/src/test/java/com/generic4/itda/repository/RecommendationRunRepositoryTest.java
@@ -370,6 +370,105 @@ class RecommendationRunRepositoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc")
+    class FindAllByProposalPositionIdOrderByCreatedAtDescIdDesc {
+
+        @Test
+        @DisplayName("지정한 proposalPositionId에 해당하는 데이터만 조회되고 다른 포지션 데이터는 포함되지 않는다")
+        void 지정한_proposalPositionId에_해당하는_데이터만_조회된다() {
+            // given
+            RecommendationRun run1 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-target-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-target-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            Position otherPos = persistPosition("프론트엔드 개발자");
+            ProposalPosition otherPP = proposal.addPosition(otherPos, "프론트엔드 개발자",
+                    null, 1L, 300_000L, 600_000L, null, null, null, null);
+            em.flush(); // managed proposal의 dirty-check로 cascade persist → otherPP에 ID 설정
+            recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(otherPP, "fp-other-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            em.clear();
+
+            // when
+            List<RecommendationRun> result =
+                    recommendationRunRepository.findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(
+                            proposalPosition.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                    .extracting(run -> run.getProposalPosition().getId())
+                    .containsOnly(proposalPosition.getId());
+        }
+
+        @Test
+        @DisplayName("createdAt 내림차순으로 정렬되어 조회된다")
+        void createdAt_내림차순으로_정렬된다() {
+            // given
+            RecommendationRun run1 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-order-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-order-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run3 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-order-3", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            forceCreatedAt(run1, LocalDateTime.of(2026, 1, 1, 10, 0));
+            forceCreatedAt(run2, LocalDateTime.of(2026, 1, 3, 10, 0));
+            forceCreatedAt(run3, LocalDateTime.of(2026, 1, 2, 10, 0));
+            em.flush();
+            em.clear();
+
+            // when
+            List<RecommendationRun> result =
+                    recommendationRunRepository.findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(
+                            proposalPosition.getId());
+
+            // then
+            assertThat(result)
+                    .extracting(RecommendationRun::getId)
+                    .containsExactly(run2.getId(), run3.getId(), run1.getId());
+        }
+
+        @Test
+        @DisplayName("createdAt이 같으면 id 내림차순으로 정렬된다")
+        void createdAt이_같으면_id_내림차순으로_정렬된다() {
+            // given
+            LocalDateTime sameTime = LocalDateTime.of(2026, 1, 1, 10, 0);
+
+            RecommendationRun run1 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-same-1", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run2 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-same-2", RecommendationAlgorithm.HEURISTIC_V1, 5));
+            RecommendationRun run3 = recommendationRunRepository.saveAndFlush(
+                    RecommendationRun.create(proposalPosition, "fp-same-3", RecommendationAlgorithm.HEURISTIC_V1, 5));
+
+            forceCreatedAt(run1, sameTime);
+            forceCreatedAt(run2, sameTime);
+            forceCreatedAt(run3, sameTime);
+            em.flush();
+            em.clear();
+
+            // when
+            List<RecommendationRun> result =
+                    recommendationRunRepository.findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(
+                            proposalPosition.getId());
+
+            // then
+            assertThat(result)
+                    .extracting(RecommendationRun::getId)
+                    .containsExactly(run3.getId(), run2.getId(), run1.getId());
+        }
+
+        private void forceCreatedAt(RecommendationRun run, LocalDateTime target) {
+            em.createNativeQuery("UPDATE recommendation_run SET created_at = :ts WHERE id = :id")
+                    .setParameter("ts", target)
+                    .setParameter("id", run.getId())
+                    .executeUpdate();
+        }
+    }
+
     private Position persistPosition(String name) {
         Position position = Position.create(name);
         em.persist(position);

--- a/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/RecommendationRunQueryServiceTest.java
@@ -34,9 +34,11 @@ import com.generic4.itda.dto.recommend.RecommendationResumeDetailViewModel;
 import com.generic4.itda.dto.recommend.RecommendationResultsViewModel;
 import com.generic4.itda.dto.recommend.RecommendationRunStatusViewModel;
 import com.generic4.itda.repository.MatchingRepository;
+import com.generic4.itda.repository.ProposalRepository;
 import com.generic4.itda.repository.RecommendationResultRepository;
 import com.generic4.itda.repository.RecommendationRunRepository;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +70,9 @@ class RecommendationRunQueryServiceTest {
     private RecommendationResultRepository recommendationResultRepository;
 
     @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
     private MatchingRepository matchingRepository;
 
     @InjectMocks
@@ -83,6 +88,75 @@ class RecommendationRunQueryServiceTest {
                 .isInstanceOf(IllegalStateException.class);
 
         then(recommendationRunRepository).should().findDetailById(RUN_ID);
+    }
+
+    @Test
+    @DisplayName("모집단위 기준 추천 실행 이력을 조회한다")
+    void getRecommendationRunHistory_returnsRunsForProposalPosition() {
+        RecommendationRun computedRun = createOwnedRun(RecommendationRunStatus.COMPUTED);
+        RecommendationRun failedRun = createOwnedRun(RecommendationRunStatus.FAILED);
+
+        ReflectionTestUtils.setField(computedRun, "id", 401L);
+        ReflectionTestUtils.setField(failedRun, "id", 402L);
+        ReflectionTestUtils.setField(computedRun, "createdAt", LocalDateTime.of(2026, 4, 25, 10, 0));
+        ReflectionTestUtils.setField(computedRun, "modifiedAt", LocalDateTime.of(2026, 4, 25, 10, 3));
+        ReflectionTestUtils.setField(failedRun, "createdAt", LocalDateTime.of(2026, 4, 25, 11, 0));
+        ReflectionTestUtils.setField(failedRun, "modifiedAt", LocalDateTime.of(2026, 4, 25, 11, 2));
+
+        Proposal proposal = computedRun.getProposalPosition().getProposal();
+
+        given(proposalRepository.findWithPositionsById(PROPOSAL_ID)).willReturn(Optional.of(proposal));
+        given(recommendationRunRepository.findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(PROPOSAL_POSITION_ID))
+                .willReturn(List.of(failedRun, computedRun));
+
+        var view = service.getRecommendationRunHistory(PROPOSAL_ID, PROPOSAL_POSITION_ID, OWNER_EMAIL);
+
+        assertThat(view.proposalId()).isEqualTo(PROPOSAL_ID);
+        assertThat(view.proposalPositionId()).isEqualTo(PROPOSAL_POSITION_ID);
+        assertThat(view.positionTitle()).isEqualTo("Backend Dev");
+        assertThat(view.positionStatusName()).isEqualTo("OPEN");
+        assertThat(view.runnable()).isTrue();
+        assertThat(view.hasRuns()).isTrue();
+        assertThat(view.runs()).hasSize(2);
+        assertThat(view.runs().get(0).runId()).isEqualTo(402L);
+        assertThat(view.runs().get(0).status()).isEqualTo(RecommendationRunStatus.FAILED);
+        assertThat(view.runs().get(0).requestedAt()).isEqualTo(LocalDateTime.of(2026, 4, 25, 11, 0));
+        assertThat(view.runs().get(1).runId()).isEqualTo(401L);
+        assertThat(view.runs().get(1).candidateCount()).isEqualTo(1);
+
+        then(proposalRepository).should().findWithPositionsById(PROPOSAL_ID);
+        then(recommendationRunRepository).should()
+                .findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(PROPOSAL_POSITION_ID);
+    }
+
+    @Test
+    @DisplayName("모집단위의 추천 실행 이력이 없으면 Empty State용 모델을 반환한다")
+    void getRecommendationRunHistory_returnsEmptyStateWhenNoRuns() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.PENDING);
+        Proposal proposal = run.getProposalPosition().getProposal();
+
+        given(proposalRepository.findWithPositionsById(PROPOSAL_ID)).willReturn(Optional.of(proposal));
+        given(recommendationRunRepository.findAllByProposalPosition_IdOrderByCreatedAtDescIdDesc(PROPOSAL_POSITION_ID))
+                .willReturn(List.of());
+
+        var view = service.getRecommendationRunHistory(PROPOSAL_ID, PROPOSAL_POSITION_ID, OWNER_EMAIL);
+
+        assertThat(view.hasRuns()).isFalse();
+        assertThat(view.helperMessage()).isEqualTo("아직 추천 실행 이력이 없습니다. 첫 추천을 실행해보세요.");
+        assertThat(view.runnable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 제안서의 모집단위로 추천 실행 이력을 조회하면 예외를 던진다")
+    void getRecommendationRunHistory_throwsWhenPositionDoesNotBelongToProposal() {
+        RecommendationRun run = createOwnedRun(RecommendationRunStatus.PENDING);
+        Proposal proposal = run.getProposalPosition().getProposal();
+
+        given(proposalRepository.findWithPositionsById(PROPOSAL_ID)).willReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> service.getRecommendationRunHistory(PROPOSAL_ID, 999L, OWNER_EMAIL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 제안서에 속한 모집 포지션이 아닙니다.");
     }
 
     @Test


### PR DESCRIPTION
## 🔎 What

- 제안서 상세의 모집단위 카드에서 `추천 결과 보기` CTA로 추천 실행 이력 화면에 진입할 수 있도록 했습니다.
- `proposalPositionId` 기준 추천 실행 이력 페이지를 추가하고, EmptyState 및 `추가추천받기` CTA를 연결했습니다.
- 추천 실행 상태/결과/후보 상세 페이지 전반에 `backUrl` 흐름을 연결해
- `제안서 상세 -> 추천 실행 이력 -> 상태/결과 -> 후보 상세` 흐름에서 이전 화면 복귀가 유지되도록 정리했습니다.
- 추천 결과 목록에서 후보 상세 진입 시 중첩 `backUrl` 때문에 뒤로가기가 깨지던 문제를 수정했습니다.
- 추천 실행 상태 페이지는
  - `COMPUTED` 상태에서 기본적으로 결과 페이지로 바로 이동하고
  - `from=recommendation` 문맥에서는 상태 화면을 한 번 렌더링한 뒤 결과 페이지로 자동 이동하도록 정리했습니다.
- 리베이스 충돌로 섞였던 `RecommendationController` / `recommendation/status.html` 의 `from` / `backUrl` 처리도 다시 맞췄습니다.

## 🔗 Issue

- Closes: #138 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?