### PR TITLE
[Refactor] proposal_position 동일 category 다중 title 저장 및 AI 매핑 정합성 개선

### DIFF
--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -38,14 +38,14 @@ public class AiBriefProposalMapper {
         Assert.notNull(aiBriefResult, "AI 브리프 결과는 필수값입니다.");
 
         applyProposalFields(proposal, aiBriefResult);
-        mergePositions(proposal, aiBriefResult.getPositions(), true, Set.of());
+        mergePositions(proposal, aiBriefResult.getPositions(), true, DeletedPositionKeys.empty());
     }
 
     public void applyForInterview(Proposal proposal, AiBriefResult aiBriefResult, String userMessage) {
         Assert.notNull(proposal, "제안서는 필수값입니다.");
         Assert.notNull(aiBriefResult, "AI 브리프 결과는 필수값입니다.");
 
-        Set<String> deletedPositionKeys = removeExplicitlyDeletedPositions(proposal, userMessage);
+        DeletedPositionKeys deletedPositionKeys = removeExplicitlyDeletedPositions(proposal, userMessage);
         applyProposalFields(proposal, aiBriefResult);
         mergePositions(proposal, aiBriefResult.getPositions(), false, deletedPositionKeys);
     }
@@ -65,7 +65,7 @@ public class AiBriefProposalMapper {
             Proposal proposal,
             List<AiBriefPositionResult> positionResults,
             boolean removePositionsNotInAiResult,
-            Set<String> ignoredPositionKeys
+            DeletedPositionKeys ignoredPositionKeys
     ) {
         if (positionResults == null || positionResults.isEmpty()) {
             return;
@@ -83,7 +83,9 @@ public class AiBriefProposalMapper {
 
         for (PositionApplication application : applications) {
             String positionKey = positionKey(application.position(), application.result().getTitle());
-            if (ignoredPositionKeys.contains(positionKey)) {
+            String categoryKey = categoryKey(application.position());
+            if (ignoredPositionKeys.positionKeys().contains(positionKey)
+                    || ignoredPositionKeys.categoryKeys().contains(categoryKey)) {
                 continue;
             }
 
@@ -134,28 +136,40 @@ public class AiBriefProposalMapper {
         }
     }
 
-    private Set<String> removeExplicitlyDeletedPositions(Proposal proposal, String userMessage) {
+    private DeletedPositionKeys removeExplicitlyDeletedPositions(Proposal proposal, String userMessage) {
         Set<String> deletedPositionKeys = new HashSet<>();
+        Set<String> deletedCategoryKeys = new HashSet<>();
         if (!StringUtils.hasText(userMessage)) {
-            return deletedPositionKeys;
+            return new DeletedPositionKeys(deletedPositionKeys, deletedCategoryKeys);
         }
 
         List<String> messageParts = splitMessageParts(userMessage);
         List<ProposalPosition> existingPositions = new ArrayList<>(proposal.getPositions());
+        Map<String, List<ProposalPosition>> existingByCategoryKey = existingPositionsByCategoryKey(proposal);
 
         for (ProposalPosition existingPosition : existingPositions) {
-            if (isExplicitlyDeleted(existingPosition, messageParts)) {
+            DeleteDecision deleteDecision = decideDeletion(existingPosition, existingByCategoryKey, messageParts);
+            if (deleteDecision.ignoreCategory()) {
+                deletedCategoryKeys.add(categoryKey(existingPosition));
+            }
+            if (deleteDecision.deletePosition()) {
                 deletedPositionKeys.add(positionKey(existingPosition));
                 proposal.removePosition(existingPosition);
             }
         }
 
-        return deletedPositionKeys;
+        return new DeletedPositionKeys(deletedPositionKeys, deletedCategoryKeys);
     }
 
-    private boolean isExplicitlyDeleted(ProposalPosition existingPosition, List<String> messageParts) {
+    private DeleteDecision decideDeletion(
+            ProposalPosition existingPosition,
+            Map<String, List<ProposalPosition>> existingByCategoryKey,
+            List<String> messageParts
+    ) {
+        String categoryKey = categoryKey(existingPosition);
         String positionName = existingPosition.getPosition() == null ? "" : existingPosition.getPosition().getName();
         String title = existingPosition.getTitle();
+        int sameCategoryCount = existingByCategoryKey.getOrDefault(categoryKey, List.of()).size();
 
         for (String messagePart : messageParts) {
             if (!hasDeleteIntent(messagePart)) {
@@ -166,12 +180,19 @@ public class AiBriefProposalMapper {
             boolean titleMatched = containsNormalized(normalizedMessagePart, title);
             boolean positionNameMatched = containsNormalized(normalizedMessagePart, positionName);
 
-            if (titleMatched || positionNameMatched) {
-                return true;
+            if (titleMatched) {
+                return new DeleteDecision(true, false);
+            }
+
+            if (positionNameMatched) {
+                if (sameCategoryCount == 1) {
+                    return new DeleteDecision(true, true);
+                }
+                return new DeleteDecision(false, true);
             }
         }
 
-        return false;
+        return new DeleteDecision(false, false);
     }
 
     private List<String> splitMessageParts(String userMessage) {
@@ -413,8 +434,18 @@ public class AiBriefProposalMapper {
     }
 
     private String positionKey(Position position, String title) {
-        String categoryKey = position == null ? "" : normalizeKey(position.getName());
-        return categoryKey + "::" + normalizeKey(title);
+        return categoryKey(position) + "::" + normalizeKey(title);
+    }
+
+    private String categoryKey(ProposalPosition proposalPosition) {
+        if (proposalPosition == null || proposalPosition.getPosition() == null) {
+            return "";
+        }
+        return categoryKey(proposalPosition.getPosition());
+    }
+
+    private String categoryKey(Position position) {
+        return position == null ? "" : normalizeKey(position.getName());
     }
 
     private String normalizeKey(String value) {
@@ -425,5 +456,15 @@ public class AiBriefProposalMapper {
     }
 
     private record SkillApplication(Skill skill, ProposalPositionSkillImportance importance) {
+    }
+
+    private record DeletedPositionKeys(Set<String> positionKeys, Set<String> categoryKeys) {
+
+        private static DeletedPositionKeys empty() {
+            return new DeletedPositionKeys(Set.of(), Set.of());
+        }
+    }
+
+    private record DeleteDecision(boolean deletePosition, boolean ignoreCategory) {
     }
 }

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -449,7 +450,12 @@ public class AiBriefProposalMapper {
     }
 
     private String normalizeKey(String value) {
-        return value == null ? "" : value.trim();
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", "")
+                .trim();
     }
 
     private record PositionApplication(Position position, AiBriefPositionResult result) {

--- a/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
+++ b/src/main/java/com/generic4/itda/service/AiBriefProposalMapper.java
@@ -71,20 +71,28 @@ public class AiBriefProposalMapper {
             return;
         }
 
-        Map<String, ProposalPosition> existingByPositionName = existingPositionsByPositionName(proposal);
-        List<PositionApplication> applications = mergePositionApplicationsByPositionName(positionResults);
+        List<PositionApplication> applications = mergePositionApplicationsByPositionKey(positionResults);
         if (applications.isEmpty()) {
             return;
         }
+
+        Map<String, ProposalPosition> existingByPositionKey = existingPositionsByPositionKey(proposal);
+        Map<String, List<ProposalPosition>> existingByCategoryKey = existingPositionsByCategoryKey(proposal);
+        Map<String, Long> applicationCountByCategoryKey = applicationCountByCategoryKey(applications);
         Set<ProposalPosition> appliedPositions = new HashSet<>();
 
         for (PositionApplication application : applications) {
-            String positionKey = normalizeKey(application.position().getName());
+            String positionKey = positionKey(application.position(), application.result().getTitle());
             if (ignoredPositionKeys.contains(positionKey)) {
                 continue;
             }
 
-            ProposalPosition proposalPosition = existingByPositionName.get(positionKey);
+            ProposalPosition proposalPosition = findExistingPosition(
+                    application,
+                    existingByPositionKey,
+                    existingByCategoryKey,
+                    applicationCountByCategoryKey
+            );
             AiBriefPositionResult result = application.result();
             ProposalWorkType workType = resolveWorkType(result);
             String workPlace = resolveWorkPlace(workType, result.getWorkPlace());
@@ -137,9 +145,7 @@ public class AiBriefProposalMapper {
 
         for (ProposalPosition existingPosition : existingPositions) {
             if (isExplicitlyDeleted(existingPosition, messageParts)) {
-                if (existingPosition.getPosition() != null) {
-                    deletedPositionKeys.add(normalizeKey(existingPosition.getPosition().getName()));
-                }
+                deletedPositionKeys.add(positionKey(existingPosition));
                 proposal.removePosition(existingPosition);
             }
         }
@@ -157,10 +163,10 @@ public class AiBriefProposalMapper {
             }
 
             String normalizedMessagePart = normalizeForContains(messagePart);
-            boolean positionNameMatched = containsNormalized(normalizedMessagePart, positionName);
             boolean titleMatched = containsNormalized(normalizedMessagePart, title);
+            boolean positionNameMatched = containsNormalized(normalizedMessagePart, positionName);
 
-            if (positionNameMatched || titleMatched) {
+            if (titleMatched || positionNameMatched) {
                 return true;
             }
         }
@@ -217,17 +223,30 @@ public class AiBriefProposalMapper {
         }
     }
 
-    private Map<String, ProposalPosition> existingPositionsByPositionName(Proposal proposal) {
+    private Map<String, ProposalPosition> existingPositionsByPositionKey(Proposal proposal) {
         Map<String, ProposalPosition> existingPositions = new LinkedHashMap<>();
         for (ProposalPosition proposalPosition : proposal.getPositions()) {
             if (proposalPosition.getPosition() != null && StringUtils.hasText(proposalPosition.getPosition().getName())) {
-                existingPositions.put(normalizeKey(proposalPosition.getPosition().getName()), proposalPosition);
+                existingPositions.put(positionKey(proposalPosition), proposalPosition);
             }
         }
         return existingPositions;
     }
 
-    private List<PositionApplication> mergePositionApplicationsByPositionName(List<AiBriefPositionResult> positionResults) {
+    private Map<String, List<ProposalPosition>> existingPositionsByCategoryKey(Proposal proposal) {
+        Map<String, List<ProposalPosition>> existingPositions = new LinkedHashMap<>();
+        for (ProposalPosition proposalPosition : proposal.getPositions()) {
+            if (proposalPosition.getPosition() == null || !StringUtils.hasText(proposalPosition.getPosition().getName())) {
+                continue;
+            }
+
+            String categoryKey = normalizeKey(proposalPosition.getPosition().getName());
+            existingPositions.computeIfAbsent(categoryKey, ignored -> new ArrayList<>()).add(proposalPosition);
+        }
+        return existingPositions;
+    }
+
+    private List<PositionApplication> mergePositionApplicationsByPositionKey(List<AiBriefPositionResult> positionResults) {
         Map<String, PositionApplication> merged = new LinkedHashMap<>();
 
         for (AiBriefPositionResult positionResult : positionResults) {
@@ -237,10 +256,44 @@ public class AiBriefProposalMapper {
             }
 
             Position position = resolvedPosition.get();
-            merged.put(normalizeKey(position.getName()), new PositionApplication(position, positionResult));
+            merged.put(positionKey(position, positionResult.getTitle()), new PositionApplication(position, positionResult));
         }
 
         return new ArrayList<>(merged.values());
+    }
+
+    private Map<String, Long> applicationCountByCategoryKey(List<PositionApplication> applications) {
+        Map<String, Long> countByCategory = new LinkedHashMap<>();
+
+        for (PositionApplication application : applications) {
+            String categoryKey = normalizeKey(application.position().getName());
+            countByCategory.put(categoryKey, countByCategory.getOrDefault(categoryKey, 0L) + 1L);
+        }
+
+        return countByCategory;
+    }
+
+    private ProposalPosition findExistingPosition(
+            PositionApplication application,
+            Map<String, ProposalPosition> existingByPositionKey,
+            Map<String, List<ProposalPosition>> existingByCategoryKey,
+            Map<String, Long> applicationCountByCategoryKey
+    ) {
+        String positionKey = positionKey(application.position(), application.result().getTitle());
+        ProposalPosition exactMatch = existingByPositionKey.get(positionKey);
+        if (exactMatch != null) {
+            return exactMatch;
+        }
+
+        String categoryKey = normalizeKey(application.position().getName());
+        List<ProposalPosition> categoryMatches = existingByCategoryKey.getOrDefault(categoryKey, List.of());
+        Long categoryApplicationCount = applicationCountByCategoryKey.getOrDefault(categoryKey, 0L);
+
+        if (categoryMatches.size() == 1 && categoryApplicationCount == 1L) {
+            return categoryMatches.get(0);
+        }
+
+        return null;
     }
 
     private Long resolveHeadCount(AiBriefPositionResult result) {
@@ -350,6 +403,18 @@ public class AiBriefProposalMapper {
             return aiBriefResult.getExpectedPeriod();
         }
         return proposal.getExpectedPeriod();
+    }
+
+    private String positionKey(ProposalPosition proposalPosition) {
+        if (proposalPosition == null || proposalPosition.getPosition() == null) {
+            return "";
+        }
+        return positionKey(proposalPosition.getPosition(), proposalPosition.getTitle());
+    }
+
+    private String positionKey(Position position, String title) {
+        String categoryKey = position == null ? "" : normalizeKey(position.getName());
+        return categoryKey + "::" + normalizeKey(title);
     }
 
     private String normalizeKey(String value) {

--- a/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiBriefGenerator.java
@@ -51,10 +51,9 @@ public class OpenAiAiBriefGenerator implements AiBriefGenerator {
             - headCount가 명확하지 않으면 1로 둔다.
             - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 모바일 앱 개발자, QA 엔지니어
             - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Java Spring 백엔드 개발자, React 프론트엔드 개발자
-            - 같은 positionCategoryName을 중복 생성하지 않는다.
-            - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
+            - 같은 positionCategoryName이라도 title이 다르고 역할이 명확히 다르면 별도 position으로 분리할 수 있다.
             - 동일한 title을 불필요하게 중복 생성하지 않는다.
-            - 같은 직무 안에서 역할이 나뉘는 경우 하나의 모집 단위 title/description에 통합해서 표현한다.
+            - 같은 positionCategoryName 안에서 역할 차이가 명확하지 않으면 하나의 모집 단위 title/description에 통합해서 표현한다.
             - 정보가 부족하면 positions는 1~3개 이내로 생성한다.
             - 사용자가 명시하지 않은 포지션은 과도하게 늘리지 않는다.
             - 입력은 시간순 요청 목록이다.

--- a/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
@@ -46,6 +46,9 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
             - 기존 폼에 이미 있는 값은 사용자가 바꾸거나 삭제하라고 하지 않았다면 최대한 유지한다.
             - 사용자가 정정한 값은 최신 사용자 메시지를 우선한다.
             - 사용자가 제거/삭제/빼달라고 한 포지션은 positions에서 제외한다.
+            - 같은 positionCategoryName에 여러 title이 있는데 사용자가 category만 언급하며 제거/삭제/빼달라고 하면 바로 삭제하지 않는다.
+            - 이 경우 assistantMessage로 어떤 title의 모집 단위를 삭제할지 되묻고, aiBriefResult.positions에는 기존 모집 단위를 유지한다.
+            - 모호한 category 삭제 요청이 있을 때 같은 category의 새 title을 임의로 만들어 기존 모집 단위를 대체하지 않는다.
             - totalBudgetMin, totalBudgetMax, unitBudgetMin, unitBudgetMax는 원화 기준 정수로 반환한다.
             - expectedPeriod는 주 단위 기준 정수로 반환한다.
             - positions는 실제 모집 단위 배열이다.

--- a/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
+++ b/src/main/java/com/generic4/itda/service/OpenAiAiInterviewGenerator.java
@@ -55,10 +55,9 @@ public class OpenAiAiInterviewGenerator implements AiInterviewGenerator {
             - headCount가 명확하지 않으면 1로 둔다.
             - positionCategoryName은 공용 직무 마스터에 대응하는 큰 분류명이다. 예: 백엔드 개발자, 모바일 앱 개발자, QA 엔지니어
             - title은 사용자가 화면에서 보게 될 구체 포지션 제목이다. 예: Java Spring 백엔드 개발자, React 프론트엔드 개발자
-            - 같은 positionCategoryName을 중복 생성하지 않는다.
-            - 같은 positionCategoryName 아래에서도 title이 다르면 별도 position으로 분리할 수 있다.
+            - 같은 positionCategoryName이라도 title이 다르고 역할이 명확히 다르면 별도 position으로 분리할 수 있다.
             - 동일한 title을 불필요하게 중복 생성하지 않는다.
-            - 같은 직무 안에서 역할이 나뉘는 경우 하나의 모집 단위 title/description에 통합해서 표현한다.
+            - 같은 positionCategoryName 안에서 역할 차이가 명확하지 않으면 하나의 모집 단위 title/description에 통합해서 표현한다.
             - 정보가 부족하면 positions는 1~3개 이내로 생성한다.
             - 사용자가 명시하지 않은 포지션은 과도하게 늘리지 않는다.
 

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -250,14 +250,16 @@ public class ProposalService {
     }
 
     private void replacePositions(Proposal proposal, List<ProposalPositionForm> positionForms) {
-        List<ProposalPositionForm> mergedPositionForms = mergePositionFormsByPositionId(positionForms);
         Map<Long, ProposalPosition> existingById = existingPositionsById(proposal);
-        Map<Long, ProposalPosition> existingByPositionId = existingPositionsByPositionId(proposal);
         Set<ProposalPosition> appliedPositions = new HashSet<>();
 
-        for (ProposalPositionForm positionForm : mergedPositionForms) {
+        for (ProposalPositionForm positionForm : positionForms) {
+            if (positionForm.getPositionId() == null) {
+                continue;
+            }
+
             Position position = getPosition(positionForm.getPositionId());
-            ProposalPosition proposalPosition = findExistingPosition(positionForm, position, existingById, existingByPositionId);
+            ProposalPosition proposalPosition = findExistingPosition(positionForm, existingById);
 
             if (proposalPosition == null) {
                 proposalPosition = proposal.addPosition(
@@ -298,17 +300,6 @@ public class ProposalService {
         removeMissingPositions(proposal, appliedPositions);
     }
 
-    private List<ProposalPositionForm> mergePositionFormsByPositionId(List<ProposalPositionForm> positionForms) {
-        Map<Long, ProposalPositionForm> merged = new LinkedHashMap<>();
-        for (ProposalPositionForm positionForm : positionForms) {
-            if (positionForm.getPositionId() == null) {
-                continue;
-            }
-            merged.put(positionForm.getPositionId(), positionForm);
-        }
-        return new ArrayList<>(merged.values());
-    }
-
     private Map<Long, ProposalPosition> existingPositionsById(Proposal proposal) {
         Map<Long, ProposalPosition> existingPositions = new LinkedHashMap<>();
         for (ProposalPosition proposalPosition : proposal.getPositions()) {
@@ -319,26 +310,14 @@ public class ProposalService {
         return existingPositions;
     }
 
-    private Map<Long, ProposalPosition> existingPositionsByPositionId(Proposal proposal) {
-        Map<Long, ProposalPosition> existingPositions = new LinkedHashMap<>();
-        for (ProposalPosition proposalPosition : proposal.getPositions()) {
-            if (proposalPosition.getPosition() != null && proposalPosition.getPosition().getId() != null) {
-                existingPositions.put(proposalPosition.getPosition().getId(), proposalPosition);
-            }
-        }
-        return existingPositions;
-    }
-
     private ProposalPosition findExistingPosition(
             ProposalPositionForm positionForm,
-            Position position,
-            Map<Long, ProposalPosition> existingById,
-            Map<Long, ProposalPosition> existingByPositionId
+            Map<Long, ProposalPosition> existingById
     ) {
-        if (positionForm.getId() != null && existingById.containsKey(positionForm.getId())) {
-            return existingById.get(positionForm.getId());
+        if (positionForm.getId() == null) {
+            return null;
         }
-        return existingByPositionId.get(position.getId());
+        return existingById.get(positionForm.getId());
     }
 
     private void removeMissingPositions(Proposal proposal, Set<ProposalPosition> appliedPositions) {

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -317,7 +317,14 @@ public class ProposalService {
         if (positionForm.getId() == null) {
             return null;
         }
-        return existingById.get(positionForm.getId());
+
+        ProposalPosition proposalPosition = existingById.get(positionForm.getId());
+        if (proposalPosition == null) {
+            throw new IllegalArgumentException(
+                    "제안서에 속하지 않는 모집 포지션입니다. proposalPositionId=" + positionForm.getId()
+            );
+        }
+        return proposalPosition;
     }
 
     private void removeMissingPositions(Proposal proposal, Set<ProposalPosition> appliedPositions) {

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -746,6 +746,75 @@ class AiBriefProposalMapperTest {
     }
 
     @Test
+    @DisplayName("AI 인터뷰에서 같은 category에 여러 title이 있을 때 category만 삭제 요청하면 기존 모집 단위를 유지하고 같은 category 신규 추가를 막는다")
+    void applyForInterview_preservesSameCategorySiblingsWhenCategoryOnlyDeletionIsAmbiguous() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+
+        ProposalPosition paymentBackendPosition = proposal.addPosition(
+                backend,
+                "결제 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_000_000L,
+                4_000_000L,
+                3L,
+                3,
+                6,
+                null
+        );
+        ProposalPosition settlementBackendPosition = proposal.addPosition(
+                backend,
+                "정산 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_500_000L,
+                4_500_000L,
+                3L,
+                3,
+                6,
+                null
+        );
+
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "커머스 백엔드 개발",
+                "백엔드 모집 단위 삭제 요청을 확인합니다.",
+                null,
+                null,
+                3L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "플랫폼 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                3_000_000L,
+                                4_000_000L,
+                                3L,
+                                3,
+                                6,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.applyForInterview(
+                proposal,
+                aiBriefResult,
+                "백엔드 개발자는 빼자."
+        );
+
+        List<String> titles = positionTitles(proposal);
+
+        assertThat(titles).containsExactly("결제 서버 백엔드 개발자", "정산 서버 백엔드 개발자");
+        assertThat(findProposalPositionByTitle(proposal, "결제 서버 백엔드 개발자")).isSameAs(paymentBackendPosition);
+        assertThat(findProposalPositionByTitle(proposal, "정산 서버 백엔드 개발자")).isSameAs(settlementBackendPosition);
+    }
+
+    @Test
     @DisplayName("AI가 기존 Position 마스터에 없는 카테고리를 반환하면 저장하지 않고 기존 모집 단위를 유지한다")
     void apply_skipsUnknownPositionCategoryWithoutRemovingExistingPositions() {
         Proposal proposal = createProposal();

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -175,6 +175,130 @@ class AiBriefProposalMapperTest {
     }
 
     @Test
+    @DisplayName("AI 브리프가 같은 category 아래 서로 다른 title을 제안하면 여러 모집 단위를 함께 저장한다")
+    void apply_keepsMultiplePositionsWithSameCategoryAndDifferentTitles() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "커머스 백엔드 개발",
+                "커머스 서버 개발이 필요합니다.",
+                null,
+                null,
+                8L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "결제 서버 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                3_000_000L,
+                                4_000_000L,
+                                4L,
+                                3,
+                                6,
+                                null,
+                                List.of()
+                        ),
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "정산 서버 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                1L,
+                                3_500_000L,
+                                4_500_000L,
+                                4L,
+                                3,
+                                6,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.apply(proposal, aiBriefResult);
+
+        List<String> titles = positionTitles(proposal);
+
+        assertThat(titles).containsExactly("결제 서버 백엔드 개발자", "정산 서버 백엔드 개발자");
+    }
+
+    @Test
+    @DisplayName("AI 인터뷰 적용은 같은 category 안에서 title이 일치하는 모집 단위만 갱신하고 다른 title은 유지한다")
+    void applyForInterview_updatesMatchingTitleOnlyAndPreservesSameCategorySibling() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+
+        ProposalPosition paymentBackendPosition = proposal.addPosition(
+                backend,
+                "결제 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_000_000L,
+                4_000_000L,
+                4L,
+                3,
+                6,
+                null
+        );
+        ProposalPosition settlementBackendPosition = proposal.addPosition(
+                backend,
+                "정산 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_500_000L,
+                4_500_000L,
+                4L,
+                3,
+                6,
+                null
+        );
+
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "커머스 백엔드 개발",
+                "결제 서버 인원을 늘립니다.",
+                null,
+                null,
+                8L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "결제 서버 백엔드 개발자",
+                                ProposalWorkType.REMOTE,
+                                2L,
+                                3_000_000L,
+                                4_000_000L,
+                                4L,
+                                3,
+                                6,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.applyForInterview(
+                proposal,
+                aiBriefResult,
+                "결제 서버 백엔드 개발자는 2명으로 늘리고 정산 서버 백엔드 개발자는 그대로 두자."
+        );
+
+        List<String> titles = positionTitles(proposal);
+        ProposalPosition updatedPaymentBackendPosition = findProposalPositionByTitle(proposal, "결제 서버 백엔드 개발자");
+        ProposalPosition preservedSettlementBackendPosition = findProposalPositionByTitle(proposal, "정산 서버 백엔드 개발자");
+
+        assertThat(titles).containsExactly("결제 서버 백엔드 개발자", "정산 서버 백엔드 개발자");
+        assertThat(updatedPaymentBackendPosition).isSameAs(paymentBackendPosition);
+        assertThat(updatedPaymentBackendPosition.getHeadCount()).isEqualTo(2L);
+        assertThat(preservedSettlementBackendPosition).isSameAs(settlementBackendPosition);
+        assertThat(preservedSettlementBackendPosition.getHeadCount()).isEqualTo(1L);
+    }
+
+    @Test
     @DisplayName("AI 브리프가 기존 스킬을 다시 제안하면 중복 추가하지 않고 중요도만 갱신한다")
     void apply_updatesExistingSkillImportanceWithoutDuplicatingSkill() {
         Proposal proposal = createProposal();
@@ -678,6 +802,19 @@ class AiBriefProposalMapperTest {
                 .filter(proposalPosition -> proposalPosition.getPosition().getName().equals(positionName))
                 .findFirst()
                 .orElseThrow();
+    }
+
+    private ProposalPosition findProposalPositionByTitle(Proposal proposal, String title) {
+        return proposal.getPositions().stream()
+                .filter(proposalPosition -> title.equals(proposalPosition.getTitle()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private List<String> positionTitles(Proposal proposal) {
+        return proposal.getPositions().stream()
+                .map(ProposalPosition::getTitle)
+                .toList();
     }
 
     private Proposal createProposal() {

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -299,6 +299,75 @@ class AiBriefProposalMapperTest {
     }
 
     @Test
+    @DisplayName("AI 인터뷰 적용은 같은 category 안에서 title 공백 차이가 있어도 기존 모집 단위를 갱신한다")
+    void applyForInterview_updatesExistingPositionWhenNormalizedTitleMatches() {
+        Proposal proposal = createProposal();
+        Position backend = Position.create("백엔드 개발자");
+
+        ProposalPosition paymentBackendPosition = proposal.addPosition(
+                backend,
+                "결제 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_000_000L,
+                4_000_000L,
+                3L,
+                3,
+                6,
+                null
+        );
+        ProposalPosition settlementBackendPosition = proposal.addPosition(
+                backend,
+                "정산 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                3_500_000L,
+                4_500_000L,
+                3L,
+                3,
+                6,
+                null
+        );
+
+        given(positionResolver.resolve("백엔드 개발자")).willReturn(Optional.of(backend));
+
+        AiBriefResult aiBriefResult = AiBriefResult.of(
+                "커머스 백엔드 개발",
+                "결제 서버 인원을 늘립니다.",
+                null,
+                null,
+                3L,
+                List.of(
+                        AiBriefPositionResult.of(
+                                "백엔드 개발자",
+                                "결제서버백엔드개발자",
+                                ProposalWorkType.REMOTE,
+                                2L,
+                                3_000_000L,
+                                4_000_000L,
+                                3L,
+                                3,
+                                6,
+                                null,
+                                List.of()
+                        )
+                )
+        );
+
+        aiBriefProposalMapper.applyForInterview(
+                proposal,
+                aiBriefResult,
+                "결제 서버 백엔드 개발자는 2명으로 늘려줘."
+        );
+
+        assertThat(proposal.getPositions()).hasSize(2);
+        assertThat(paymentBackendPosition.getTitle()).isEqualTo("결제서버백엔드개발자");
+        assertThat(paymentBackendPosition.getHeadCount()).isEqualTo(2L);
+        assertThat(findProposalPositionByTitle(proposal, "결제서버백엔드개발자")).isSameAs(paymentBackendPosition);
+        assertThat(findProposalPositionByTitle(proposal, "정산 서버 백엔드 개발자")).isSameAs(settlementBackendPosition);
+    }
+
+    @Test
     @DisplayName("AI 브리프가 기존 스킬을 다시 제안하면 중복 추가하지 않고 중요도만 갱신한다")
     void apply_updatesExistingSkillImportanceWithoutDuplicatingSkill() {
         Proposal proposal = createProposal();

--- a/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
+++ b/src/test/java/com/generic4/itda/service/AiBriefProposalMapperTest.java
@@ -238,7 +238,7 @@ class AiBriefProposalMapperTest {
                 1L,
                 3_000_000L,
                 4_000_000L,
-                4L,
+                3L,
                 3,
                 6,
                 null
@@ -250,7 +250,7 @@ class AiBriefProposalMapperTest {
                 1L,
                 3_500_000L,
                 4_500_000L,
-                4L,
+                3L,
                 3,
                 6,
                 null
@@ -263,7 +263,7 @@ class AiBriefProposalMapperTest {
                 "결제 서버 인원을 늘립니다.",
                 null,
                 null,
-                8L,
+                3L,
                 List.of(
                         AiBriefPositionResult.of(
                                 "백엔드 개발자",
@@ -272,7 +272,7 @@ class AiBriefProposalMapperTest {
                                 2L,
                                 3_000_000L,
                                 4_000_000L,
-                                4L,
+                                3L,
                                 3,
                                 6,
                                 null,

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -148,6 +148,140 @@ class ProposalServiceTest {
     }
 
     @Test
+    @DisplayName("같은 직무 category라도 title이 다르면 여러 모집 단위를 함께 저장한다")
+    void saveDraft_keepsMultiplePositionsWithSamePositionIdAndDifferentTitles() {
+        Position backend = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(backend, "id", 1L);
+
+        ProposalPositionForm paymentBackendForm = new ProposalPositionForm();
+        paymentBackendForm.setPositionId(1L);
+        paymentBackendForm.setTitle("결제 서버 백엔드 개발자");
+        paymentBackendForm.setWorkType(ProposalWorkType.REMOTE);
+        paymentBackendForm.setHeadCount(1L);
+        paymentBackendForm.setUnitBudgetMin(3_000_000L);
+        paymentBackendForm.setUnitBudgetMax(4_000_000L);
+        paymentBackendForm.setExpectedPeriod(4L);
+
+        ProposalPositionForm settlementBackendForm = new ProposalPositionForm();
+        settlementBackendForm.setPositionId(1L);
+        settlementBackendForm.setTitle("정산 서버 백엔드 개발자");
+        settlementBackendForm.setWorkType(ProposalWorkType.REMOTE);
+        settlementBackendForm.setHeadCount(1L);
+        settlementBackendForm.setUnitBudgetMin(3_500_000L);
+        settlementBackendForm.setUnitBudgetMax(4_500_000L);
+        settlementBackendForm.setExpectedPeriod(4L);
+
+        ProposalForm form = new ProposalForm();
+        form.setTitle("커머스 백엔드 개발");
+        form.setRawInputText("");
+        form.setExpectedPeriod(8L);
+        form.getPositions().add(paymentBackendForm);
+        form.getPositions().add(settlementBackendForm);
+
+        when(positionRepository.findById(1L)).thenReturn(Optional.of(backend));
+
+        Proposal proposal = proposalService.saveDraft(EMAIL, form);
+
+        List<String> titles = proposal.getPositions().stream()
+                .map(ProposalPosition::getTitle)
+                .toList();
+
+        assertThat(titles).hasSize(2);
+        assertThat(titles).containsExactly("결제 서버 백엔드 개발자", "정산 서버 백엔드 개발자");
+    }
+
+    @Test
+    @DisplayName("제안서 수정은 proposalPositionId가 있는 모집 단위만 갱신하고 같은 positionId 신규 row는 새로 추가한다")
+    void saveDraft_updatesExistingPositionByProposalPositionIdAndAddsNewSamePositionIdRow() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "기존 설명",
+                null,
+                null,
+                8L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        Position backend = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(backend, "id", 1L);
+
+        ProposalPosition existingPaymentBackend = proposal.addPosition(
+                backend,
+                "기존 결제 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                2_000_000L,
+                3_000_000L,
+                4L,
+                2,
+                5,
+                null
+        );
+        ReflectionTestUtils.setField(existingPaymentBackend, "id", 10L);
+
+        ProposalPosition existingSettlementBackend = proposal.addPosition(
+                backend,
+                "기존 정산 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                2_500_000L,
+                3_500_000L,
+                4L,
+                2,
+                5,
+                null
+        );
+        ReflectionTestUtils.setField(existingSettlementBackend, "id", 11L);
+
+        ProposalPositionForm updatedPaymentBackendForm = new ProposalPositionForm();
+        updatedPaymentBackendForm.setId(10L);
+        updatedPaymentBackendForm.setPositionId(1L);
+        updatedPaymentBackendForm.setTitle("수정된 결제 서버 백엔드 개발자");
+        updatedPaymentBackendForm.setWorkType(ProposalWorkType.REMOTE);
+        updatedPaymentBackendForm.setHeadCount(2L);
+        updatedPaymentBackendForm.setUnitBudgetMin(3_000_000L);
+        updatedPaymentBackendForm.setUnitBudgetMax(4_000_000L);
+        updatedPaymentBackendForm.setExpectedPeriod(5L);
+
+        ProposalPositionForm searchBackendForm = new ProposalPositionForm();
+        searchBackendForm.setPositionId(1L);
+        searchBackendForm.setTitle("검색 서버 백엔드 개발자");
+        searchBackendForm.setWorkType(ProposalWorkType.REMOTE);
+        searchBackendForm.setHeadCount(1L);
+        searchBackendForm.setUnitBudgetMin(3_500_000L);
+        searchBackendForm.setUnitBudgetMax(4_500_000L);
+        searchBackendForm.setExpectedPeriod(4L);
+
+        ProposalForm form = new ProposalForm();
+        form.setTitle("수정된 프로젝트");
+        form.setRawInputText("수정된 원본 입력");
+        form.setDescription("수정된 설명");
+        form.setExpectedPeriod(8L);
+        form.getPositions().add(updatedPaymentBackendForm);
+        form.getPositions().add(searchBackendForm);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(positionRepository.findById(1L)).thenReturn(Optional.of(backend));
+
+        Proposal saved = proposalService.saveDraft(1L, EMAIL, form);
+
+        List<String> titles = saved.getPositions().stream()
+                .map(ProposalPosition::getTitle)
+                .toList();
+        Long updatedPaymentBackendId = saved.getPositions().stream()
+                .filter(position -> "수정된 결제 서버 백엔드 개발자".equals(position.getTitle()))
+                .map(ProposalPosition::getId)
+                .findFirst()
+                .orElse(null);
+
+        assertThat(titles).hasSize(2);
+        assertThat(titles).containsExactly("수정된 결제 서버 백엔드 개발자", "검색 서버 백엔드 개발자");
+        assertThat(updatedPaymentBackendId).isEqualTo(10L);
+    }
+
+    @Test
     @DisplayName("MATCHING 상태 원본 제안서는 직접 임시저장할 수 없다")
     void saveDraft_blocksDirectUpdateForMatchingProposal() {
         Proposal proposal = Proposal.create(
@@ -677,15 +811,22 @@ class ProposalServiceTest {
                 .isInstanceOf(ProposalNotFoundException.class);
     }
 
-    // ── closePosition 테스트 ──
-
     @Test
     @DisplayName("MATCHING 상태 제안서의 OPEN 포지션을 소유자가 종료하면 CLOSED로 전환된다")
     void closePosition_closesOpenPosition() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
 
         when(proposalPositionRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(position));
@@ -700,8 +841,17 @@ class ProposalServiceTest {
     void closePosition_closesFullPosition() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
         position.changeStatus(ProposalPositionStatus.FULL);
 
@@ -717,8 +867,17 @@ class ProposalServiceTest {
     void closePosition_rejectsPendingMatchingsOnly() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
 
         Member freelancerA = createMember("freelancer-a@example.com", "hashed-password", "프리랜서A", "010-1111-1111");
@@ -745,8 +904,17 @@ class ProposalServiceTest {
     void closePosition_throws_whenAlreadyClosed() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
         position.changeStatus(ProposalPositionStatus.CLOSED);
 
@@ -761,11 +929,27 @@ class ProposalServiceTest {
     @DisplayName("MATCHING이 아닌 제안서의 포지션을 종료하면 예외가 발생한다")
     void closePosition_throws_whenProposalNotMatching() {
         Proposal proposal = Proposal.create(
-                member, "프로젝트", "", "설명", null, null, 6L);
+                member,
+                "프로젝트",
+                "",
+                "설명",
+                null,
+                null,
+                6L
+        );
         ReflectionTestUtils.setField(proposal, "id", 1L);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
 
         when(proposalPositionRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(position));
@@ -780,8 +964,17 @@ class ProposalServiceTest {
     void closePosition_throws_whenNotOwner() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
 
         when(proposalPositionRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(position));
@@ -805,8 +998,17 @@ class ProposalServiceTest {
         Proposal proposal = createMatchingProposal(member);
         ReflectionTestUtils.setField(proposal, "id", 2L);
         ProposalPosition position = proposal.addPosition(
-                Position.create("백엔드"), "백엔드 개발자",
-                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+                Position.create("백엔드"),
+                "백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                2L,
+                1_000_000L,
+                2_000_000L,
+                4L,
+                1,
+                5,
+                null
+        );
         ReflectionTestUtils.setField(position, "id", 10L);
 
         when(proposalPositionRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(position));
@@ -820,7 +1022,14 @@ class ProposalServiceTest {
 
     private Proposal createMatchingProposal(Member owner) {
         Proposal proposal = Proposal.create(
-                owner, "프로젝트", "", "설명", null, null, 6L);
+                owner,
+                "프로젝트",
+                "",
+                "설명",
+                null,
+                null,
+                6L
+        );
         ReflectionTestUtils.setField(proposal, "id", 1L);
         proposal.startMatching();
         return proposal;

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -282,6 +282,62 @@ class ProposalServiceTest {
     }
 
     @Test
+    @DisplayName("제안서 수정 요청의 proposalPositionId가 현재 제안서에 없으면 예외가 발생한다")
+    void saveDraft_throwsWhenProposalPositionIdDoesNotBelongToProposal() {
+        Proposal proposal = Proposal.create(
+                member,
+                "기존 프로젝트",
+                "기존 원본 입력",
+                "기존 설명",
+                null,
+                null,
+                8L
+        );
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        Position backend = Position.create("백엔드 개발자");
+        ReflectionTestUtils.setField(backend, "id", 1L);
+
+        ProposalPosition existingPaymentBackend = proposal.addPosition(
+                backend,
+                "기존 결제 서버 백엔드 개발자",
+                ProposalWorkType.REMOTE,
+                1L,
+                2_000_000L,
+                3_000_000L,
+                4L,
+                2,
+                5,
+                null
+        );
+        ReflectionTestUtils.setField(existingPaymentBackend, "id", 10L);
+
+        ProposalPositionForm foreignPositionForm = new ProposalPositionForm();
+        foreignPositionForm.setId(99L);
+        foreignPositionForm.setPositionId(1L);
+        foreignPositionForm.setTitle("다른 제안서의 백엔드 개발자");
+        foreignPositionForm.setWorkType(ProposalWorkType.REMOTE);
+        foreignPositionForm.setHeadCount(1L);
+        foreignPositionForm.setUnitBudgetMin(3_000_000L);
+        foreignPositionForm.setUnitBudgetMax(4_000_000L);
+        foreignPositionForm.setExpectedPeriod(4L);
+
+        ProposalForm form = new ProposalForm();
+        form.setTitle("수정된 프로젝트");
+        form.setRawInputText("수정된 원본 입력");
+        form.setDescription("수정된 설명");
+        form.setExpectedPeriod(8L);
+        form.getPositions().add(foreignPositionForm);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(positionRepository.findById(1L)).thenReturn(Optional.of(backend));
+
+        assertThatThrownBy(() -> proposalService.saveDraft(1L, EMAIL, form))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("제안서에 속하지 않는 모집 포지션입니다. proposalPositionId=99");
+    }
+
+    @Test
     @DisplayName("MATCHING 상태 원본 제안서는 직접 임시저장할 수 없다")
     void saveDraft_blocksDirectUpdateForMatchingProposal() {
         Proposal proposal = Proposal.create(


### PR DESCRIPTION
## 🔎 What

- 제안서 저장 로직에서 `positionId` 기준 병합 흐름 점검 및 수정
- 같은 category 아래 서로 다른 `title` 포지션이 동시에 유지되도록 저장 규칙 정리
- AI 브리프 매핑 시 category 이름만으로 기존 포지션을 찾는 흐름 보완
- AI 인터뷰 반영 시 동일 category 다중 포지션을 안전하게 구분하는 방식 정리
- `proposal_position` 식별 기준을 `id`, `category`, `title` 관점에서 명확히 정리
- 수정/삭제 시 어떤 포지션을 대상으로 하는지 충돌 없는 규칙 정리
- 관련 서비스 테스트 보강
- 관련 AI 매퍼 테스트 보강
- 같은 category 아래 다른 `title`을 가진 실제 저장/수정 시나리오 수동 검증
- 수동 저장/수정 시 `positionId` 기준 form 병합 제거
- 기존 모집 단위 갱신 기준을 `proposalPositionId` 우선으로 정리
- `id` 없는 신규 row는 같은 `positionId`가 있어도 새 모집 단위로 추가
- AI 매핑 시 `positionCategoryName` 단독 병합 제거
- AI 매핑 기준을 `category + normalized title` 중심으로 보완
- AI 인터뷰 삭제/수정 대상 판별 시 같은 category 내 title 구분 반영
- AI 프롬프트의 “같은 category 중복 생성 금지” 문구를 title 기준 정책으로 수정
- 같은 category + 다른 title 2개 저장 테스트 추가
- 같은 category + 다른 title 2개 AI 매핑 테스트 추가

## 🔗 Issue

- Closes: #102 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?