### PR TITLE
[Bug] 추천 최종 점수가 100%로 과도하게 포화되는 문제

### DIFF
--- a/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
+++ b/src/main/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorer.java
@@ -19,6 +19,9 @@ import org.springframework.util.Assert;
 @RequiredArgsConstructor
 public class HeuristicV1RecommendationScorer {
 
+    private static final double SKILL_ADJUSTMENT_CONTRIBUTION_WEIGHT = 0.35;
+    private static final double CAREER_ADJUSTMENT_CONTRIBUTION_WEIGHT = 0.25;
+
     private final AiEmbeddingProperties properties;
     private final RecommendationQueryTextGenerator recommendationQueryTextGenerator;
     private final QueryEmbeddingGenerator queryEmbeddingGenerator;
@@ -115,7 +118,11 @@ public class HeuristicV1RecommendationScorer {
                 proposalPosition.getCareerMaxYears()
         );
 
-        double finalScore = clampScore(embeddingScore + skillAdjustmentScore + careerAdjustmentScore);
+        double finalScore = clampScore(
+                embeddingScore
+                        + (skillAdjustmentScore * SKILL_ADJUSTMENT_CONTRIBUTION_WEIGHT)
+                        + (careerAdjustmentScore * CAREER_ADJUSTMENT_CONTRIBUTION_WEIGHT)
+        );
 
         return new ScoredCandidate(
                 candidate,

--- a/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
+++ b/src/test/java/com/generic4/itda/service/recommend/scoring/HeuristicV1RecommendationScorerTest.java
@@ -123,7 +123,7 @@ class HeuristicV1RecommendationScorerTest {
             assertThat(scoredCandidate.similarityScore()).isEqualTo(0.6);
             assertThat(scoredCandidate.skillAdjustmentScore()).isEqualTo(0.10);
             assertThat(scoredCandidate.careerAdjustmentScore()).isEqualTo(0.08);
-            assertThat(scoredCandidate.finalScore()).isCloseTo(0.78, offset(1e-9));
+            assertThat(scoredCandidate.finalScore()).isCloseTo(0.655, offset(1e-9));
         });
 
         verify(recommendationQueryTextGenerator).generate(
@@ -371,9 +371,9 @@ class HeuristicV1RecommendationScorerTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("embeddingScore와 보정치의 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
-    void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
-        // given — rawCosine(0.8) + skill(0.15) + career(0.08) = 1.03 → clamp 1.0
+    @DisplayName("높은 임베딩과 일반적인 최대 보정치 조합에서도 finalScore가 바로 1.0으로 포화되지 않는다")
+    void score_DoesNotImmediatelySaturateToOne_WithHighEmbeddingAndNormalAdjustments() {
+        // given — normalized embedding(0.9) + skill(0.15*0.35) + career(0.08*0.25) = 0.9725
         RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(0.8, 0.2);
@@ -394,6 +394,33 @@ class HeuristicV1RecommendationScorerTest {
 
         // then
         assertThat(result).hasSize(1);
+        assertThat(result.get(0).scoreBreakdown().finalScore()).isCloseTo(0.9725, offset(1e-9));
+    }
+
+    @Test
+    @DisplayName("가중 반영 후 합이 1.0을 초과하면 finalScore는 1.0으로 clamp된다")
+    void score_ClampsFinalScore_ToOneWhenSumExceedsOne() {
+        // given — normalized embedding(0.9) + skill(0.50*0.35) + career(0.30*0.25) = 1.15 → clamp 1.0
+        RecommendationScorableCandidate candidate = candidateWith(100L);
+        List<Double> queryEmbedding = dummyQueryEmbedding();
+        List<Double> resumeEmbedding = List.of(0.8, 0.2);
+
+        given(recommendationQueryTextGenerator.generate(any(), any(), any(), any()))
+                .willReturn("query text");
+        given(queryEmbeddingGenerator.generate(anyString())).willReturn(queryEmbedding);
+        given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
+                .willReturn(Map.of(100L, resumeEmbedding));
+        given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(0.8);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(0.50);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(0.30);
+
+        // when
+        List<ScoredCandidate> result = scorer.score(
+                proposal, proposalPosition, Set.of(), Set.of(), List.of(candidate), EMBEDDING_MODEL
+        );
+
+        // then
+        assertThat(result).hasSize(1);
         assertThat(result.get(0).scoreBreakdown().finalScore()).isEqualTo(1.0);
     }
 
@@ -402,9 +429,9 @@ class HeuristicV1RecommendationScorerTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("embeddingScore와 보정치의 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
+    @DisplayName("가중 반영 후 합이 0.0 미만이면 finalScore는 0.0으로 clamp된다")
     void score_ClampsFinalScore_ToZeroWhenSumBelowZero() {
-        // given — rawCosine(-0.8) + skill(-0.15) + career(-0.12) = -1.07 → clamp 0.0
+        // given — normalized embedding(0.1) + skill(-0.50*0.35) + career(-0.50*0.25) = -0.20 → clamp 0.0
         RecommendationScorableCandidate candidate = candidateWith(100L);
         List<Double> queryEmbedding = dummyQueryEmbedding();
         List<Double> resumeEmbedding = List.of(-0.8, 0.2);
@@ -415,8 +442,8 @@ class HeuristicV1RecommendationScorerTest {
         given(resumeEmbeddingReader.readEmbeddingsByResumeIds(any(), anyString()))
                 .willReturn(Map.of(100L, resumeEmbedding));
         given(cosineSimilarityCalculator.calculate(queryEmbedding, resumeEmbedding)).willReturn(-0.8);
-        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(-0.15);
-        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(-0.12);
+        given(skillAdjustmentCalculator.calculate(any(), any(), any())).willReturn(-0.50);
+        given(careerAdjustmentCalculator.calculate(any(int.class), any(), any())).willReturn(-0.50);
 
         // when
         List<ScoredCandidate> result = scorer.score(


### PR DESCRIPTION
## 🔎 What

* 추천 최종 점수(`finalScore`)가 상위 후보에서 과도하게 100%로 포화되던 문제를 개선했습니다.
* 스킬/경력 보정치를 단순 합산하던 구조를 가중 반영(`skill * 0.35`, `career * 0.25`)으로 변경하고, 최종 점수는 기존처럼 `0.0 ~ 1.0` 범위로 clamp 처리했습니다.
* 변경된 산식을 반영해 단위 테스트 기대값을 수정하고, 점수 포화가 완화되는 시나리오 및 clamp 경계 테스트를 보강했습니다.

## 🔗 Issue

* Closes: #153 

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요?
* [x] 제목이 이슈 제목과 동일한가요?
* [x] 최소 1명의 리뷰를 받았나요?
