### PR TITLE
[Feat] 제안서 상세에서 제안서 종료 CTA 추가 및 전체 모집 종료 시 제안서 자동 완료 처리

### DIFF
--- a/src/main/java/com/generic4/itda/controller/ProposalController.java
+++ b/src/main/java/com/generic4/itda/controller/ProposalController.java
@@ -279,12 +279,36 @@ public class ProposalController {
             RedirectAttributes redirectAttributes
     ) {
         try {
-            proposalService.closePosition(proposalId, positionId, principal.getEmail());
-            redirectAttributes.addFlashAttribute("noticeMessage", "해당 포지션의 모집이 종료되었습니다.");
+            ProposalPosition closedPosition = proposalService.closePosition(proposalId, positionId, principal.getEmail());
+            if (closedPosition.getProposal().getStatus() == ProposalStatus.COMPLETE) {
+                redirectAttributes.addFlashAttribute("noticeMessage",
+                        "해당 포지션의 모집이 종료되었습니다. 모든 포지션이 종료되어 제안서가 완료 처리되었습니다.");
+            } else {
+                redirectAttributes.addFlashAttribute("noticeMessage", "해당 포지션의 모집이 종료되었습니다.");
+            }
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 모집 포지션입니다.");
         } catch (AccessDeniedException e) {
             redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서의 모집 포지션만 종료할 수 있습니다.");
+        } catch (IllegalStateException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/proposals/" + proposalId;
+    }
+
+    @PostMapping("/{proposalId}/complete")
+    public String completeProposal(
+            @PathVariable Long proposalId,
+            @AuthenticationPrincipal ItDaPrincipal principal,
+            RedirectAttributes redirectAttributes
+    ) {
+        try {
+            proposalService.completeProposal(proposalId, principal.getEmail());
+            redirectAttributes.addFlashAttribute("noticeMessage", "제안서가 종료되었습니다.");
+        } catch (ProposalNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "존재하지 않는 제안서입니다.");
+        } catch (AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "본인 제안서만 종료할 수 있습니다.");
         } catch (IllegalStateException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }

--- a/src/main/java/com/generic4/itda/domain/matching/Matching.java
+++ b/src/main/java/com/generic4/itda/domain/matching/Matching.java
@@ -171,8 +171,8 @@ public class Matching extends BaseTimeEntity {
     }
 
     public void rejectByClientClosingPosition(String reasonDetail) {
-        if (this.status != MatchingStatus.PROPOSED) {
-            throw new IllegalStateException("제안 상태의 매칭만 거절할 수 있습니다.");
+        if (this.status != MatchingStatus.PROPOSED && this.status != MatchingStatus.ACCEPTED) {
+            throw new IllegalStateException("제안 또는 수락 상태의 매칭만 거절할 수 있습니다.");
         }
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -249,8 +249,8 @@ public class ProposalService {
                 .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
 
         for (ProposalPosition position : proposalWithPositions.getPositions()) {
+            rejectPendingMatchings(position.getId(), memberEmail, PROPOSAL_CLOSED_REJECTION_REASON);
             if (position.getStatus() != ProposalPositionStatus.CLOSED) {
-                rejectPendingMatchings(position.getId(), memberEmail, PROPOSAL_CLOSED_REJECTION_REASON);
                 position.changeStatus(ProposalPositionStatus.CLOSED);
             }
         }

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -226,7 +226,7 @@ public class ProposalService {
             throw new IllegalStateException("이미 종료된 모집 포지션입니다.");
         }
 
-        rejectPendingMatchings(positionId, memberEmail, POSITION_CLOSED_REJECTION_REASON);
+        rejectClosableMatchings(positionId, memberEmail, POSITION_CLOSED_REJECTION_REASON);
         position.changeStatus(ProposalPositionStatus.CLOSED);
 
         boolean allClosed = proposal.getPositions().stream()
@@ -249,7 +249,7 @@ public class ProposalService {
                 .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
 
         for (ProposalPosition position : proposalWithPositions.getPositions()) {
-            rejectPendingMatchings(position.getId(), memberEmail, PROPOSAL_CLOSED_REJECTION_REASON);
+            rejectClosableMatchings(position.getId(), memberEmail, PROPOSAL_CLOSED_REJECTION_REASON);
             if (position.getStatus() != ProposalPositionStatus.CLOSED) {
                 position.changeStatus(ProposalPositionStatus.CLOSED);
             }
@@ -267,14 +267,15 @@ public class ProposalService {
         return calculateTotalBudgetMax(getPositionForms(form));
     }
 
-    private void rejectPendingMatchings(Long positionId, String memberEmail, String reason) {
+    private void rejectClosableMatchings(Long positionId, String memberEmail, String reason) {
         List<Matching> matchings = matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(
                 positionId,
                 memberEmail
         );
 
         matchings.stream()
-                .filter(matching -> matching.getStatus() == MatchingStatus.PROPOSED)
+                .filter(matching -> matching.getStatus() == MatchingStatus.PROPOSED
+                        || matching.getStatus() == MatchingStatus.ACCEPTED)
                 .forEach(matching -> matching.rejectByClientClosingPosition(reason));
     }
 

--- a/src/main/java/com/generic4/itda/service/ProposalService.java
+++ b/src/main/java/com/generic4/itda/service/ProposalService.java
@@ -10,13 +10,13 @@ import com.generic4.itda.domain.proposal.ProposalAiInterviewMessage;
 import com.generic4.itda.domain.proposal.ProposalPosition;
 import com.generic4.itda.domain.proposal.ProposalPositionSkill;
 import com.generic4.itda.domain.proposal.ProposalPositionSkillImportance;
+import com.generic4.itda.domain.proposal.ProposalPositionStatus;
 import com.generic4.itda.domain.proposal.ProposalStatus;
 import com.generic4.itda.domain.skill.Skill;
 import com.generic4.itda.dto.proposal.AiInterviewDraftSaveRequest;
 import com.generic4.itda.dto.proposal.ProposalForm;
 import com.generic4.itda.dto.proposal.ProposalPositionForm;
 import com.generic4.itda.exception.ProposalNotFoundException;
-import com.generic4.itda.domain.proposal.ProposalPositionStatus;
 import com.generic4.itda.repository.MatchingRepository;
 import com.generic4.itda.repository.MemberRepository;
 import com.generic4.itda.repository.PositionRepository;
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
 public class ProposalService {
 
     private static final String POSITION_CLOSED_REJECTION_REASON = "클라이언트가 모집을 종료했습니다.";
+    private static final String PROPOSAL_CLOSED_REJECTION_REASON = "클라이언트가 제안서 모집을 종료했습니다.";
 
     private static final EnumSet<MatchingStatus> BLOCKING_MATCHING_STATUSES = EnumSet.of(
             MatchingStatus.PROPOSED,
@@ -225,9 +226,37 @@ public class ProposalService {
             throw new IllegalStateException("이미 종료된 모집 포지션입니다.");
         }
 
-        rejectPendingMatchings(positionId, memberEmail);
+        rejectPendingMatchings(positionId, memberEmail, POSITION_CLOSED_REJECTION_REASON);
         position.changeStatus(ProposalPositionStatus.CLOSED);
+
+        boolean allClosed = proposal.getPositions().stream()
+                .allMatch(p -> p.getStatus() == ProposalPositionStatus.CLOSED);
+        if (allClosed) {
+            proposal.complete();
+        }
+
         return position;
+    }
+
+    public Proposal completeProposal(Long proposalId, String memberEmail) {
+        Proposal proposal = getOwnedProposal(proposalId, memberEmail);
+
+        if (proposal.getStatus() != ProposalStatus.MATCHING) {
+            throw new IllegalStateException("매칭 중인 제안서만 종료할 수 있습니다.");
+        }
+
+        Proposal proposalWithPositions = proposalRepository.findWithPositionsById(proposalId)
+                .orElseThrow(() -> new ProposalNotFoundException("제안서를 찾을 수 없습니다. id=" + proposalId));
+
+        for (ProposalPosition position : proposalWithPositions.getPositions()) {
+            if (position.getStatus() != ProposalPositionStatus.CLOSED) {
+                rejectPendingMatchings(position.getId(), memberEmail, PROPOSAL_CLOSED_REJECTION_REASON);
+                position.changeStatus(ProposalPositionStatus.CLOSED);
+            }
+        }
+
+        proposalWithPositions.complete();
+        return proposalWithPositions;
     }
 
     public Long calculateTotalBudgetMin(ProposalForm form) {
@@ -238,7 +267,7 @@ public class ProposalService {
         return calculateTotalBudgetMax(getPositionForms(form));
     }
 
-    private void rejectPendingMatchings(Long positionId, String memberEmail) {
+    private void rejectPendingMatchings(Long positionId, String memberEmail, String reason) {
         List<Matching> matchings = matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(
                 positionId,
                 memberEmail
@@ -246,7 +275,7 @@ public class ProposalService {
 
         matchings.stream()
                 .filter(matching -> matching.getStatus() == MatchingStatus.PROPOSED)
-                .forEach(matching -> matching.rejectByClientClosingPosition(POSITION_CLOSED_REJECTION_REASON));
+                .forEach(matching -> matching.rejectByClientClosingPosition(reason));
     }
 
     private void replacePositions(Proposal proposal, List<ProposalPositionForm> positionForms) {
@@ -293,7 +322,8 @@ public class ProposalService {
                 proposalPosition.changeStatus(positionForm.getStatus());
             }
 
-            replaceSkills(proposalPosition, positionForm.getEssentialSkillNames(), positionForm.getPreferredSkillNames());
+            replaceSkills(proposalPosition, positionForm.getEssentialSkillNames(),
+                    positionForm.getPreferredSkillNames());
             appliedPositions.add(proposalPosition);
         }
 
@@ -479,7 +509,8 @@ public class ProposalService {
         aiInterviewMessageRepository.saveAll(copiedMessages);
     }
 
-    private ProposalAiInterviewMessage copyAiInterviewMessage(Proposal draftCopy, ProposalAiInterviewMessage sourceMessage) {
+    private ProposalAiInterviewMessage copyAiInterviewMessage(Proposal draftCopy,
+            ProposalAiInterviewMessage sourceMessage) {
         if (sourceMessage.getRole() == AiInterviewMessageRole.USER) {
             return ProposalAiInterviewMessage.createUserMessage(
                     draftCopy,
@@ -534,7 +565,8 @@ public class ProposalService {
             return;
         }
 
-        if (matchingRepository.existsByProposalPosition_Proposal_IdAndStatusIn(proposalId, BLOCKING_MATCHING_STATUSES)) {
+        if (matchingRepository.existsByProposalPosition_Proposal_IdAndStatusIn(proposalId,
+                BLOCKING_MATCHING_STATUSES)) {
             throw new IllegalStateException("진행 중이거나 완료된 매칭이 있는 제안서는 수정할 수 없습니다.");
         }
     }
@@ -571,5 +603,6 @@ public class ProposalService {
     }
 
     private record SkillApplication(Skill skill, ProposalPositionSkillImportance importance) {
+
     }
 }

--- a/src/main/resources/templates/client/proposalDetail.html
+++ b/src/main/resources/templates/client/proposalDetail.html
@@ -62,6 +62,18 @@
                                 <i data-lucide="sparkles" class="h-4 w-4"></i>
                                 추천 받아 보기
                             </button>
+
+                            <form th:if="${viewerRole == 'CLIENT' and proposal.status.name() == 'MATCHING'}"
+                                  th:action="@{/proposals/{id}/complete(id=${proposal.id})}"
+                                  method="post"
+                                  class="inline"
+                                  onsubmit="return confirm('제안서를 종료하시겠습니까? 모든 포지션의 모집이 종료되고, 대기 중인 매칭 요청이 거절됩니다.')">
+                                <button type="submit"
+                                        class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-500 transition hover:border-red-300 hover:text-red-600">
+                                    <i data-lucide="square" class="h-4 w-4"></i>
+                                    제안서 모집 종료
+                                </button>
+                            </form>
                             
                             <span th:if="${proposal.status.name() == 'COMPLETE'}"
                                   class="inline-flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-sm font-bold text-emerald-600">

--- a/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
+++ b/src/test/java/com/generic4/itda/controller/ProposalControllerTest.java
@@ -895,7 +895,10 @@ class ProposalControllerTest {
     @Test
     @DisplayName("모집 포지션 종료 요청 시 proposalId와 positionId를 함께 검증하도록 서비스에 전달한다")
     void closePositionPassesProposalAndPositionIdsToService() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getStatus()).willReturn(ProposalStatus.MATCHING);
         ProposalPosition position = org.mockito.Mockito.mock(ProposalPosition.class);
+        given(position.getProposal()).willReturn(proposal);
         given(proposalService.closePosition(1L, 10L, "client@example.com")).willReturn(position);
 
         ItDaPrincipal principal = ItDaPrincipal.from(
@@ -912,6 +915,30 @@ class ProposalControllerTest {
                 .andExpect(flash().attribute("noticeMessage", "해당 포지션의 모집이 종료되었습니다."));
 
         then(proposalService).should().closePosition(1L, 10L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("마지막 포지션 종료 시 자동 완료되면 안내 메시지가 포함된다")
+    void closePositionShowsAutoCompleteMessage() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposal.getStatus()).willReturn(ProposalStatus.COMPLETE);
+        ProposalPosition position = org.mockito.Mockito.mock(ProposalPosition.class);
+        given(position.getProposal()).willReturn(proposal);
+        given(proposalService.closePosition(1L, 10L, "client@example.com")).willReturn(position);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/positions/10/close")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1"))
+                .andExpect(flash().attribute("noticeMessage",
+                        "해당 포지션의 모집이 종료되었습니다. 모든 포지션이 종료되어 제안서가 완료 처리되었습니다."));
     }
 
     @Test
@@ -1084,5 +1111,89 @@ class ProposalControllerTest {
                 .andExpect(view().name("client/proposalDetail"))
                 .andExpect(model().attribute("viewerRole", "CLIENT"))
                 .andExpect(model().attributeDoesNotExist("recommendEntry"));
+    }
+
+    // ── completeProposal 테스트 ──
+
+    @Test
+    @DisplayName("제안서 종료 요청이 성공하면 성공 메시지와 함께 제안서 상세로 리다이렉트된다")
+    void completeProposalRedirectsWithSuccessMessage() throws Exception {
+        Proposal proposal = org.mockito.Mockito.mock(Proposal.class);
+        given(proposalService.completeProposal(1L, "client@example.com")).willReturn(proposal);
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라���언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/complete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1"))
+                .andExpect(flash().attribute("noticeMessage", "제안서가 종료되었습니다."));
+
+        then(proposalService).should().completeProposal(1L, "client@example.com");
+    }
+
+    @Test
+    @DisplayName("MATCHING이 아닌 제안서 종료 요청이면 에러 메시지와 함께 리다이렉트된다")
+    void completeProposalRedirectsWithErrorForInvalidState() throws Exception {
+        willThrow(new IllegalStateException("매칭 중인 제안서만 종료할 수 있습니다."))
+                .given(proposalService).completeProposal(1L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언��", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/1/complete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1"))
+                .andExpect(flash().attribute("errorMessage", "매칭 중인 제안서만 종료할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서 종료 요청이면 에러 메시지와 함께 리다이렉트된다")
+    void completeProposalRedirectsWithErrorForNotFound() throws Exception {
+        willThrow(new ProposalNotFoundException("제안서를 찾을 수 없습니다."))
+                .given(proposalService).completeProposal(999L, "client@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("client@example.com", "hashed-password", "클라이언트", "010-1234-5678")
+        );
+
+        mockMvc.perform(post("/proposals/999/complete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/999"))
+                .andExpect(flash().attribute("errorMessage", "존재하지 않는 제안서입니다."));
+    }
+
+    @Test
+    @DisplayName("소유자가 아닌 사용자의 제안서 종료 요청이면 에러 메시지와 함께 리다이렉트된다")
+    void completeProposalRedirectsWithErrorForAccessDenied() throws Exception {
+        willThrow(new AccessDeniedException("본인 제안서만 조회하거나 수정할 수 있습니다."))
+                .given(proposalService).completeProposal(1L, "other@example.com");
+
+        ItDaPrincipal principal = ItDaPrincipal.from(
+                createMember("other@example.com", "hashed-password", "다른사용자", "010-9999-9999")
+        );
+
+        mockMvc.perform(post("/proposals/1/complete")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/proposals/1"))
+                .andExpect(flash().attribute("errorMessage", "본인 제안서만 종료할 수 있습니다."));
     }
 }

--- a/src/test/java/com/generic4/itda/domain/matching/MatchingTest.java
+++ b/src/test/java/com/generic4/itda/domain/matching/MatchingTest.java
@@ -223,6 +223,20 @@ class MatchingTest {
         assertThat(matching.getCancellationRequestedAt()).isEqualTo(matching.getRejectedAt());
     }
 
+    @Test
+    @DisplayName("수락된 매칭도 클라이언트 모집 종료로 거절 처리할 수 있다")
+    void rejectByClientClosingPosition_allowsAcceptedMatching() {
+        Matching matching = acceptedMatching();
+
+        matching.rejectByClientClosingPosition("클라이언트가 모집을 종료했습니다.");
+
+        assertThat(matching.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(matching.getAcceptedAt()).isNotNull();
+        assertThat(matching.getRejectedAt()).isNotNull();
+        assertThat(matching.getCancellationRequestedBy()).isEqualTo(MatchingParticipantRole.CLIENT);
+        assertThat(matching.getCancellationReasonDetail()).isEqualTo("클라이언트가 모집을 종료했습니다.");
+    }
+
     private Matching acceptedMatching() {
         Matching matching = proposedMatching();
         matching.accept();

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -1180,8 +1180,8 @@ class ProposalServiceTest {
     }
 
     @Test
-    @DisplayName("제안서 종료 시 이미 CLOSED인 포지션은 건너뛴다")
-    void completeProposal_skipsAlreadyClosedPositions() {
+    @DisplayName("제안서 종료 시 이미 CLOSED인 포지션의 PROPOSED 매칭도 거절하고 포지션 상태는 유지한다")
+    void completeProposal_rejectsPendingMatchingsForClosedPositionsToo() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition closedPosition = proposal.addPosition(
                 Position.create("백엔드"), "백엔드 개발자",
@@ -1194,13 +1194,27 @@ class ProposalServiceTest {
                 ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
         ReflectionTestUtils.setField(openPosition, "id", 20L);
 
+        Member freelancerA = createMember("freelancer-a@example.com", "hashed-password", "프리랜서A", "010-1111-1111");
+        Member freelancerB = createMember("freelancer-b@example.com", "hashed-password", "프리랜서B", "010-2222-2222");
+        Matching closedPositionProposed = Matching.create(null, closedPosition, member, freelancerA);
+        Matching openPositionProposed = Matching.create(null, openPosition, member, freelancerB);
+
         when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
         when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+        when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(10L, EMAIL))
+                .thenReturn(List.of(closedPositionProposed));
+        when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(20L, EMAIL))
+                .thenReturn(List.of(openPositionProposed));
 
         proposalService.completeProposal(1L, EMAIL);
 
         assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.COMPLETE);
-        then(matchingRepository).should(never()).findByProposalPosition_IdAndClientMember_Email_Value(eq(10L), any());
+        assertThat(closedPosition.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
+        assertThat(closedPositionProposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(closedPositionProposed.getCancellationReasonDetail())
+                .isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
+        assertThat(openPositionProposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        then(matchingRepository).should().findByProposalPosition_IdAndClientMember_Email_Value(10L, EMAIL);
         then(matchingRepository).should().findByProposalPosition_IdAndClientMember_Email_Value(20L, EMAIL);
     }
 

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -923,8 +923,8 @@ class ProposalServiceTest {
     }
 
     @Test
-    @DisplayName("포지션 종료 시 해당 포지션의 PROPOSED 매칭은 종료 사유와 함께 REJECTED로 전환되고 ACCEPTED 매칭은 유지된다")
-    void closePosition_rejectsPendingMatchingsOnly() {
+    @DisplayName("포지션 종료 시 해당 포지션의 PROPOSED와 ACCEPTED 매칭은 종료 사유와 함께 REJECTED로 전환된다")
+    void closePosition_rejectsProposedAndAcceptedMatchings() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
                 Position.create("백엔드"),
@@ -956,7 +956,10 @@ class ProposalServiceTest {
         assertThat(proposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
         assertThat(proposed.getRejectedAt()).isNotNull();
         assertThat(proposed.getCancellationReasonDetail()).isEqualTo("클라이언트가 모집을 종료했습니다.");
-        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(accepted.getAcceptedAt()).isNotNull();
+        assertThat(accepted.getRejectedAt()).isNotNull();
+        assertThat(accepted.getCancellationReasonDetail()).isEqualTo("클라이언트가 모집을 종료했습니다.");
     }
 
     @Test
@@ -1153,8 +1156,8 @@ class ProposalServiceTest {
     }
 
     @Test
-    @DisplayName("제안서 종료 시 PROPOSED 매칭은 제안서 종료 사유와 함께 거절되고 ACCEPTED 매칭은 유지된다")
-    void completeProposal_rejectsPendingMatchingsWithProposalReason() {
+    @DisplayName("제안서 종료 시 PROPOSED와 ACCEPTED 매칭은 제안서 종료 사유와 함께 거절된다")
+    void completeProposal_rejectsProposedAndAcceptedMatchingsWithProposalReason() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition position = proposal.addPosition(
                 Position.create("백엔드"), "백엔드 개발자",
@@ -1176,12 +1179,14 @@ class ProposalServiceTest {
 
         assertThat(proposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
         assertThat(proposed.getCancellationReasonDetail()).isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
-        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(accepted.getAcceptedAt()).isNotNull();
+        assertThat(accepted.getCancellationReasonDetail()).isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
     }
 
     @Test
-    @DisplayName("제안서 종료 시 이미 CLOSED인 포지션의 PROPOSED 매칭도 거절하고 포지션 상태는 유지한다")
-    void completeProposal_rejectsPendingMatchingsForClosedPositionsToo() {
+    @DisplayName("제안서 종료 시 이미 CLOSED인 포지션의 PROPOSED와 ACCEPTED 매칭도 거절하고 포지션 상태는 유지한다")
+    void completeProposal_rejectsProposedAndAcceptedMatchingsForClosedPositionsToo() {
         Proposal proposal = createMatchingProposal(member);
         ProposalPosition closedPosition = proposal.addPosition(
                 Position.create("백엔드"), "백엔드 개발자",
@@ -1196,13 +1201,16 @@ class ProposalServiceTest {
 
         Member freelancerA = createMember("freelancer-a@example.com", "hashed-password", "프리랜서A", "010-1111-1111");
         Member freelancerB = createMember("freelancer-b@example.com", "hashed-password", "프리랜서B", "010-2222-2222");
+        Member freelancerC = createMember("freelancer-c@example.com", "hashed-password", "프리랜서C", "010-3333-3333");
         Matching closedPositionProposed = Matching.create(null, closedPosition, member, freelancerA);
-        Matching openPositionProposed = Matching.create(null, openPosition, member, freelancerB);
+        Matching closedPositionAccepted = Matching.create(null, closedPosition, member, freelancerB);
+        closedPositionAccepted.accept();
+        Matching openPositionProposed = Matching.create(null, openPosition, member, freelancerC);
 
         when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
         when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
         when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(10L, EMAIL))
-                .thenReturn(List.of(closedPositionProposed));
+                .thenReturn(List.of(closedPositionProposed, closedPositionAccepted));
         when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(20L, EMAIL))
                 .thenReturn(List.of(openPositionProposed));
 
@@ -1212,6 +1220,10 @@ class ProposalServiceTest {
         assertThat(closedPosition.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
         assertThat(closedPositionProposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
         assertThat(closedPositionProposed.getCancellationReasonDetail())
+                .isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
+        assertThat(closedPositionAccepted.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(closedPositionAccepted.getAcceptedAt()).isNotNull();
+        assertThat(closedPositionAccepted.getCancellationReasonDetail())
                 .isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
         assertThat(openPositionProposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
         then(matchingRepository).should().findByProposalPosition_IdAndClientMember_Email_Value(10L, EMAIL);

--- a/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
+++ b/src/test/java/com/generic4/itda/service/ProposalServiceTest.java
@@ -91,12 +91,15 @@ class ProposalServiceTest {
         member = createMember(EMAIL, "hashed-password", "클라이언트", "010-1234-5678");
 
         lenient().when(memberRepository.findByEmail_Value(EMAIL)).thenReturn(member);
-        lenient().when(proposalRepository.save(any(Proposal.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(proposalRepository.save(any(Proposal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         lenient().when(matchingRepository.existsByProposalPosition_Proposal_IdAndStatusIn(any(Long.class), any()))
                 .thenReturn(false);
         lenient().when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(any(Long.class), any()))
                 .thenReturn(List.of());
-        lenient().when(proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(any(Long.class), any()))
+        lenient().when(
+                        proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(any(Long.class),
+                                any()))
                 .thenReturn(Optional.empty());
         lenient().when(positionResolver.isAllowedPosition(any(Position.class))).thenReturn(true);
         lenient().when(aiInterviewMessageRepository.findAllByProposalIdOrderBySequenceAsc(any(Long.class)))
@@ -718,7 +721,8 @@ class ProposalServiceTest {
         ReflectionTestUtils.setField(existingDraft, "id", 7L);
 
         when(proposalRepository.findById(1L)).thenReturn(Optional.of(source));
-        when(proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(1L, ProposalStatus.WRITING))
+        when(proposalRepository.findFirstBySourceProposal_IdAndStatusOrderByModifiedAtDescIdDesc(1L,
+                ProposalStatus.WRITING))
                 .thenReturn(Optional.of(existingDraft));
 
         Proposal reused = proposalService.createEditDraft(1L, EMAIL);
@@ -1074,6 +1078,164 @@ class ProposalServiceTest {
                 .hasMessageContaining("proposalId=1")
                 .hasMessageContaining("positionId=10");
         then(matchingRepository).should(never()).findByProposalPosition_IdAndClientMember_Email_Value(any(), any());
+    }
+
+    // ── closePosition 자동 완료 테스트 ──
+
+    @Test
+    @DisplayName("마지막 포지션을 종료하면 제안서가 자동으로 COMPLETE 상태가 된다")
+    void closePosition_autoCompletesProposalWhenAllPositionsClosed() {
+        Proposal proposal = createMatchingProposal(member);
+        ProposalPosition position1 = proposal.addPosition(
+                Position.create("백엔드"), "백엔드 개발자",
+                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position1, "id", 10L);
+        position1.changeStatus(ProposalPositionStatus.CLOSED);
+
+        ProposalPosition position2 = proposal.addPosition(
+                Position.create("프론트엔드"), "프론트엔드 개발자",
+                ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position2, "id", 20L);
+
+        when(proposalPositionRepository.findByIdForUpdate(20L)).thenReturn(Optional.of(position2));
+
+        proposalService.closePosition(1L, 20L, EMAIL);
+
+        assertThat(position2.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
+        assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.COMPLETE);
+    }
+
+    @Test
+    @DisplayName("다른 포지션이 아직 OPEN이면 제안서는 MATCHING 상태를 유지한다")
+    void closePosition_doesNotAutoCompleteWhenOtherPositionsOpen() {
+        Proposal proposal = createMatchingProposal(member);
+        ProposalPosition position1 = proposal.addPosition(
+                Position.create("백엔드"), "백엔드 개발자",
+                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position1, "id", 10L);
+
+        ProposalPosition position2 = proposal.addPosition(
+                Position.create("프론트엔드"), "프론트엔드 개발자",
+                ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position2, "id", 20L);
+
+        when(proposalPositionRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(position1));
+
+        proposalService.closePosition(1L, 10L, EMAIL);
+
+        assertThat(position1.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
+        assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.MATCHING);
+    }
+
+    // ── completeProposal 테스트 ──
+
+    @Test
+    @DisplayName("MATCHING 상태 제안서를 종료하면 COMPLETE로 전환되고 모든 포지션이 CLOSED가 된다")
+    void completeProposal_completesProposalAndClosesAllPositions() {
+        Proposal proposal = createMatchingProposal(member);
+        ProposalPosition position1 = proposal.addPosition(
+                Position.create("백엔드"), "백엔드 개발자",
+                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position1, "id", 10L);
+        ProposalPosition position2 = proposal.addPosition(
+                Position.create("프론트엔드"), "프론트엔드 개발자",
+                ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position2, "id", 20L);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        Proposal result = proposalService.completeProposal(1L, EMAIL);
+
+        assertThat(result.getStatus()).isEqualTo(ProposalStatus.COMPLETE);
+        assertThat(position1.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
+        assertThat(position2.getStatus()).isEqualTo(ProposalPositionStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("제안서 종료 시 PROPOSED 매칭은 제안서 종료 사유와 함께 거절되고 ACCEPTED 매칭은 유지된다")
+    void completeProposal_rejectsPendingMatchingsWithProposalReason() {
+        Proposal proposal = createMatchingProposal(member);
+        ProposalPosition position = proposal.addPosition(
+                Position.create("백엔드"), "백엔드 개발자",
+                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(position, "id", 10L);
+
+        Member freelancerA = createMember("freelancer-a@example.com", "hashed-password", "프리랜서A", "010-1111-1111");
+        Member freelancerB = createMember("freelancer-b@example.com", "hashed-password", "프리랜서B", "010-2222-2222");
+        Matching proposed = Matching.create(null, position, member, freelancerA);
+        Matching accepted = Matching.create(null, position, member, freelancerB);
+        accepted.accept();
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+        when(matchingRepository.findByProposalPosition_IdAndClientMember_Email_Value(10L, EMAIL))
+                .thenReturn(List.of(proposed, accepted));
+
+        proposalService.completeProposal(1L, EMAIL);
+
+        assertThat(proposed.getStatus()).isEqualTo(MatchingStatus.REJECTED);
+        assertThat(proposed.getCancellationReasonDetail()).isEqualTo("클라이언트가 제안서 모집을 종료했습니다.");
+        assertThat(accepted.getStatus()).isEqualTo(MatchingStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("제안서 종료 시 이미 CLOSED인 포지션은 건너뛴다")
+    void completeProposal_skipsAlreadyClosedPositions() {
+        Proposal proposal = createMatchingProposal(member);
+        ProposalPosition closedPosition = proposal.addPosition(
+                Position.create("백엔드"), "백엔드 개발자",
+                ProposalWorkType.REMOTE, 2L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(closedPosition, "id", 10L);
+        closedPosition.changeStatus(ProposalPositionStatus.CLOSED);
+
+        ProposalPosition openPosition = proposal.addPosition(
+                Position.create("프론트엔드"), "프론트엔드 개발자",
+                ProposalWorkType.REMOTE, 1L, 1_000_000L, 2_000_000L, 4L, 1, 5, null);
+        ReflectionTestUtils.setField(openPosition, "id", 20L);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+        when(proposalRepository.findWithPositionsById(1L)).thenReturn(Optional.of(proposal));
+
+        proposalService.completeProposal(1L, EMAIL);
+
+        assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.COMPLETE);
+        then(matchingRepository).should(never()).findByProposalPosition_IdAndClientMember_Email_Value(eq(10L), any());
+        then(matchingRepository).should().findByProposalPosition_IdAndClientMember_Email_Value(20L, EMAIL);
+    }
+
+    @Test
+    @DisplayName("MATCHING이 아닌 제안서를 종료하면 예외가 발생한다")
+    void completeProposal_throws_whenNotMatching() {
+        Proposal proposal = Proposal.create(
+                member, "프로젝트", "", "설명", null, null, 6L);
+        ReflectionTestUtils.setField(proposal, "id", 1L);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.completeProposal(1L, EMAIL))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매칭 중인 제안서만 종료할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("소유자가 아닌 사용자가 제안서를 종료하면 예외가 발생한다")
+    void completeProposal_throws_whenNotOwner() {
+        Proposal proposal = createMatchingProposal(member);
+
+        when(proposalRepository.findById(1L)).thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> proposalService.completeProposal(1L, OTHER_EMAIL))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제안서를 종료하면 예외가 발생한다")
+    void completeProposal_throws_whenNotFound() {
+        when(proposalRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proposalService.completeProposal(999L, EMAIL))
+                .isInstanceOf(ProposalNotFoundException.class);
     }
 
     private Proposal createMatchingProposal(Member owner) {


### PR DESCRIPTION
• ## 🔎 What

- 제안서 상세 페이지에 클라이언트용 `제안서 종료` CTA를 추가했습니다.
- `POST /proposals/{proposalId}/complete` 엔드포인트를 추가해, 매칭 중인 제안서를 명시적으로 종료할 수 있도록 했습니다.
- 제안서 종료 시
  - `Proposal.status`를 `COMPLETE`로 변경하고
  - 아직 닫히지 않은 모든 `ProposalPosition`을 `CLOSED`로 전환하며
  - 해당 포지션에 연결된 `PROPOSED`와 `ACCEPTED` 매칭만 `REJECTED`로 정리하도록 반영했습니다.
- 제안서 종료로 거절된 매칭에는 `클라이언트가 제안서 모집을 종료했습니다.` 사유를 남기고, `IN_PROGRESS` 이상 진행된 매칭은 유지되도록 했습니다.
- 기존 `closePosition()` 흐름도 보강해서, 마지막 남은 모집단위를 종료하면 상위 제안서가 자동으로 `COMPLETE` 상태가 되도록 처리했습니다.
- 제안서 상세 화면에서는 제안서 상태에 따라
  - `MATCHING`일 때 `제안서 종료` CTA
  - `COMPLETE`일 때 완료 배지 및 매칭 결과 보기 CTA가 자연스럽게 보이도록 정리했습니다.

## 🔗 Issue

- Closes: #145 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?